### PR TITLE
Refactor state management and parser allocations

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -57,7 +57,7 @@ int            MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
 Engine::Engine(std::optional<std::string> path) :
     binaryDirectory(path ? CommandLine::get_binary_directory(*path) : ""),
     numaContext(NumaConfig::from_system()),
-    states(new std::deque<StateInfo>(1)),
+    states(std::make_unique<std::deque<StateInfo>>(1)),
     threads(),
     networks(
       numaContext,
@@ -302,18 +302,17 @@ void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search
 
 void Engine::set_position(const std::string& fen, const std::vector<std::string>& moves) {
     // Drop the old state and create a new one
-    states = StateListPtr(new std::deque<StateInfo>(1));
-    pos.set(fen, options["UCI_Chess960"], &states->back());
+    states = std::make_unique<std::deque<StateInfo>>(moves.size() + 1);
+    pos.set(fen, options["UCI_Chess960"], &(*states)[0]);
 
-    for (const auto& move : moves)
+    for (size_t i = 0; i < moves.size(); ++i)
     {
-        auto m = UCIEngine::to_move(pos, move);
+        auto m = UCIEngine::to_move(pos, moves[i]);
 
         if (m == Move::none())
             break;
 
-        states->emplace_back();
-        pos.do_move(m, states->back());
+        pos.do_move(m, (*states)[i + 1]);
     }
 }
 
@@ -399,7 +398,7 @@ void Engine::save_network(const std::pair<std::optional<std::string>, std::strin
 // utility functions
 
 void Engine::trace_eval() const {
-    StateListPtr trace_states(new std::deque<StateInfo>(1));
+    StateListPtr trace_states = std::make_unique<std::deque<StateInfo>>(1);
     Position     p;
     p.set(pos.fen(), options["UCI_Chess960"], &trace_states->back());
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -89,6 +89,8 @@ inline std::vector<std::string_view> split(std::string_view s, std::string_view 
     if (s.empty())
         return res;
 
+    res.reserve(1 + s.size() / delimiter.size());
+
     size_t begin = 0;
     for (;;)
     {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -28,7 +28,7 @@
 #include <cstdlib>
 #include <initializer_list>
 #include <iostream>
-#include <list>
+#include <deque>
 #include <ratio>
 #include <string>
 #include <utility>
@@ -2035,7 +2035,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
                  > moveOverhead;
     };
 
-    std::list<StateInfo> sts;
+    std::deque<StateInfo> sts;
 
     // Step 0, do the rootMove, no correction allowed, as needed for MultiPV in TB.
     auto& stRoot = sts.emplace_back();

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -388,15 +388,14 @@ std::vector<size_t> ThreadPool::get_bound_thread_count_by_numa_node() const {
 
     if (!boundThreadToNumaNode.empty())
     {
-        NumaIndex highestNumaNode = 0;
+        counts.reserve(boundThreadToNumaNode.size());
         for (NumaIndex n : boundThreadToNumaNode)
-            if (n > highestNumaNode)
-                highestNumaNode = n;
+        {
+            if (n >= counts.size())
+                counts.resize(n + 1, 0);
 
-        counts.resize(highestNumaNode + 1, 0);
-
-        for (NumaIndex n : boundThreadToNumaNode)
-            counts[n] += 1;
+            ++counts[n];
+        }
     }
 
     return counts;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -508,10 +508,11 @@ void UCIEngine::position(std::istringstream& is) {
         return;
 
     std::vector<std::string> moves;
+    moves.reserve(32);
 
     while (is >> token)
     {
-        moves.push_back(token);
+        moves.emplace_back(std::move(token));
     }
 
     engine.set_position(fen, moves);


### PR DESCRIPTION
## Summary
- Use `std::make_unique` and sized `deque` for state lists to avoid manual `new` and reallocation
- Reserve and move-construct tokens in UCI move parsing to limit copies
- Streamline NUMA node thread counting and use cache-friendly containers
- Preallocate memory in utility `split`

## Testing
- `cd src && make build`


------
https://chatgpt.com/codex/tasks/task_e_68c044cb51ac83278863298f32ae290e