### PR TITLE
Load experience files asynchronously to improve GUI startup

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -162,7 +162,7 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Experience Enabled", Option(true, [this](const Option& o) {
                     if (bool(o))
-                        experience.load(options["Experience File"]);
+                        experience.load_async(options["Experience File"]);
                     else
                         experience.clear();
                     return std::nullopt;
@@ -170,7 +170,7 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
-                        experience.load(o);
+                        experience.load_async(o);
                     return std::nullopt;
                 }));
 
@@ -202,7 +202,7 @@ Engine::Engine(std::optional<std::string> path) :
       }));
 
     if ((bool) options["Experience Enabled"])
-        experience.load(options["Experience File"]);
+        experience.load_async(options["Experience File"]);
 
     load_networks();
     resize_threads();

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <future>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -13,7 +14,15 @@ namespace Stockfish {
 
 Experience experience;
 
-void Experience::clear() { table.clear(); }
+void Experience::wait_until_loaded() {
+    if (loader.valid())
+        loader.wait();
+}
+
+void Experience::clear() {
+    wait_until_loaded();
+    table.clear();
+}
 
 void Experience::load(const std::string& file) {
     std::string   path = file;
@@ -166,6 +175,10 @@ void Experience::load(const std::string& file) {
         save(path);
 }
 
+void Experience::load_async(const std::string& file) {
+    loader = std::async(std::launch::async, [this, file] { load(file); });
+}
+
 void Experience::save(const std::string& file) const {
     std::string path = file;
 
@@ -244,6 +257,7 @@ void Experience::save(const std::string& file) const {
 }
 
 Move Experience::probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves) {
+    wait_until_loaded();
     auto it = table.find(pos.key());
     if (it == table.end())
         return Move::none();
@@ -271,6 +285,7 @@ Move Experience::probe(Position& pos, int width, int evalImportance, int minDept
 }
 
 void Experience::update(Position& pos, Move move, int score, int depth) {
+    wait_until_loaded();
     auto& vec = table[pos.key()];
     for (auto& e : vec)
         if (e.move == move)

--- a/src/experience.h
+++ b/src/experience.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 #include <string>
+#include <future>
 
 #include "position.h"
 #include "types.h"
@@ -41,6 +42,8 @@ class Experience {
    public:
     void clear();
     void load(const std::string& file);
+    void load_async(const std::string& file);
+    void wait_until_loaded();
     void save(const std::string& file) const;
     Move probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
@@ -48,6 +51,7 @@ class Experience {
    private:
     std::unordered_map<Key, std::vector<ExperienceEntry>> table;
     bool binaryFormat = false;
+    std::future<void> loader;
 };
 
 extern Experience experience;


### PR DESCRIPTION
## Summary
- Load experience files in a background thread and block probes until finished
- Add helpers to wait for experience data before use
- Switch engine option handlers to asynchronous loading

## Testing
- `cd src && make build`

------
https://chatgpt.com/codex/tasks/task_e_68b215f8caac83278bc69898d563ee8e