### PR TITLE
Rename engine to revolution v.1.2.0 dev-070925

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0-dev] - 2025-09-07
+### Changed
+- Updated engine identifier to "revolution v.1.2.0 dev- 070925".
+
 ## [1.20] - 2025-09-06
 ### Changed
 - Updated engine identifier to "revolution 1.20 060925 avx" for official release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revolution Chess Engine
 
-**Version 1.20**
+**Version v1.2.0 dev-070925**
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_060925_v1.20.exe
+        EXE = revolution_070925_v1.2.0.exe
 else
-        EXE = revolution_060925_v1.20
+        EXE = revolution_070925_v1.2.0
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution 1.20 060925 avx"
+#   - ENGINE_NAME: "revolution v.1.2.0 dev- 070925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution 1.20 060925 avx" ENGINE_BUILD_DATE=20250906
-ENGINE_NAME        ?= revolution 1.20 060925 avx
+#   make ENGINE_NAME="revolution v.1.2.0 dev- 070925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= revolution v.1.2.0 dev- 070925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution 1.20 060925 avx\""
-    #define ENGINE_NAME "revolution 1.20 060925 avx"
+    // override at build time with:  -DENGINE_NAME="\"revolution v.1.2.0 dev- 070925\""
+    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 1.20 060925 avx"
+    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 1.20 060925 avx"
+    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -126,11 +126,11 @@ void UCIEngine::loop() {
         {
             // Force a stable, explicit UCI name so GUIs show "Revolution 1.0"
             sync_cout_start();
-            std::cout << "id name " << ENGINE_NAME
-                      << "\n"
-                      << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
-                      << "\n"
-                      << engine.get_options() << std::endl;
+            std::cout
+              << "id name " << ENGINE_NAME << "\n"
+              << "id author Jorge Ruiz Centelles and the Stockfish developers (see AUTHORS file)"
+              << "\n"
+              << engine.get_options() << std::endl;
             sync_cout_end();
 
             sync_cout << "uciok" << sync_endl;
@@ -168,9 +168,8 @@ void UCIEngine::loop() {
         else if (token == "eval")
             engine.trace_eval();
         else if (token == "showexp")
-            experience.show(engine.position(),
-                             (int) engine.get_options()["Experience Eval Weight"],
-                             (int) engine.get_options()["Experience Book Max Moves"]);
+            experience.show(engine.position(), (int) engine.get_options()["Experience Eval Weight"],
+                            (int) engine.get_options()["Experience Book Max Moves"]);
         else if (token == "compiler")
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,10 +21,10 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-#define ENGINE_NAME "revolution 1.20 060925 avx"
+    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
 #endif
 #ifndef ENGINE_BUILD_DATE
-#define ENGINE_BUILD_DATE ""  // build identifier
+    #define ENGINE_BUILD_DATE ""  // build identifier
 #endif
 
 


### PR DESCRIPTION
## Summary
- update engine identifier and version strings to `revolution v.1.2.0 dev- 070925`
- adjust Makefile defaults and executable names to new version
- document new version in README and changelog

## Testing
- `g++ -c src/uci.cpp -o /tmp/uci.o`
- `g++ -c src/main.cpp -o /tmp/main.o`
- `make -C src build` *(fails: tune.o: file not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf92cc5908327b59b4763e3fa941e