### PR TITLE
Retune pruning and bump engine version

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_070925_v1.2.0.exe
+        EXE = revolution_090925_v2.20_avx.exe
 else
-        EXE = revolution_070925_v1.2.0
+        EXE = revolution_090925_v2.20_avx
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution v.1.2.0 dev- 070925"
+#   - ENGINE_NAME: "Revolution-dev v.2.20 090925 avx"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution v.1.2.0 dev- 070925" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= revolution v.1.2.0 dev- 070925
+#   make ENGINE_NAME="Revolution-dev v.2.20 090925 avx" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= Revolution-dev v.2.20 090925 avx
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution v.1.2.0 dev- 070925\""
-    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
+    // override at build time with:  -DENGINE_NAME="\"Revolution-dev v.2.20 090925 avx\""
+    #define ENGINE_NAME "Revolution-dev v.2.20 090925 avx"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
+    #define ENGINE_NAME "Revolution-dev v.2.20 090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1150,9 +1150,10 @@ moves_loop:  // When in check, search starts here
 
                 lmrDepth += history / 3233;
 
-                Value baseFutility = (bestMove ? 46 : 230);
+                // Retuned futility pruning margins and depth scaling
+                Value baseFutility = (bestMove ? 52 : 215);
                 Value futilityValue =
-                  ss->staticEval + baseFutility + 131 * lmrDepth + 91 * (ss->staticEval > alpha);
+                  ss->staticEval + baseFutility + 125 * lmrDepth + 91 * (ss->staticEval > alpha);
 
                 // Futility pruning: parent node
                 // (*Scaler): Generally, more frequent futility pruning

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
+    #define ENGINE_NAME "Revolution-dev v.2.20 090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -124,7 +124,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 1.0"
+            // Force a stable, explicit UCI name so GUIs show "Revolution-dev v.2.20 090925 avx"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.1.2.0 dev- 070925"
+    #define ENGINE_NAME "Revolution-dev v.2.20 090925 avx"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""  // build identifier


### PR DESCRIPTION
## Summary
- adjust futility pruning margins and depth scaling
- rename engine to "Revolution-dev v.2.20 090925 avx"

## Testing
- `make build`
- `bash tests/perft.sh ./src/revolution_090925_v2.20_avx`


------
https://chatgpt.com/codex/tasks/task_e_68bff5ec4e708327b3ed6a4b7985391d