### PR TITLE
Add experience book and concurrent save options

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -28,6 +28,8 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include <iomanip>
+#include <random>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -173,6 +175,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load_async(o);
+                    concurrentExperienceFile.clear();
                     return std::nullopt;
                 }));
 
@@ -182,6 +185,13 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience Eval Weight", Option(5, 0, 10));
     options.add("Experience Min Depth", Option(27, 4, 64));
     options.add("Experience Max Moves", Option(16, 1, 100));
+    options.add("Experience Book", Option(false));
+    options.add("Experience Book Max Moves", Option(100, 1, 100));
+    options.add("Experience Book Min Depth", Option(4, 1, 255));
+    options.add("Experience Concurrent", Option(false, [this](const Option&) {
+                    concurrentExperienceFile.clear();
+                    return std::nullopt;
+                }));
 
     // Optional experimental evaluation tweak that adapts weights based on
     // simple positional cues. Disabled by default so it does not alter
@@ -237,7 +247,27 @@ void Engine::search_clear() {
     Tablebases::release();
 
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
-        experience.save(options["Experience File"]);
+    {
+        std::string file = options["Experience File"];
+        if ((bool) options["Experience Concurrent"])
+        {
+            if (concurrentExperienceFile.empty())
+            {
+                std::random_device rd;
+                uint64_t           r = (uint64_t(rd()) << 32) ^ rd();
+                std::ostringstream oss;
+                oss << std::hex << std::setfill('0') << std::setw(16) << r;
+                std::string suffix = oss.str();
+                auto        p      = file.find_last_of('.');
+                if (p != std::string::npos)
+                    concurrentExperienceFile = file.substr(0, p) + "-" + suffix + file.substr(p);
+                else
+                    concurrentExperienceFile = file + "-" + suffix;
+            }
+            file = concurrentExperienceFile;
+        }
+        experience.save(file);
+    }
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {
@@ -441,4 +471,6 @@ std::string Engine::thread_allocation_information_as_string() const {
 
     return ss.str();
 }
+
+const Position& Engine::position() const { return pos; }
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -106,6 +106,7 @@ class Engine {
     std::string                            numa_config_information_as_string() const;
     std::string                            thread_allocation_information_as_string() const;
     std::string                            thread_binding_information_as_string() const;
+    const Position&                        position() const;
 
    private:
     const std::string binaryDirectory;
@@ -122,6 +123,8 @@ class Engine {
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
+
+    std::string concurrentExperienceFile;
 };
 
 }  // namespace Stockfish

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 
 #include "misc.h"
+#include "uci.h"
 
 namespace Stockfish {
 
@@ -286,6 +287,32 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
         }
     // First encounter of this move in the current position.
     vec.push_back({move, score, depth, 1});
+}
+
+void Experience::show(const Position& pos, int evalImportance, int maxMoves) const {
+    if (!is_ready())
+        return;
+    auto it = table.find(pos.key());
+    if (it == table.end())
+    {
+        sync_cout << "info string No experience available" << sync_endl;
+        return;
+    }
+    auto vec = it->second;
+    std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
+        return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
+    });
+    int shown = 0;
+    for (const auto& e : vec)
+    {
+        if (shown++ >= maxMoves)
+            break;
+        sync_cout << "info string "
+                  << UCIEngine::move(e.move, pos.is_chess960())
+                  << " score " << e.score
+                  << " depth " << e.depth
+                  << " count " << e.count << sync_endl;
+    }
 }
 
 }  // namespace Stockfish

--- a/src/experience.h
+++ b/src/experience.h
@@ -47,6 +47,7 @@ class Experience {
     void save(const std::string& file) const;
     Move probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves);
     void update(Position& pos, Move move, int score, int depth);
+    void show(const Position& pos, int evalImportance, int maxMoves) const;
 
    private:
     bool is_ready() const;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -186,15 +186,26 @@ void Search::Worker::start_searching() {
     {
         if (!limits.infinite && !limits.mate)
         {
-            if ((bool) options["Experience Enabled"] && (bool) options["Experience Prior"])
-                preferredMove =
-                  experience.probe(rootPos, (int) options["Experience Width"],
-                                   (int) options["Experience Eval Weight"],
-                                   (int) options["Experience Min Depth"],
-                                   (int) options["Experience Max Moves"]);
+            if ((bool) options["Experience Enabled"])
+            {
+                if ((bool) options["Experience Prior"])
+                    preferredMove =
+                      experience.probe(rootPos, (int) options["Experience Width"],
+                                       (int) options["Experience Eval Weight"],
+                                       (int) options["Experience Min Depth"],
+                                       (int) options["Experience Max Moves"]);
+
+                if ((bool) options["Experience Book"])
+                    bookMove = experience.probe(rootPos,
+                                               (int) options["Experience Book Max Moves"],
+                                               (int) options["Experience Eval Weight"],
+                                               (int) options["Experience Book Min Depth"],
+                                               (int) options["Experience Book Max Moves"]);
+            }
 
             if ((bool) options["Book1"]
-                && rootPos.game_ply() / 2 < (int) options["Book1 Depth"])
+                && rootPos.game_ply() / 2 < (int) options["Book1 Depth"]
+                && bookMove == Move::none())
                 bookMove = polybook[0].probe(rootPos, (bool) options["Book1 BestBookMove"],
                                              (int) options["Book1 Width"]);
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -170,6 +170,10 @@ void UCIEngine::loop() {
             sync_cout << engine.visualize() << sync_endl;
         else if (token == "eval")
             engine.trace_eval();
+        else if (token == "showexp")
+            experience.show(engine.position(),
+                             (int) engine.get_options()["Experience Eval Weight"],
+                             (int) engine.get_options()["Experience Book Max Moves"]);
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")


### PR DESCRIPTION
## Summary
- Allow engine to use experience file as an opening book
- Add option to save experience concurrently with unique file names
- Introduce `showexp` command to list stored moves for the current position

## Testing
- `make -C src build ARCH=x86-64`

------
https://chatgpt.com/codex/tasks/task_e_68b5f077d0ac8327bee4ff77f20689bd