### PR TITLE
Ensure experience stats are reported and bump build date

### DIFF
--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,4 +1,4 @@
-Revolution 1.0 250827
+Revolution 1.0 dev 250827
 - Initial fork from Stockfish.
 - Updated engine name and build system.
 - Added experience book system with persistent `.exp` file (legacy `.bin` files are converted automatically) and new UCI options.

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -16,17 +16,18 @@ Experience experience;
 void Experience::clear() { table.clear(); }
 
 void Experience::load(const std::string& file) {
-    std::string path = file;
+    std::string   path = file;
     std::ifstream in;
-    bool        convertBin = false;
+    bool          convertBin = false;
 
-    if (path.size() >= 4) {
+    if (path.size() >= 4)
+    {
         std::string ext = path.substr(path.size() - 4);
-        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
-            return char(std::tolower(c));
-        });
+        std::transform(ext.begin(), ext.end(), ext.begin(),
+                       [](unsigned char c) { return char(std::tolower(c)); });
 
-        if (ext == ".bin") {
+        if (ext == ".bin")
+        {
             convertBin = true;
             in.open(path);
             path = path.substr(0, path.size() - 4) + ".exp";
@@ -42,7 +43,8 @@ void Experience::load(const std::string& file) {
     if (path != file)
         display += " (from " + file + ")";
 
-    if (!in) {
+    if (!in)
+    {
         sync_cout << "info string Could not open " << display << sync_endl;
         return;
     }
@@ -56,12 +58,14 @@ void Experience::load(const std::string& file) {
     std::size_t totalMoves     = 0;
     std::size_t duplicateMoves = 0;
 
-    while (in >> key >> move >> score >> depth >> count) {
+    while (in >> key >> move >> score >> depth >> count)
+    {
         totalMoves++;
         auto& vec = table[key];
         bool  dup = false;
         for (auto& e : vec)
-            if (e.move.raw() == move) {
+            if (e.move.raw() == move)
+            {
                 dup = true;
                 duplicateMoves++;
                 e.score = score;
@@ -74,11 +78,10 @@ void Experience::load(const std::string& file) {
     }
 
     std::size_t totalPositions = table.size();
-    double      frag = totalPositions ? 100.0 * duplicateMoves / totalPositions : 0.0;
+    double      frag           = totalPositions ? 100.0 * duplicateMoves / totalPositions : 0.0;
 
     sync_cout << "info string " << display << " -> Total moves: " << totalMoves
-              << ". Total positions: " << totalPositions
-              << ". Duplicate moves: " << duplicateMoves
+              << ". Total positions: " << totalPositions << ". Duplicate moves: " << duplicateMoves
               << ". Fragmentation: " << std::fixed << std::setprecision(2) << frag << "%)"
               << sync_endl;
 
@@ -89,13 +92,14 @@ void Experience::load(const std::string& file) {
 void Experience::save(const std::string& file) const {
     std::string path = file;
 
-    if (path.size() >= 4) {
+    if (path.size() >= 4)
+    {
         std::string ext = path.substr(path.size() - 4);
-        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
-            return char(std::tolower(c));
-        });
+        std::transform(ext.begin(), ext.end(), ext.begin(),
+                       [](unsigned char c) { return char(std::tolower(c)); });
 
-        if (ext == ".bin") {
+        if (ext == ".bin")
+        {
             path = path.substr(0, path.size() - 4) + ".exp";
             sync_cout << "info string '.bin' experience files are deprecated; saving to '" << path
                       << "'" << sync_endl;
@@ -103,19 +107,30 @@ void Experience::save(const std::string& file) const {
     }
 
     std::ofstream out(path);
-    if (!out) {
+    if (!out)
+    {
         sync_cout << "info string Could not open " << path << " for writing" << sync_endl;
         return;
     }
 
+    std::size_t totalMoves = 0;
+
     for (const auto& [key, vec] : table)
         for (const auto& e : vec)
-            out << key << ' ' << e.move.raw() << ' ' << e.score << ' ' << e.depth << ' '
-                << e.count << '\n';
+        {
+            out << key << ' ' << e.move.raw() << ' ' << e.score << ' ' << e.depth << ' ' << e.count
+                << '\n';
+            totalMoves++;
+        }
+
+    std::size_t totalPositions = table.size();
+
+    sync_cout << "info string " << path << " <- Total moves: " << totalMoves
+              << ". Total positions: " << totalPositions << sync_endl;
 }
 
-Move Experience::probe(Position& pos, [[maybe_unused]] int width, int evalImportance,
-                       int minDepth, int maxMoves) {
+Move Experience::probe(
+  Position& pos, [[maybe_unused]] int width, int evalImportance, int minDepth, int maxMoves) {
     auto it = table.find(pos.key());
     if (it == table.end())
         return Move::none();
@@ -139,7 +154,8 @@ Move Experience::probe(Position& pos, [[maybe_unused]] int width, int evalImport
 void Experience::update(Position& pos, Move move, int score, int depth) {
     auto& vec = table[pos.key()];
     for (auto& e : vec)
-        if (e.move == move) {
+        if (e.move == move)
+        {
             e.score = score;
             e.depth = depth;
             e.count++;
@@ -149,4 +165,3 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
 }
 
 }  // namespace Stockfish
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-// ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=270825
-#define ENGINE_BUILD_DATE "000000"
+    // yymmdd; override at build time with:  -DENGINE_BUILD_DATE=250827
+    #define ENGINE_BUILD_DATE "250827"
 #endif
 
 #ifndef ENGINE_NAME
-// override at build time with:  -DENGINE_NAME="\"Revolution 1.0\""
-#define ENGINE_NAME "Revolution 1.0"
+    // override at build time with:  -DENGINE_NAME="\"Revolution 1.0\""
+    #define ENGINE_NAME "Revolution 1.0"
 #endif
 
 using namespace Stockfish;
@@ -39,9 +39,9 @@ using namespace Stockfish;
 int main(int argc, char* argv[]) {
 
     // Clear, consistent banner (many GUIs echo this to their logs)
-    std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE
-              << ' ' << __DATE__ << ' ' << __TIME__
-              << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << std::endl;
+    std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << ' ' << __DATE__ << ' ' << __TIME__
+              << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
+              << std::endl;
 
     std::cout << compiler_info() << std::endl;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "000000"
+    #define ENGINE_BUILD_DATE "250827"
 #endif
 
 namespace Stockfish {
@@ -119,14 +119,12 @@ class Logger {
 
 
 // Returns the full name of the current Revolution version.
-std::string engine_version_info() {
-    return std::string("Revolution 1.0 ") + version.data();
-}
+std::string engine_version_info() { return std::string("Revolution 1.0 ") + version.data(); }
 
 // Update author information
 std::string engine_info(bool to_uci) {
     return engine_version_info() + (to_uci ? "\nid author " : " by ")
-           + "Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)";
+         + "Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)";
 }
 
 // Returns a string trying to describe the compiler we use


### PR DESCRIPTION
## Summary
- print move and position totals to the console whenever the experience book is saved
- update default build date macros to 250827
- mark changelog as dev build 250827

## Testing
- ⚠️ `make build` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68aef4a9320c8327930a31f739248aa0