### PR TITLE
Rename engine to revolution dev 290825 v1.0.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution.exe
+        EXE = revolution_dev_290825_v1.0.1.exe
 else
-        EXE = revolution
+        EXE = revolution_dev_290825_v1.0.1
 endif
 
 ### Installation dir definitions
@@ -842,11 +842,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution device v.1.0.0"
+#   - ENGINE_NAME: "revolution dev 290825 v1.0.1"
 #   - ENGINE_BUILD_DATE: fixed build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution device v.1.0.0" ENGINE_BUILD_DATE=2708225
-ENGINE_NAME        ?= revolution device v.1.0.0
+#   make ENGINE_NAME="revolution dev 290825 v1.0.1" ENGINE_BUILD_DATE=2708225
+ENGINE_NAME        ?= revolution dev 290825 v1.0.1
 ENGINE_BUILD_DATE  ?= 2708225
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution device v.1.0.0\""
-    #define ENGINE_NAME "revolution device v.1.0.0"
+    // override at build time with:  -DENGINE_NAME="\"revolution dev 290825 v1.0.1\""
+    #define ENGINE_NAME "revolution dev 290825 v1.0.1"
 #endif
 
 using namespace Stockfish;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution device v.1.0.0"
+#define ENGINE_NAME "revolution dev 290825 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE "2708225"  // build identifier


### PR DESCRIPTION
## Summary
- Update ENGINE_NAME defaults to "revolution dev 290825 v1.0.1"
- Build now outputs revolution_dev_290825_v1.0.1 executable
- Document new engine name in Makefile comments

## Testing
- `make build`
- `printf "quit" | ./revolution_dev_290825_v1.0.1 | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_68b17353a0e48327b5ecdcc8581a9f68