### PR TITLE
Improve pruning safety and history updates

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -731,6 +731,7 @@ Value Search::Worker::search(
     excludedMove                   = ss->excludedMove;
     posKey                         = pos.key();
     auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+    assert(!ttHit || ttData.key16 == uint16_t(posKey));
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
     ttData.move  = rootNode ? rootMoves[pvIdx].pv[0] : ttHit ? ttData.move : Move::none();
@@ -770,6 +771,7 @@ Value Search::Worker::search(
                 pos.do_move(ttData.move, st);
                 Key nextPosKey                             = pos.key();
                 auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
+                assert(!ttHitNext || ttDataNext.key16 == uint16_t(nextPosKey));
                 pos.undo_move(ttData.move);
 
                 // Check that the ttValue after the tt move would also trigger a cutoff
@@ -923,12 +925,13 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search
     if (cutNode && ss->staticEval >= beta - 19 * depth + 403 && !excludedMove
-        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && !is_loss(beta))
+        && (pos.non_pawn_material(us) >= RookValue || pos.count<PAWN>(us) > 2)
+        && ss->ply >= nmpMinPly && !is_loss(beta))
     {
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        Depth R = 3 + depth / 4;
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
@@ -1081,7 +1084,9 @@ moves_loop:  // When in check, search starts here
 
         int delta = beta - alpha;
 
-        Depth r = reduction(improving, depth, moveCount, delta);
+        Depth r = (moveCount > 1 && depth >= 3)
+                    ? reduction(improving, depth, moveCount, delta)
+                    : Depth(0);
 
         // Increase reduction for ttPv nodes (*Scaler)
         // Smaller or even negative value is better for short time controls
@@ -1444,9 +1449,8 @@ moves_loop:  // When in check, search starts here
     if (!moveCount)
         bestValue = excludedMove ? alpha : ss->inCheck ? mated_in(ss->ply) : VALUE_DRAW;
 
-    // If there is a move that produces search value greater than alpha,
-    // we update the stats of searched moves.
-    else if (bestMove)
+    // Only update stats if a real beta cutoff occurred
+    else if (bestMove && bestValue >= beta)
     {
         update_all_stats(pos, ss, *this, bestMove, prevSq, quietsSearched, capturesSearched, depth,
                          ttData.move, moveCount);
@@ -2229,7 +2233,9 @@ bool RootMove::extract_ponder_from_tt(const TranspositionTable& tt, Position& po
 
     pos.do_move(pv[0], st, &tt);
 
-    auto [ttHit, ttData, ttWriter] = tt.probe(pos.key());
+    Key verifyKey;
+    auto [ttHit, ttData, ttWriter] = tt.probe(verifyKey = pos.key());
+    assert(!ttHit || ttData.key16 == uint16_t(verifyKey));
     if (ttHit)
     {
         if (MoveList<LEGAL>(pos).contains(ttData.move))

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -47,9 +47,9 @@ namespace Stockfish {
 // Equally, the store order in save() matches this order.
 
 TTData TTEntry::read() const {
-    return TTData{Move(move16),           Value(value16),
-                  Value(eval16),          Depth(depth8 + DEPTH_ENTRY_OFFSET),
-                  Bound(genBound8 & 0x3), bool(genBound8 & 0x4)};
+    return TTData{Move(move16),           Value(value16),          Value(eval16),
+                  Depth(depth8 + DEPTH_ENTRY_OFFSET),
+                  Bound(genBound8 & 0x3), bool(genBound8 & 0x4), key16};
 }
 
 // `genBound8` is where most of the details are. We use the following constants to manipulate 5 leading generation bits
@@ -207,7 +207,7 @@ std::tuple<bool, TTData, TTWriter> TranspositionTable::probe(const Key key) cons
         }
 
     return {false,
-            TTData{Move::none(), VALUE_NONE, VALUE_NONE, DEPTH_ENTRY_OFFSET, BOUND_NONE, false},
+            TTData{Move::none(), VALUE_NONE, VALUE_NONE, DEPTH_ENTRY_OFFSET, BOUND_NONE, false, 0},
             TTWriter(const_cast<TranspositionTable*>(this), clusterIndex, replaceIdx)};
 }
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -53,17 +53,19 @@ struct TTData {
     Depth depth;
     Bound bound;
     bool  is_pv;
+    uint16_t key16;
 
     TTData() = delete;
 
     // clang-format off
-    TTData(Move m, Value v, Value ev, Depth d, Bound b, bool pv) :
+    TTData(Move m, Value v, Value ev, Depth d, Bound b, bool pv, uint16_t k) :
         move(m),
         value(v),
         eval(ev),
         depth(d),
         bound(b),
-        is_pv(pv) {};
+        is_pv(pv),
+        key16(k) {};
     // clang-format on
 };
 


### PR DESCRIPTION
## Summary
- Record low bits of hash keys in TT entries and assert they match during probes
- Restrict null-move pruning in low-material endgames and soften its depth reduction
- Apply late move reduction only for lower-priority moves at sufficient depth
- Update history tables only after true beta cutoffs

## Testing
- `make build ARCH=x86-64 -j2`
- `bash tests/perft.sh ./src/revolution_060925_v1.20` *(fails: expect: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf5cdbd0c8327b643848653057ed7