### PR TITLE
Restore Stockfish headers and update author string

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Revolution's architecture features:
 - SMP parallelization with YBWC (Young Brothers Wait Concept)
 - Advanced pruning techniques (Reverse Futility Pruning, Late Move Pruning)
 - Efficient move ordering with history heuristics and killer moves
-- Tuned search parameters through reinforcement learning
+- Optional root experience book storing previously played moves
 
 ## Files
 
@@ -108,8 +108,6 @@ Revolution is distributed under the **[GNU General Public License v3][gpl-link]*
 It integrates source code from:
 
 - [Stockfish](https://github.com/official-stockfish/Stockfish)
-
-No code from Berserk or Obsidian is currently included in Revolution.
 
 Because Stockfish is GPLv3, any distribution of Revolution must also comply with GPLv3.
 For a summary of your obligations under GPLv3 see <https://www.gnu.org/licenses/quick-guide-gplv3.html>.

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -1,3 +1,23 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Modifications Copyright (C) 2024 Jorge Ruiz Centelles
+*/
+
 #include "experience.h"
 
 #include <algorithm>

--- a/src/experience.h
+++ b/src/experience.h
@@ -1,3 +1,23 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  Modifications Copyright (C) 2024 Jorge Ruiz Centelles
+*/
+
 #ifndef EXPERIENCE_H_INCLUDED
 #define EXPERIENCE_H_INCLUDED
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
     // Clear, consistent banner (many GUIs echo this to their logs)
     std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE
               << ' ' << __DATE__ << ' ' << __TIME__
-              << " by Jorge Ruiz Centelles y los desarrolladores de Stockfish (ver archivo AUTHORS)" << std::endl;
+              << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << std::endl;
 
     std::cout << compiler_info() << std::endl;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -126,7 +126,7 @@ std::string engine_version_info() {
 // Update author information
 std::string engine_info(bool to_uci) {
     return engine_version_info() + (to_uci ? "\nid author " : " by ")
-           + "Jorge Ruiz Centelles y los desarrolladores de Stockfish (ver archivo AUTHORS)";
+           + "Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)";
 }
 
 // Returns a string trying to describe the compiler we use


### PR DESCRIPTION
## Summary
- restore original Stockfish GPL header in experience files and add modification copyright
- update author string to "Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
- clean README: remove Berserk/Obsidian references and clarify experience book

## Testing
- `make build -j2`

------
https://chatgpt.com/codex/tasks/task_e_68aecd2a1860832787721c4d18ae7c51