### PR TITLE
Update engine ID name to revolution-dev v.2.40 130925

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution_dev-120925_v2.30_avx.exe
+        EXE = revolution-dev_v2.40_130925.exe
 else
-        EXE = revolution_dev-120925_v2.30_avx
+        EXE = revolution-dev_v2.40_130925
 endif
 
 ### Installation dir definitions
@@ -862,11 +862,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution v.2.30 dev-120925 avx"
+#- ENGINE_NAME : "revolution-dev v.2.40 130925"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution v.2.30 dev-120925 avx" ENGINE_BUILD_DATE = 20250907
-ENGINE_NAME        ?= revolution v.2.30 dev-120925 avx
+#make ENGINE_NAME = "revolution-dev v.2.40 130925" ENGINE_BUILD_DATE = 20250913
+ENGINE_NAME        ?= revolution-dev v.2.40 130925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution v.2.30 dev-120925 avx"
+            // Force a stable, explicit UCI name so GUIs show "revolution-dev v.2.40 130925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.2.30 dev-120925 avx"
+    #define ENGINE_NAME "revolution-dev v.2.40 130925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- set default engine name to "revolution-dev v.2.40 130925" and expose it via UCI
- update build scripts and executable naming to match new version

## Testing
- `make build -j2`


------
https://chatgpt.com/codex/tasks/task_e_68c5607294ec8327b6357f052b1700b0