### PR TITLE
Release revolution 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.20] - 2025-09-06
+### Changed
+- Updated engine identifier to "revolution 1.20 060925 avx" for official release.
+
 ## [1.0.1] - 2025-09-01
 ### Added
 - UCI option `Minimum Thinking Time` to enforce a minimum search duration per move.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revolution Chess Engine
 
-**Version 1.0**
+**Version 1.20**
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_dev_010925_v1.0.1.exe
+        EXE = revolution_060925_v1.20.exe
 else
-        EXE = revolution_dev_010925_v1.0.1
+        EXE = revolution_060925_v1.20
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution dev-1.0.1 050925 avx"
+#   - ENGINE_NAME: "revolution 1.20 060925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution dev-1.0.1 050925 avx" ENGINE_BUILD_DATE=20250901
-ENGINE_NAME        ?= revolution dev-1.0.1 050925 avx
+#   make ENGINE_NAME="revolution 1.20 060925 avx" ENGINE_BUILD_DATE=20250906
+ENGINE_NAME        ?= revolution 1.20 060925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution dev-1.0.1 050925 avx\""
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    // override at build time with:  -DENGINE_NAME="\"revolution 1.20 060925 avx\""
+    #define ENGINE_NAME "revolution 1.20 060925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    #define ENGINE_NAME "revolution 1.20 060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+    #define ENGINE_NAME "revolution 1.20 060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution dev-1.0.1 050925 avx"
+#define ENGINE_NAME "revolution 1.20 060925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
 #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- set UCI engine identifier to `revolution 1.20 060925 avx`
- update executable name and documentation for the 1.20 release
- note the new official engine id in the changelog

## Testing
- `bash tests/perft.sh` *(fails: exit code 127)*
- `make -C src -j2 build ARCH=x86-64` *(fails: benchmark.o: file not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb58208988327ab0906ffeabaf82b