### PR TITLE
Bump engine to Revolution 2.0.1 dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.0.1-dev] - 2025-08-04
+### Changed
+- Bump engine version to Revolution 2.0.1 dev with build date 040825.
+
 ## [2.0] - 2025-09-04
 ### Changed
 - Renamed engine to Revolution 2.0 with build date 040925 for GUI identification.

--- a/sparsehash/README.md
+++ b/sparsehash/README.md
@@ -1,0 +1,1 @@
+Placeholder for sparsehash integration

--- a/src/Makefile
+++ b/src/Makefile
@@ -842,12 +842,12 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Revolution 2.0"
-#   - ENGINE_BUILD_DATE: 040925 (ddmmyy format)
+#   - ENGINE_NAME: "Revolution 2.0.1 dev"
+#   - ENGINE_BUILD_DATE: 040825 (ddmmyy format)
 # You can override on the command line:
-#   make ENGINE_NAME="Revolution 2.0 beta" ENGINE_BUILD_DATE=040925
-ENGINE_NAME        ?= Revolution 2.0
-ENGINE_BUILD_DATE  ?= 040925
+#   make ENGINE_NAME="Revolution 2.0.1 dev" ENGINE_BUILD_DATE=040825
+ENGINE_NAME        ?= Revolution 2.0.1 dev
+ENGINE_BUILD_DATE  ?= 040825
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
 ### 3.9 Link Time Optimization

--- a/src/README_CHANGELOG.txt
+++ b/src/README_CHANGELOG.txt
@@ -1,3 +1,6 @@
+Revolution 2.0.1 dev 040825
+- Updated engine version to 2.0.1 dev with build date 040825.
+
 Revolution 2.0 040925
 - Renamed engine to Revolution 2.0 with build date 040925.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,13 +25,13 @@
 #include "position.h"
 
 #ifndef ENGINE_BUILD_DATE
-    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040925
-    #define ENGINE_BUILD_DATE "040925"
+    // ddmmyy; override at build time with:  -DENGINE_BUILD_DATE=040825
+    #define ENGINE_BUILD_DATE "040825"
 #endif
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 2.0\""
-    #define ENGINE_NAME "Revolution 2.0"
+    // override at build time with:  -DENGINE_NAME="\"Revolution 2.0.1 dev\""
+    #define ENGINE_NAME "Revolution 2.0.1 dev"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,10 @@
 
 #include "types.h"
 #ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE "040925"
+    #define ENGINE_BUILD_DATE "040825"
+#endif
+#ifndef ENGINE_NAME
+    #define ENGINE_NAME "Revolution 2.0.1 dev"
 #endif
 
 namespace Stockfish {
@@ -119,7 +122,7 @@ class Logger {
 
 
 // Returns the full name of the current Revolution version.
-std::string engine_version_info() { return std::string("Revolution 2.0 ") + version.data(); }
+std::string engine_version_info() { return std::string(ENGINE_NAME " ") + version.data(); }
 
 // Update author information
 std::string engine_info(bool to_uci) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -143,7 +143,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 2.0 <date>"
+            // Force a stable, explicit UCI name so GUIs show "Revolution 2.0.1 dev <date>"
             sync_cout << "id name " << ENGINE_NAME << ' ' << ENGINE_BUILD_DATE << "\n"
                 << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)" << "\n"
                 << engine.get_options() << sync_endl;

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "Revolution 2.0"
+#define ENGINE_NAME "Revolution 2.0.1 dev"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE "040925"  // ddmmyy; overridden by Makefile if provided
+#define ENGINE_BUILD_DATE "040825"  // ddmmyy; overridden by Makefile if provided
 #endif
 
 


### PR DESCRIPTION
## Summary
- add placeholder sparsehash folder for future hashing work
- bump default ENGINE_NAME and build date to 2.0.1 dev 040825
- record new version in changelog and misc utilities

## Testing
- `make -C src build ARCH=x86-64`
- `bash tests/perft.sh src/revolution` *(fails: exit code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68b935053f048327a3924f8e3c66e8e9