### PR TITLE
Update engine version to v1.2 with automatic build date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2] - 2025-09-03
+### Changed
+- Updated engine name to "revolution dev v1.2" and automated build date handling.
+
 ## [1.0.1] - 2025-09-01
 ### Added
 - UCI option `Minimum Thinking Time` to enforce a minimum search duration per move.

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_dev_010925_v1.0.1.exe
+        EXE = revolution_dev_$(ENGINE_BUILD_DATE)_v1.2.exe
 else
-        EXE = revolution_dev_010925_v1.0.1
+        EXE = revolution_dev_$(ENGINE_BUILD_DATE)_v1.2
 endif
 
 ### Installation dir definitions
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution dev 010925 v1.0.1"
-#   - ENGINE_BUILD_DATE: optional build identifier
+#   - ENGINE_NAME: "revolution dev v1.2"
+#   - ENGINE_BUILD_DATE: optional build identifier (defaults to today's date in DDMMYY format)
 # You can override on the command line:
-#   make ENGINE_NAME="revolution dev 010925 v1.0.1" ENGINE_BUILD_DATE=20250901
-ENGINE_NAME        ?= revolution dev 010925 v1.0.1
-ENGINE_BUILD_DATE  ?= $(shell date +%Y-%m-%d)
+#   make ENGINE_NAME="revolution dev v1.2" ENGINE_BUILD_DATE=030925
+ENGINE_NAME        ?= revolution dev v1.2
+ENGINE_BUILD_DATE  ?= $(shell date +%d%m%y)
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,8 +30,8 @@
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution dev 010925 v1.0.1\""
-    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
+    // override at build time with:  -DENGINE_NAME="\"revolution dev v1.2\""
+    #define ENGINE_NAME "revolution dev v1.2"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
+    #define ENGINE_NAME "revolution dev v1.2"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev 010925 v1.0.1"
+    #define ENGINE_NAME "revolution dev v1.2"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE __DATE__

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution dev 010925 v1.0.1"
+#define ENGINE_NAME "revolution dev v1.2"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- bump engine name to `revolution dev v1.2`
- append automatic build date from makefile to UCI id and binary name
- add changelog entry for v1.2

## Testing
- `make -C src build`


------
https://chatgpt.com/codex/tasks/task_e_68b8330bee24832781938492f662a218