### PR TITLE
Simplify LMR and update dev version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# [1.0.0-dev 2708225]
+### Changed
+- Simplified LMR logic to streamline search and improve speed.
+- Updated default engine name to "revolution device v.1.0.0" with build identifier 2708225.
+
 ## [1.0] - 2025-08-27
 ### Added
 - Initial public release of Revolution v1.0.

--- a/src/Makefile
+++ b/src/Makefile
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 1.0"
-#   - ENGINE_BUILD_DATE: system date in ddmmyy format
+#   - ENGINE_NAME: "revolution device v.1.0.0"
+#   - ENGINE_BUILD_DATE: fixed build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 1.0.2 beta" ENGINE_BUILD_DATE=251001
-ENGINE_NAME        ?= Revolution 1.0
-ENGINE_BUILD_DATE  ?= $(shell date +%d%m%y)
+#   make ENGINE_NAME="revolution device v.1.0.0" ENGINE_BUILD_DATE=2708225
+ENGINE_NAME        ?= revolution device v.1.0.0
+ENGINE_BUILD_DATE  ?= 2708225
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // yymmdd; override at build time with:  -DENGINE_BUILD_DATE=250827
-    #define ENGINE_BUILD_DATE "250827"
+    // Custom build identifier
+    #define ENGINE_BUILD_DATE "2708225"
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 1.0\""
-    #define ENGINE_NAME "Revolution 1.0"
+    // override at build time with:  -DENGINE_NAME="\"revolution device v.1.0.0\""
+    #define ENGINE_NAME "revolution device v.1.0.0"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "250827"
+    #define ENGINE_BUILD_DATE "2708225"
 #endif
 
 namespace Stockfish {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1255,38 +1255,19 @@ moves_loop:  // When in check, search starts here
         // Decrease/increase reduction for moves with a good/bad history
         r -= ss->statScore * 789 / 8192;
 
-        // Step 17. Late moves reduction / extension (LMR)
+        // Step 17. Late moves reduction (LMR)
         if (depth >= 2 && moveCount > 1)
         {
-            // In general we want to cap the LMR depth search at newDepth, but when
-            // reduction is negative, we allow this move a limited search extension
-            // beyond the first move depth.
-            // To prevent problems when the max value is less than the min value,
-            // std::clamp has been replaced by a more robust implementation.
-            Depth d = std::max(1, std::min(newDepth - r / 1024, newDepth + 1 + PvNode)) + PvNode;
+            // Apply a simple reduction limited between one ply and the remaining depth
+            Depth d = std::max(1, newDepth - r / 1024);
 
             ss->reduction = newDepth - d;
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
 
             // Do a full-depth search when reduced LMR search fails high
-            // (*Scaler) Usually doing more shallower searches
-            // doesn't scale well to longer TCs
             if (value > alpha)
-            {
-                // Adjust full-depth search based on LMR results - if the result was
-                // good enough search deeper, if it was bad enough search shallower.
-                const bool doDeeperSearch = d < newDepth && value > (bestValue + 43 + 2 * newDepth);
-                const bool doShallowerSearch = value < bestValue + 9;
-
-                newDepth += doDeeperSearch - doShallowerSearch;
-
-                if (newDepth > d)
-                    value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
-
-                // Post LMR continuation history updates
-                update_continuation_histories(ss, movedPiece, move.to_sq(), 1412);
-            }
+                value = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, newDepth, !cutNode);
         }
 
         // Step 18. Full-depth search when LMR is skipped

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 1.0"
+#define ENGINE_NAME "revolution device v.1.0.0"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "000000"  // ddmmyy; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "2708225"  // build identifier
 #endif
 
 


### PR DESCRIPTION
## Summary
- streamline late-move reduction logic for faster search
- set development version identifier to "revolution device v.1.0.0" build 2708225
- document changes in changelog

## Testing
- `make -C src build`
- `tests/signature.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af1a13e37c8327aaa83aaf7fb8bb0c