### PR TITLE
Add Falcon network option and document minimum thinking time

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ ordering during search. The following UCI options control this system:
 
 The file is loaded at engine startup and updated after each game if `Experience Readonly` is disabled.
 
+## UCI Options
+
+### Minimum Thinking Time
+
+The `Minimum Thinking Time` option ensures the engine spends at least a
+specified number of milliseconds searching for a move, even if it finds
+a good one instantly. This avoids extremely fast, low-quality replies.
+Set it with:
+
+```
+setoption name Minimum Thinking Time value <milliseconds>
+```
+
+### Falcon Net
+
+Revolution can switch to an alternative neural network using the
+`FalconFile` option. To load the bundled `3.net` file, send:
+
+```
+setoption name FalconFile value 3.net
+```
+
 ## License
 
 Revolution is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -215,6 +215,12 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
+    options.add(  //
+      "FalconFile", Option("3.net", [this](const Option& o) {
+          load_big_network(o);
+          return std::nullopt;
+      }));
+
     load_networks();
     resize_threads();
 }


### PR DESCRIPTION
## Summary
- introduce `FalconFile` UCI option to load an alternate neural network like `3.net`
- add README section explaining `Minimum Thinking Time` and how to set `FalconFile`

## Testing
- `make -C src build ARCH=x86-64`

------
https://chatgpt.com/codex/tasks/task_e_68b9f33855c88327b2ef50e4863c2521