### PR TITLE
Refine improvement detection and dynamic reductions

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -860,7 +860,9 @@ Value Search::Worker::search(
     // bigger than the previous static evaluation at our turn (if we were in
     // check at our previous move we go back until we weren't in check) and is
     // false otherwise. The improving flag is used in various pruning heuristics.
-    improving         = ss->staticEval > (ss - 2)->staticEval;
+    // Allow a small margin so that minor setbacks are still considered
+    // improving which helps to avoid over-pruning in quiet positions.
+    improving         = ss->staticEval >= (ss - 2)->staticEval - 45;
     opponentWorsening = ss->staticEval > -(ss - 1)->staticEval;
 
     if (priorReduction >= (depth < 10 ? 1 : 3) && !opponentWorsening)
@@ -1761,7 +1763,12 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
 Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
     int reductionScale = reductions[d] * reductions[mn];
-    return reductionScale - delta * 731 / rootDelta + !i * reductionScale * 216 / 512 + 1089;
+    // Increase the difference between improving and non-improving lines.
+    // Improving moves get a slightly smaller reduction while non-improving
+    // moves are reduced more aggressively to speed up the search without
+    // harming tactical strength at longer time controls.
+    int improvingBonus = i ? -reductionScale * 57 / 512 : reductionScale * 273 / 512;
+    return reductionScale - delta * 731 / rootDelta + improvingBonus + 1089;
 }
 
 // elapsed() returns the time elapsed since the search started. If the


### PR DESCRIPTION
## Summary
- Relaxed improving flag detection to treat small eval drops as improving, reducing premature pruning
- Differentiated LMR reduction between improving and non-improving lines for sharper move ordering

## Testing
- ❌ `bash tests/perft.sh` (engine not named `stockfish`, tests expect it)
- ✅ `./src/revolution bench 64 1 15`


------
https://chatgpt.com/codex/tasks/task_e_68ae8936aebc8327b327377b2b44ab05