### PR TITLE
Avoid zero-bonus correction history work

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -98,6 +98,9 @@ void update_correction_history(const Position& pos,
                                Stack* const    ss,
                                Search::Worker& workerThread,
                                const int       bonus) {
+    if (bonus == 0)
+        return;
+
     const Move  m  = (ss - 1)->currentMove;
     const Color us = pos.side_to_move();
 


### PR DESCRIPTION
## Summary
- Skip correction history updates when bonus is zero to reduce overhead in search

## Testing
- `bash tests/signature.sh`
- `bash tests/perft.sh ./stockfish`

------
https://chatgpt.com/codex/tasks/task_e_68bb48ec3b388327922d3450fb70634c