### PR TITLE
Add CCZ compression for experience files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ previous games. Rather than forcing book moves, the cached information biases ro
 ordering during search. The following UCI options control this system:
 
 - `Experience Enabled`: enables or disables the experience feature (default `true`).
-- `Experience File`: name of the file where the experience data is stored (default `revolution.exp`; legacy `.bin` files are converted automatically).
+- `Experience File`: name of the file where the experience data is stored (default `revolution.ccz`; legacy `.bin` files are converted automatically and saved in compressed form).
 - `Experience Readonly`: if `true`, no changes are written to the file.
 - `Experience Prior`: uses stored experience to bias root move ordering.
 - `Experience Width`: number of principal moves to consider (1–20).

--- a/src/Makefile
+++ b/src/Makefile
@@ -440,7 +440,7 @@ endif
 
 CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
-LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
+LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS) -lz
 
 ifeq ($(COMP),)
 	COMP=gcc

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -172,7 +172,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.exp", [this](const Option& o) {
+    options.add("Experience File", Option("revolution.ccz", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load_async(o);
                     concurrentExperienceFile.clear();

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -7,7 +7,10 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <iterator>
+#include <memory>
 #include <sstream>
+#include <zlib.h>
 
 #include "misc.h"
 #include "uci.h"
@@ -31,38 +34,51 @@ void Experience::clear() {
 }
 
 void Experience::load(const std::string& file) {
-    std::string   path = file;
-    std::ifstream in;
-    bool          convertBin = false;
+    std::string path = file;
+    bool        convertBin = false;
+    bool        compressed = false;
+    std::string display;
 
-    if (path.size() >= 4)
-    {
+    if (path.size() >= 4) {
         std::string ext = path.substr(path.size() - 4);
         std::transform(ext.begin(), ext.end(), ext.begin(),
                        [](unsigned char c) { return char(std::tolower(c)); });
 
-        if (ext == ".bin")
-        {
+        if (ext == ".bin") {
             convertBin = true;
-            in.open(path, std::ios::binary);
-            path = path.substr(0, path.size() - 4) + ".exp";
+            path       = path.substr(0, path.size() - 4) + ".ccz";
             sync_cout << "info string '.bin' experience files are deprecated; converting to '"
                       << path << "'" << sync_endl;
-        }
+        } else if (ext == ".ccz")
+            compressed = true;
     }
 
-    if (!convertBin)
-        in.open(path, std::ios::binary);
-
-    std::string display = path;
+    display = path;
     if (path != file)
         display += " (from " + file + ")";
 
-    if (!in)
-    {
-        sync_cout << "info string Could not open " << display << sync_endl;
-        return;
+    std::string buffer;
+    if (compressed) {
+        gzFile gzin = gzopen(path.c_str(), "rb");
+        if (!gzin) {
+            sync_cout << "info string Could not open " << display << sync_endl;
+            return;
+        }
+        char tmp[1 << 15];
+        int  bytes;
+        while ((bytes = gzread(gzin, tmp, sizeof(tmp))) > 0)
+            buffer.append(tmp, bytes);
+        gzclose(gzin);
+    } else {
+        std::ifstream f(convertBin ? file : path, std::ios::binary);
+        if (!f) {
+            sync_cout << "info string Could not open " << display << sync_endl;
+            return;
+        }
+        buffer.assign(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
     }
+
+    std::istringstream in(buffer);
 
     const std::string sigV2 = "SugaR Experience version 2";
     const std::string sigV1 = "SugaR";
@@ -132,14 +148,6 @@ void Experience::load(const std::string& file) {
     }
     else
     {
-        in.close();
-        in.open(path);  // reopen in text mode
-        if (!in)
-        {
-            sync_cout << "info string Could not open " << display << sync_endl;
-            return;
-        }
-
         std::string line;
         while (std::getline(in, line))
         {
@@ -190,35 +198,29 @@ void Experience::load_async(const std::string& file) {
 void Experience::save(const std::string& file) const {
     wait_until_loaded();
     std::string path = file;
+    bool        compressed = false;
 
-    if (path.size() >= 4)
-    {
+    if (path.size() >= 4) {
         std::string ext = path.substr(path.size() - 4);
         std::transform(ext.begin(), ext.end(), ext.begin(),
                        [](unsigned char c) { return char(std::tolower(c)); });
 
-        if (ext == ".bin")
-        {
-            path = path.substr(0, path.size() - 4) + ".exp";
+        if (ext == ".bin") {
+            path = path.substr(0, path.size() - 4) + ".ccz";
             sync_cout << "info string '.bin' experience files are deprecated; saving to '" << path
                       << "'" << sync_endl;
-        }
-    }
-
-    std::ofstream out(path, std::ios::binary);
-    if (!out)
-    {
-        sync_cout << "info string Could not open " << path << " for writing" << sync_endl;
-        return;
+            compressed = true;
+        } else if (ext == ".ccz")
+            compressed = true;
     }
 
     const std::string sig = "SugaR Experience version 2";
-    out.write(sig.c_str(), sig.size());
+    std::string        buffer;
+    buffer.append(sig);
 
     std::size_t totalMoves = 0;
     for (const auto& [key, vec] : table)
-        for (const auto& e : vec)
-        {
+        for (const auto& e : vec) {
             struct BinV2 {
                 uint64_t key;
                 uint32_t move;
@@ -232,9 +234,30 @@ void Experience::save(const std::string& file) const {
                  e.depth,
                  static_cast<uint16_t>(std::min(e.count, 0xFFFF)),
                  {0, 0}};
-            out.write(reinterpret_cast<const char*>(&be), sizeof(be));
+            buffer.append(reinterpret_cast<const char*>(&be), sizeof(be));
             totalMoves++;
         }
+
+    bool ok = false;
+    if (compressed) {
+        gzFile out = gzopen(path.c_str(), "wb9");
+        if (out) {
+            if (gzwrite(out, buffer.data(), buffer.size()) == (int)buffer.size())
+                ok = true;
+            gzclose(out);
+        }
+    } else {
+        std::ofstream out(path, std::ios::binary);
+        if (out) {
+            out.write(buffer.data(), buffer.size());
+            ok = bool(out);
+        }
+    }
+
+    if (!ok) {
+        sync_cout << "info string Could not open " << path << " for writing" << sync_endl;
+        return;
+    }
 
     std::size_t totalPositions = table.size();
 


### PR DESCRIPTION
## Summary
- compress and load experience files in CCZ format using zlib
- switch default experience file to `revolution.ccz`
- link zlib and document new compressed experience file

## Testing
- `cd src && make build -j2`

------
https://chatgpt.com/codex/tasks/task_e_68b60c4d6ef8832792ca7137af593852