### PR TITLE
Add Minimum Thinking Time UCI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-# [1.0.0-dev 2708225]
+## [1.0.1] - 2025-08-30
+### Added
+- UCI option `Minimum Thinking Time` to enforce a minimum search duration per move.
+- Engine now appends the build date after its name in UCI identification.
+
+## [1.0.0-dev 2708225]
 ### Changed
 - Simplified LMR logic to streamline search and improve speed.
 - Updated default engine name to "revolution device v.1.0.0" with build identifier 2708225.

--- a/src/Makefile
+++ b/src/Makefile
@@ -847,7 +847,7 @@ endif
 # You can override on the command line:
 #   make ENGINE_NAME="revolution dev 290825 v1.0.1" ENGINE_BUILD_DATE=20240829
 ENGINE_NAME        ?= revolution dev 290825 v1.0.1
-ENGINE_BUILD_DATE  ?=
+ENGINE_BUILD_DATE  ?= $(shell date +%Y-%m-%d)
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -108,6 +108,8 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("nodestime", Option(0, 0, 10000));
 
+    options.add("Minimum Thinking Time", Option(20, 0, 5000));
+
     options.add("UCI_Chess960", Option(false));
 
     options.add("UCI_LimitStrength", Option(false));
@@ -213,6 +215,11 @@ std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960
 
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
+
+    TimePoint minTime = TimePoint(options["Minimum Thinking Time"]);
+    if (limits.movetime && limits.movetime < minTime)
+        limits.movetime = minTime;
+
     verify_networks();
 
     threads.start_thinking(options, pos, states, limits);

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -135,6 +135,10 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
+
+    TimePoint minimumThinkingTime = TimePoint(options["Minimum Thinking Time"]);
+    optimumTime = std::max(optimumTime, minimumThinkingTime);
+    maximumTime = std::max(maximumTime, minimumThinkingTime);
 }
 
 }  // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -46,7 +46,7 @@
     #define ENGINE_NAME "revolution dev 290825 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
+    #define ENGINE_BUILD_DATE __DATE__
 #endif
 
 namespace Stockfish {


### PR DESCRIPTION
## Summary
- add `Minimum Thinking Time` option to guarantee a minimum search duration
- append build date to the engine name using the Makefile's default date

## Testing
- `make build`
- `printf "uci\nquit\n" | ./revolution_dev_290825_v1.0.1 | head -n 10`
- `time ( printf "setoption name Minimum Thinking Time value 1000\nposition startpos\ngo movetime 10\nquit\n" | ./revolution_dev_290825_v1.0.1 > /tmp/run.log )`


------
https://chatgpt.com/codex/tasks/task_e_68b377b257dc832798fc2c2d64dfa002