### PR TITLE
Track state index in Position state history

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -202,7 +202,10 @@ Position& Position::set(const string& fenStr, bool isChess960, StateInfo* si) {
 
     std::memset(this, 0, sizeof(Position));
     std::memset(si, 0, sizeof(StateInfo));
-    st = si;
+    st              = si;
+    stateIndex      = 0;
+    si->previous    = nullptr;
+    si->previousIndex = -1;
 
     ss >> std::noskipws;
 
@@ -701,8 +704,10 @@ DirtyPiece Position::do_move(Move                      m,
     // ones which are going to be recalculated from scratch anyway and then switch
     // our state pointer to point to the new (ready to be updated) state.
     std::memcpy(&newSt, st, offsetof(StateInfo, key));
-    newSt.previous = st;
-    st             = &newSt;
+    newSt.previous      = st;
+    newSt.previousIndex = stateIndex;
+    st                  = &newSt;
+    ++stateIndex;
 
     // Increment ply counters. In particular, rule50 will be reset to zero later on
     // in case of a capture or a pawn move.
@@ -1012,6 +1017,7 @@ void Position::undo_move(Move m) {
 
     // Finally point our state pointer back to the previous state
     st = st->previous;
+    --stateIndex;
     --gamePly;
 
     assert(pos_is_ok());
@@ -1058,8 +1064,10 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
 
     std::memcpy(&newSt, st, sizeof(StateInfo));
 
-    newSt.previous = st;
-    st             = &newSt;
+    newSt.previous      = st;
+    newSt.previousIndex = stateIndex;
+    st                  = &newSt;
+    ++stateIndex;
 
     if (st->epSquare != SQ_NONE)
     {
@@ -1088,6 +1096,7 @@ void Position::undo_null_move() {
     assert(!checkers());
 
     st         = st->previous;
+    --stateIndex;
     sideToMove = ~sideToMove;
 }
 

--- a/src/position.h
+++ b/src/position.h
@@ -53,6 +53,7 @@ struct StateInfo {
     Key        key;
     Bitboard   checkersBB;
     StateInfo* previous;
+    int        previousIndex;
     Bitboard   blockersForKing[COLOR_NB];
     Bitboard   pinners[COLOR_NB];
     Bitboard   checkSquares[PIECE_TYPE_NB];
@@ -195,6 +196,7 @@ class Position {
     Square     castlingRookSquare[CASTLING_RIGHT_NB];
     Bitboard   castlingPath[CASTLING_RIGHT_NB];
     StateInfo* st;
+    int        stateIndex;
     int        gamePly;
     Color      sideToMove;
     bool       chess960;


### PR DESCRIPTION
## Summary
- Extend StateInfo with a `previousIndex` field
- Track a running `stateIndex` inside Position
- Keep the indices updated in set/do_move/undo_move and null-move helpers

## Testing
- `make -j2 build ARCH=x86-64`
- `python3 tests/instrumented.py --none src/revolution_dev_010925_v1.0.1` *(fails: KeyboardInterrupt during TestInteractive)*

------
https://chatgpt.com/codex/tasks/task_e_68bbaa29c774832788256237a77b43ca