### PR TITLE
Fix experience file parsing and remove duplicate build date

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -843,11 +843,11 @@ endif
 # UCI "id name" string shown in GUIs.
 # Defaults:
 #   - ENGINE_NAME: "revolution dev 290825 v1.0.1"
-#   - ENGINE_BUILD_DATE: fixed build identifier
+#   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution dev 290825 v1.0.1" ENGINE_BUILD_DATE=2708225
+#   make ENGINE_NAME="revolution dev 290825 v1.0.1" ENGINE_BUILD_DATE=20240829
 ENGINE_NAME        ?= revolution dev 290825 v1.0.1
-ENGINE_BUILD_DATE  ?= 2708225
+ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -51,15 +51,37 @@ void Experience::load(const std::string& file) {
 
     table.clear();
 
-    uint64_t key;
-    unsigned move;
-    int      score, depth, count;
-
     std::size_t totalMoves     = 0;
     std::size_t duplicateMoves = 0;
 
-    while (in >> key >> move >> score >> depth >> count)
+    std::string line;
+    while (std::getline(in, line))
     {
+        if (line.empty() || line[0] == '#')
+            continue;
+
+        std::istringstream iss(line);
+        std::string        keyStr, moveStr;
+        int                score, depth, count;
+
+        if (!(iss >> keyStr >> moveStr >> score >> depth >> count))
+            continue;
+
+        auto parse = [](const std::string& s, uint64_t& out) {
+            std::istringstream ss(s);
+            if (s.find_first_not_of("0123456789") == std::string::npos)
+                ss >> out;
+            else
+                ss >> std::hex >> out;
+            return !ss.fail();
+        };
+
+        uint64_t key64, move64;
+        if (!parse(keyStr, key64) || !parse(moveStr, move64))
+            continue;
+        uint64_t key  = key64;
+        unsigned move = static_cast<unsigned>(move64);
+
         totalMoves++;
         auto& vec = table[key];
         bool  dup = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // Custom build identifier
-    #define ENGINE_BUILD_DATE "2708225"
+    // Optional custom build identifier
+    #define ENGINE_BUILD_DATE ""
 #endif
 
 #ifndef ENGINE_NAME
@@ -39,7 +39,10 @@ using namespace Stockfish;
 int main(int argc, char* argv[]) {
 
     // Clear, consistent banner (many GUIs echo this to their logs)
-    std::cout << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << ' ' << __DATE__ << ' ' << __TIME__
+    std::cout << ENGINE_NAME;
+    if (*ENGINE_BUILD_DATE)
+        std::cout << ' ' << ENGINE_BUILD_DATE;
+    std::cout << ' ' << __DATE__ << ' ' << __TIME__
               << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
               << std::endl;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -36,16 +36,16 @@
 #include <string_view>
 
 #include "types.h"
+#ifndef ENGINE_NAME
+    #define ENGINE_NAME "revolution dev 290825 v1.0.1"
+#endif
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "2708225"
+    #define ENGINE_BUILD_DATE ""
 #endif
 
 namespace Stockfish {
 
 namespace {
-
-// Version number or dev.
-constexpr std::string_view version = ENGINE_BUILD_DATE;
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -119,7 +119,7 @@ class Logger {
 
 
 // Returns the full name of the current Revolution version.
-std::string engine_version_info() { return std::string("Revolution 1.0 ") + version.data(); }
+std::string engine_version_info() { return std::string(ENGINE_NAME); }
 
 // Update author information
 std::string engine_info(bool to_uci) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -41,6 +41,13 @@
 #include "types.h"
 #include "ucioption.h"
 
+#ifndef ENGINE_NAME
+#define ENGINE_NAME "revolution dev 290825 v1.0.1"
+#endif
+#ifndef ENGINE_BUILD_DATE
+#define ENGINE_BUILD_DATE ""
+#endif
+
 namespace Stockfish {
 
 constexpr auto BenchmarkCommand = "speedtest";
@@ -116,9 +123,11 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0 <date>"
-            sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
-                << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
+            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0"
+            sync_cout << "id name " << ENGINE_NAME;
+            if (*ENGINE_BUILD_DATE)
+                sync_cout << ' ' << ENGINE_BUILD_DATE;
+            sync_cout << "\n" << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
                 << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -24,7 +24,7 @@
 #define ENGINE_NAME "revolution dev 290825 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "2708225"  // build identifier
+#define ENGINE_BUILD_DATE ""  // build identifier
 #endif
 
 


### PR DESCRIPTION
## Summary
- parse experience files line-by-line and support hexadecimal keys to load .exp data from other engines
- drop default build-date string so engine banner only shows version name

## Testing
- `make -C src build ARCH=x86-64`
- `./src/revolution_dev_290825_v1.0.1`

------
https://chatgpt.com/codex/tasks/task_e_68b1f47d508483278955b6b6313efb5e