### PR TITLE
Fix UCI initialization output for Revolution engine

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -201,9 +201,6 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    if ((bool) options["Experience Enabled"])
-        experience.load_async(options["Experience File"]);
-
     load_networks();
     resize_threads();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,15 +38,16 @@ using namespace Stockfish;
 
 int main(int argc, char* argv[]) {
 
-    // Clear, consistent banner (many GUIs echo this to their logs)
-    std::cout << ENGINE_NAME;
+    // Clear, consistent banner (many GUIs echo this to their logs).
+    // Send banner to stderr so it doesn't interfere with UCI handshake on stdout.
+    std::cerr << ENGINE_NAME;
     if (*ENGINE_BUILD_DATE)
-        std::cout << ' ' << ENGINE_BUILD_DATE;
-    std::cout << ' ' << __DATE__ << ' ' << __TIME__
+        std::cerr << ' ' << ENGINE_BUILD_DATE;
+    std::cerr << ' ' << __DATE__ << ' ' << __TIME__
               << " by Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
               << std::endl;
 
-    std::cout << compiler_info() << std::endl;
+    std::cerr << compiler_info() << std::endl;
 
     Bitboards::init();
     Position::init();

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -38,6 +38,7 @@
 #include "position.h"
 #include "score.h"
 #include "search.h"
+#include "experience.h"
 #include "types.h"
 #include "ucioption.h"
 
@@ -131,6 +132,9 @@ void UCIEngine::loop() {
                 << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;
+
+            if ((bool)engine.get_options()["Experience Enabled"])
+                experience.load_async(engine.get_options()["Experience File"]);
         }
 
         else if (token == "setoption")


### PR DESCRIPTION
## Summary
- Log startup banner to stderr to avoid interfering with UCI handshake
- Defer experience file loading until after `uci` command
- Include experience header in UCI module

## Testing
- `bash tests/perft.sh ./src/revolution_dev_290825_v1.0.1` *(fails: command hung after multiple attempts)*

------
https://chatgpt.com/codex/tasks/task_e_68b22365409c8327be9de74ff0a395ee