### PR TITLE
Support BrainLearn .exp experience files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,16 @@ previous games. Rather than forcing book moves, the cached information biases ro
 ordering during search. The following UCI options control this system:
 
 - `Experience Enabled`: enables or disables the experience feature (default `true`).
-- `Experience File`: name of the file where the experience data is stored (default `revolution.ccz`; legacy `.bin` files are converted automatically and saved in compressed form).
+- `Experience File`: name of the file where the experience data is stored (default `experience.exp`; legacy `.bin` files are converted automatically to this format).
 - `Experience Readonly`: if `true`, no changes are written to the file.
 - `Experience Prior`: uses stored experience to bias root move ordering.
 - `Experience Width`: number of principal moves to consider (1–20).
 - `Experience Eval Weight`: weighting of evaluation when ordering moves (0–10).
 - `Experience Min Depth`: minimum depth required to store a move (4–64).
 - `Experience Max Moves`: maximum number of moves saved per position (1–100).
+- `Experience Book`: if `true`, use the experience file as an opening book.
+- `Experience Book Max Moves`: limit of moves considered when using the experience book (1–100, default 100).
+- `Experience Book Min Depth`: minimum depth required for a move to be used from the experience book (1–255, default 4).
 
 The file is loaded at engine startup and updated after each game if `Experience Readonly` is disabled.
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -172,7 +172,7 @@ Engine::Engine(std::optional<std::string> path) :
                     return std::nullopt;
                 }));
 
-    options.add("Experience File", Option("revolution.ccz", [this](const Option& o) {
+    options.add("Experience File", Option("experience.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load_async(o);
                     concurrentExperienceFile.clear();

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -34,7 +34,7 @@ void Experience::clear() {
 }
 
 void Experience::load(const std::string& file) {
-    std::string path = file;
+    std::string path       = file;
     bool        convertBin = false;
     bool        compressed = false;
     std::string display;
@@ -46,11 +46,14 @@ void Experience::load(const std::string& file) {
 
         if (ext == ".bin") {
             convertBin = true;
-            path       = path.substr(0, path.size() - 4) + ".ccz";
+            path       = path.substr(0, path.size() - 4) + ".exp";
             sync_cout << "info string '.bin' experience files are deprecated; converting to '"
                       << path << "'" << sync_endl;
         } else if (ext == ".ccz")
             compressed = true;
+        else if (ext == ".exp") {
+            // Default uncompressed experience format
+        }
     }
 
     display = path;
@@ -197,7 +200,7 @@ void Experience::load_async(const std::string& file) {
 
 void Experience::save(const std::string& file) const {
     wait_until_loaded();
-    std::string path = file;
+    std::string path       = file;
     bool        compressed = false;
 
     if (path.size() >= 4) {
@@ -206,12 +209,14 @@ void Experience::save(const std::string& file) const {
                        [](unsigned char c) { return char(std::tolower(c)); });
 
         if (ext == ".bin") {
-            path = path.substr(0, path.size() - 4) + ".ccz";
+            path = path.substr(0, path.size() - 4) + ".exp";
             sync_cout << "info string '.bin' experience files are deprecated; saving to '" << path
                       << "'" << sync_endl;
-            compressed = true;
         } else if (ext == ".ccz")
             compressed = true;
+        else if (ext == ".exp") {
+            // Default uncompressed experience format
+        }
     }
 
     const std::string sig = "SugaR Experience version 2";


### PR DESCRIPTION
## Summary
- Default the experience file to `experience.exp` for BrainLearn compatibility.
- Recognize the `.exp` extension when loading or saving experience data and convert legacy `.bin` files automatically.
- Document new experience-book options and updated experience file format.

## Testing
- `make build ARCH=x86-64`


------
https://chatgpt.com/codex/tasks/task_e_68b612dbc1f48327b50eea29ff53ef84