### PR TITLE
Add experience file stats output and use .exp default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ influence the internal search beyond the root. The following UCI options
 control this system:
 
 - `Experience Enabled`: enables or disables the experience feature (default `true`).
-- `Experience File`: name of the file where the experience data is stored (default `revolution.bin`).
+- `Experience File`: name of the file where the experience data is stored (default `revolution.exp`).
 - `Experience Readonly`: if `true`, no changes are written to the file.
 - `Experience Book`: uses the experience data as an opening book.
 - `Experience Book Width`: number of principal moves to consider (1–20).

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,6 +1,6 @@
 Revolution 1.0 250827
 - Initial fork from Stockfish.
 - Updated engine name and build system.
-- Added experience book system with persistent `.bin` file and new UCI options.
+- Added experience book system with persistent `.exp` file and new UCI options.
 - Iterative deepening now begins at depth 2 for faster, deeper search.
 - Updated version strings and AUTHORS for first public release.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -168,7 +168,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.bin", [this](const Option& o) {
+    options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load(o);
                     return std::nullopt;

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -23,6 +23,9 @@
 #include <algorithm>
 #include <fstream>
 #include <sstream>
+#include <iomanip>
+#include "misc.h"
+#include <iostream>
 
 namespace Stockfish {
 
@@ -33,13 +36,47 @@ void Experience::clear() { table.clear(); }
 void Experience::load(const std::string& file) {
     std::ifstream in(file);
     if (!in)
+    {
+        sync_cout << "info string Could not open " << file << sync_endl;
         return;
+    }
+
     table.clear();
+
     uint64_t key;
     unsigned move;
     int      score, depth, count;
+
+    std::size_t totalMoves = 0;
+    std::size_t duplicateMoves = 0;
+
     while (in >> key >> move >> score >> depth >> count)
-        table[key].push_back({Move(static_cast<std::uint16_t>(move)), score, depth, count});
+    {
+        totalMoves++;
+        auto& vec  = table[key];
+        bool  dup  = false;
+        for (auto& e : vec)
+            if (e.move.raw() == move)
+            {
+                dup        = true;
+                duplicateMoves++;
+                e.score = score;
+                e.depth = depth;
+                e.count += count;
+                break;
+            }
+        if (!dup)
+            vec.push_back({Move(static_cast<std::uint16_t>(move)), score, depth, count});
+    }
+
+    std::size_t totalPositions = table.size();
+    double      frag = totalPositions ? 100.0 * duplicateMoves / totalPositions : 0.0;
+
+    sync_cout << "info string " << file << " -> Total moves: " << totalMoves
+              << ". Total positions: " << totalPositions
+              << ". Duplicate moves: " << duplicateMoves
+              << ". Fragmentation: " << std::fixed << std::setprecision(2) << frag << "%)"
+              << sync_endl;
 }
 
 void Experience::save(const std::string& file) const {


### PR DESCRIPTION
## Summary
- display experience file statistics (moves, positions, duplicates, fragmentation) when loading
- change default experience filename to `revolution.exp`
- document experience file extension and changelog

## Testing
- `make -C src -j2 build ARCH=x86-64`
- `python tests/instrumented.py --none src/revolution` *(fails: Function starts_with timed out after 300 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68aed2ea49308327bdd1c55bfeae99a0