### PR TITLE
Simplify key adjustment and add sparsehash stubs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## [1.0.1] - 2025-08-30
+## [1.0.1] - 2025-09-01
 ### Added
 - UCI option `Minimum Thinking Time` to enforce a minimum search duration per move.
 - Engine now appends the build date after its name in UCI identification.
+### Changed
+- Simplified rule-50 key adjustment by removing the unused template parameter.
 
 ## [1.0.0-dev 2708225]
 ### Changed

--- a/sparsehash/dense_hash_map
+++ b/sparsehash/dense_hash_map
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+#define REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H
+
+// Placeholder dense_hash_map for the Revolution project.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_MAP_H

--- a/sparsehash/dense_hash_set
+++ b/sparsehash/dense_hash_set
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+#define REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H
+
+// Placeholder dense_hash_set for the Revolution project.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_DENSE_HASH_SET_H

--- a/sparsehash/sparse_hash_map
+++ b/sparsehash/sparse_hash_map
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+#define REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H
+
+// Placeholder sparse_hash_map for the Revolution project.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_MAP_H

--- a/sparsehash/sparse_hash_set
+++ b/sparsehash/sparse_hash_set
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+#define REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H
+
+// Placeholder sparse_hash_set for the Revolution project.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_SPARSE_HASH_SET_H

--- a/sparsehash/sparsetable
+++ b/sparsehash/sparsetable
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_SPARSETABLE_H
+#define REVOLUTION_SPARSEHASH_SPARSETABLE_H
+
+// Placeholder sparsetable for the Revolution project.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_SPARSETABLE_H

--- a/sparsehash/template_util.h
+++ b/sparsehash/template_util.h
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+#define REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H
+
+// Utility templates for the Revolution project's sparsehash placeholders.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_TEMPLATE_UTIL_H

--- a/sparsehash/type_traits.h
+++ b/sparsehash/type_traits.h
@@ -1,0 +1,7 @@
+#ifndef REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+#define REVOLUTION_SPARSEHASH_TYPE_TRAITS_H
+
+// Type trait helpers for the Revolution project's sparsehash placeholders.
+// Implementation intentionally minimal.
+
+#endif // REVOLUTION_SPARSEHASH_TYPE_TRAITS_H

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_dev_290825_v1.0.1.exe
+        EXE = revolution_dev_010925_v1.0.1.exe
 else
-        EXE = revolution_dev_290825_v1.0.1
+        EXE = revolution_dev_010925_v1.0.1
 endif
 
 ### Installation dir definitions
@@ -842,11 +842,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution dev 290825 v1.0.1"
+#   - ENGINE_NAME: "revolution dev 010925 v1.0.1"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution dev 290825 v1.0.1" ENGINE_BUILD_DATE=20240829
-ENGINE_NAME        ?= revolution dev 290825 v1.0.1
+#   make ENGINE_NAME="revolution dev 010925 v1.0.1" ENGINE_BUILD_DATE=20250901
+ENGINE_NAME        ?= revolution dev 010925 v1.0.1
 ENGINE_BUILD_DATE  ?= $(shell date +%Y-%m-%d)
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution dev 290825 v1.0.1\""
-    #define ENGINE_NAME "revolution dev 290825 v1.0.1"
+    // override at build time with:  -DENGINE_NAME="\"revolution dev 010925 v1.0.1\""
+    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev 290825 v1.0.1"
+    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/position.h
+++ b/src/position.h
@@ -184,7 +184,6 @@ class Position {
                      Square&           rfrom,
                      Square&           rto,
                      DirtyPiece* const dp = nullptr);
-    template<bool AfterMove>
     Key adjust_key50(Key k) const;
 
     // Data members
@@ -288,11 +287,10 @@ inline Bitboard Position::pinners(Color c) const { return st->pinners[c]; }
 
 inline Bitboard Position::check_squares(PieceType pt) const { return st->checkSquares[pt]; }
 
-inline Key Position::key() const { return adjust_key50<false>(st->key); }
+inline Key Position::key() const { return adjust_key50(st->key); }
 
-template<bool AfterMove>
 inline Key Position::adjust_key50(Key k) const {
-    return st->rule50 < 14 - AfterMove ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
+    return st->rule50 < 14 ? k : k ^ make_key((st->rule50 - 14) / 8);
 }
 
 inline Key Position::pawn_key() const { return st->pawnKey; }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev 290825 v1.0.1"
+    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE __DATE__

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution dev 290825 v1.0.1"
+#define ENGINE_NAME "revolution dev 010925 v1.0.1"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- remove unused AfterMove template from `adjust_key50`
- update engine name to `revolution dev 010925 v1.0.1`
- add placeholder sparsehash headers referencing the Revolution project

## Testing
- `make build -j2 ARCH=x86-64-sse41-popcnt`

------
https://chatgpt.com/codex/tasks/task_e_68b5c33c046c83278654e635c8d7c856