### PR TITLE
Refactor transposition table to vector with memory pooling

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <new>
 #include <type_traits>
@@ -209,6 +210,37 @@ T* align_ptr_up(T* ptr) {
     const uintptr_t ptrint = reinterpret_cast<uintptr_t>(reinterpret_cast<char*>(ptr));
     return reinterpret_cast<T*>(
       reinterpret_cast<char*>((ptrint + (Alignment - 1)) / Alignment * Alignment));
+}
+
+// Simple allocator backed by aligned large pages. This can be used with
+// standard containers such as std::vector to provide a pool-like behaviour
+// while retaining proper alignment guarantees.
+template<typename T>
+struct LargePageAllocator {
+    using value_type = T;
+
+    LargePageAllocator() noexcept {}
+    template<class U>
+    LargePageAllocator(const LargePageAllocator<U>&) noexcept {}
+
+    T* allocate(std::size_t n) {
+        void* ptr = aligned_large_pages_alloc(n * sizeof(T));
+        if (!ptr)
+            std::abort();
+        return static_cast<T*>(ptr);
+    }
+
+    void deallocate(T* p, std::size_t) noexcept { aligned_large_pages_free(p); }
+};
+
+template<class T, class U>
+bool operator==(const LargePageAllocator<T>&, const LargePageAllocator<U>&) {
+    return true;
+}
+
+template<class T, class U>
+bool operator!=(const LargePageAllocator<T>&, const LargePageAllocator<U>&) {
+    return false;
 }
 
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -46,30 +46,11 @@ namespace Stockfish {
 // These fields are in the same order as accessed by TT::probe(), since memory is fastest sequentially.
 // Equally, the store order in save() matches this order.
 
-struct TTEntry {
-
-    // Convert internal bitfields to external types
-    TTData read() const {
-        return TTData{Move(move16),           Value(value16),
-                      Value(eval16),          Depth(depth8 + DEPTH_ENTRY_OFFSET),
-                      Bound(genBound8 & 0x3), bool(genBound8 & 0x4)};
-    }
-
-    bool is_occupied() const;
-    void save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
-    // The returned age is a multiple of TranspositionTable::GENERATION_DELTA
-    uint8_t relative_age(const uint8_t generation8) const;
-
-   private:
-    friend class TranspositionTable;
-
-    uint16_t key16;
-    uint8_t  depth8;
-    uint8_t  genBound8;
-    Move     move16;
-    int16_t  value16;
-    int16_t  eval16;
-};
+TTData TTEntry::read() const {
+    return TTData{Move(move16),           Value(value16),
+                  Value(eval16),          Depth(depth8 + DEPTH_ENTRY_OFFSET),
+                  Bound(genBound8 & 0x3), bool(genBound8 & 0x4)};
+}
 
 // `genBound8` is where most of the details are. We use the following constants to manipulate 5 leading generation bits
 // and 3 trailing miscellaneous bits.
@@ -125,45 +106,23 @@ uint8_t TTEntry::relative_age(const uint8_t generation8) const {
 }
 
 
-// TTWriter is but a very thin wrapper around the pointer
-TTWriter::TTWriter(TTEntry* tte) :
-    entry(tte) {}
+// TTWriter refers to an entry by index instead of pointer to avoid raw pointers
+TTWriter::TTWriter(TranspositionTable* t, size_t cIdx, int eIdx) :
+    tt(t), clusterIndex(cIdx), entryIndex(eIdx) {}
 
 void TTWriter::write(
   Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8) {
-    entry->save(k, v, pv, b, d, m, ev, generation8);
+    tt->table[clusterIndex].entry[entryIndex].save(k, v, pv, b, d, m, ev, generation8);
 }
-
-
-// A TranspositionTable is an array of Cluster, of size clusterCount. Each cluster consists of ClusterSize number
-// of TTEntry. Each non-empty TTEntry contains information on exactly one position. The size of a Cluster should
-// divide the size of a cache line for best performance, as the cacheline is prefetched when possible.
-
-static constexpr int ClusterSize = 3;
-
-struct Cluster {
-    TTEntry entry[ClusterSize];
-    char    padding[2];  // Pad to 32 bytes
-};
-
-static_assert(sizeof(Cluster) == 32, "Suboptimal Cluster size");
 
 
 // Sets the size of the transposition table,
 // measured in megabytes. Transposition table consists
 // of clusters and each cluster consists of ClusterSize number of TTEntry.
 void TranspositionTable::resize(size_t mbSize, ThreadPool& threads) {
-    aligned_large_pages_free(table);
-
     clusterCount = mbSize * 1024 * 1024 / sizeof(Cluster);
-
-    table = static_cast<Cluster*>(aligned_large_pages_alloc(clusterCount * sizeof(Cluster)));
-
-    if (!table)
-    {
-        std::cerr << "Failed to allocate " << mbSize << "MB for transposition table." << std::endl;
-        exit(EXIT_FAILURE);
-    }
+    table.clear();
+    table.resize(clusterCount);
 
     clear(threads);
 }
@@ -183,7 +142,7 @@ void TranspositionTable::clear(ThreadPool& threads) {
             const size_t start  = stride * i;
             const size_t len    = i + 1 != threadCount ? stride : clusterCount - start;
 
-            std::memset(&table[start], 0, len * sizeof(Cluster));
+            std::memset(table.data() + start, 0, len * sizeof(Cluster));
         });
     }
 
