### PR TITLE
Bump engine version to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0] - 2025-09-04
+### Changed
+- Renamed engine to Revolution 2.0 with build date 040925 for GUI identification.
+
 ## [1.0] - 2025-08-27
 ### Added
 - Initial public release of Revolution v1.0.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revolution Chess Engine
 
-**Version 1.0**
+**Version 2.0**
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 1.0"
-#   - ENGINE_BUILD_DATE: system date in ddmmyy format
+#   - ENGINE_NAME: "Revolution 2.0"
+#   - ENGINE_BUILD_DATE: 040925 (ddmmyy format)
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 1.0.2 beta" ENGINE_BUILD_DATE=251001
-ENGINE_NAME        ?= Revolution 1.0
-ENGINE_BUILD_DATE  ?= $(shell date +%d%m%y)
+#   make ENGINE_NAME="Revolution 2.0 beta" ENGINE_BUILD_DATE=040925
+ENGINE_NAME        ?= Revolution 2.0
+ENGINE_BUILD_DATE  ?= 040925
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,3 +1,6 @@
+Revolution 2.0 040925
+- Renamed engine to Revolution 2.0 with build date 040925.
+
 Revolution 1.0 dev 250827
 - Initial fork from Stockfish.
 - Updated engine name and build system.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // yymmdd; override at build time with:  -DENGINE_BUILD_DATE=250827
-    #define ENGINE_BUILD_DATE "250827"
+    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040925
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 1.0\""
-    #define ENGINE_NAME "Revolution 1.0"
+    // override at build time with:  -DENGINE_NAME="\"Revolution 2.0\""
+    #define ENGINE_NAME "Revolution 2.0"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "250827"
+    #define ENGINE_BUILD_DATE "040925"
 #endif
 
 namespace Stockfish {
@@ -119,7 +119,7 @@ class Logger {
 
 
 // Returns the full name of the current Revolution version.
-std::string engine_version_info() { return std::string("Revolution 1.0 ") + version.data(); }
+std::string engine_version_info() { return std::string("Revolution 2.0 ") + version.data(); }
 
 // Update author information
 std::string engine_info(bool to_uci) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -143,7 +143,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0 <date>"
+            // Force a stable, explicit UCI name so GUIs show "Revolution 2.0 <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 1.0"
+#define ENGINE_NAME "Revolution 2.0"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "000000"  // ddmmyy; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "040925"  // ddmmyy; overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- rename engine to "Revolution 2.0" and set build date 040925
- update documentation and changelog for 2.0 release

## Testing
- `make -C src build`
- `printf "uci\nquit\n" | ./src/revolution | head -n 20`
- `bash tests/perft.sh ./src/revolution` *(fails: /usr/bin/expect not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c461d68c832793d260041863754c