@@ -224,25 +183,32 @@ uint8_t TranspositionTable::generation() const { return generation8; }
 // TTEntry t2 if its replace value is greater than that of t2.
 std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) const {
 
-    TTEntry* const tte   = first_entry(key);
-    const uint16_t key16 = uint16_t(key);  // Use the low 16 bits as key inside the cluster
+    const size_t  clusterIndex = mul_hi64(key, clusterCount);
+    TTEntry*      const tte    = table[clusterIndex].entry;
+    const uint16_t key16       = uint16_t(key);  // Use the low 16 bits as key inside the cluster
 
     for (int i = 0; i < ClusterSize; ++i)
         if (tte[i].key16 == key16)
             // This gap is the main place for read races.
             // After `read()` completes that copy is final, but may be self-inconsistent.
-            return {tte[i].is_occupied(), tte[i].read(), TTWriter(&tte[i])};
+            return {tte[i].is_occupied(),
+                    tte[i].read(),
+                    TTWriter(const_cast<TranspositionTable*>(this), clusterIndex, i)};
 
     // Find an entry to be replaced according to the replacement strategy
-    TTEntry* replace = tte;
+    int      replaceIdx = 0;
+    TTEntry* replace    = tte;
     for (int i = 1; i < ClusterSize; ++i)
         if (replace->depth8 - replace->relative_age(generation8)
             > tte[i].depth8 - tte[i].relative_age(generation8))
-            replace = &tte[i];
+        {
+            replace    = &tte[i];
+            replaceIdx = i;
+        }
 
     return {false,
             TTData{Move::none(), VALUE_NONE, VALUE_NONE, DEPTH_ENTRY_OFFSET, BOUND_NONE, false},
-            TTWriter(replace)};
+            TTWriter(const_cast<TranspositionTable*>(this), clusterIndex, replaceIdx)};
 }
 
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <tuple>
+#include <vector>
 
 #include "memory.h"
 #include "types.h"
@@ -31,6 +32,7 @@ namespace Stockfish {
 class ThreadPool;
 struct TTEntry;
 struct Cluster;
+class TranspositionTable;
 
 // There is only one global hash table for the engine and all its threads. For chess in particular, we even allow racy
 // updates between threads to and from the TT, as taking the time to synchronize access would cost thinking time and
@@ -67,22 +69,49 @@ struct TTData {
 
 
 // This is used to make racy writes to the global TT.
+// TTEntry struct is the 10 bytes transposition table entry.
+struct TTEntry {
+    TTData   read() const;
+    bool     is_occupied() const;
+    void     save(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
+    uint8_t  relative_age(const uint8_t generation8) const;
+
+   private:
+    friend class TranspositionTable;
+    uint16_t key16;
+    uint8_t  depth8;
+    uint8_t  genBound8;
+    Move     move16;
+    int16_t  value16;
+    int16_t  eval16;
+};
+
+// A TranspositionTable is an array of Cluster, of size clusterCount. Each cluster consists of ClusterSize TTEntry.
+static constexpr int ClusterSize = 3;
+
+struct Cluster {
+    TTEntry entry[ClusterSize];
+    char    padding[2];  // Pad to 32 bytes
+};
+
+static_assert(sizeof(Cluster) == 32, "Suboptimal Cluster size");
+
 struct TTWriter {
    public:
     void write(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
 
    private:
     friend class TranspositionTable;
-    TTEntry* entry;
-    TTWriter(TTEntry* tte);
+    TranspositionTable* tt;
+    size_t clusterIndex;
+    int    entryIndex;
+    TTWriter(TranspositionTable* t, size_t cIdx, int eIdx);
 };
 
 
 class TranspositionTable {
 
    public:
-    ~TranspositionTable() { aligned_large_pages_free(table); }
-
     void resize(size_t mbSize, ThreadPool& threads);  // Set TT size
     void clear(ThreadPool& threads);                  // Re-initialize memory, multithreaded
     int  hashfull(int maxAge = 0)
@@ -98,9 +127,10 @@ class TranspositionTable {
 
    private:
     friend struct TTEntry;
+    friend struct TTWriter;
 
-    size_t   clusterCount;
-    Cluster* table = nullptr;
+    size_t clusterCount = 0;
+    mutable std::vector<Cluster, LargePageAllocator<Cluster>> table;
 
     uint8_t generation8 = 0;  // Size must be not bigger than TTEntry::genBound8
 };


### PR DESCRIPTION
## Summary
- Implement `LargePageAllocator` for page-aligned memory pools
- Replace raw TT table pointer with `std::vector` and index-based TTWriter

## Testing
- `make build ARCH=x86-64-modern`

------
https://chatgpt.com/codex/tasks/task_e_68bbaca8018c8327a170ed2e53ce7794