### PR TITLE
Track ttHit in child search stack

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -726,6 +726,7 @@ Value Search::Worker::search(
     (ss - 1)->reduction = 0;
     ss->statScore       = 0;
     (ss + 2)->cutoffCnt = 0;
+    (ss + 1)->ttHit     = false;
 
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
@@ -774,6 +775,8 @@ Value Search::Worker::search(
                 auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
                 assert(!ttHitNext || ttDataNext.key16 == uint16_t(nextPosKey));
                 pos.undo_move(ttData.move);
+
+                (ss + 1)->ttHit = true;
 
                 // Check that the ttValue after the tt move would also trigger a cutoff
                 if (!is_valid(ttDataNext.value))
@@ -1212,9 +1215,11 @@ moves_loop:  // When in check, search starts here
             {
                 int corrValAdj   = std::abs(correctionValue) / 249096;
                 int doubleMargin = 4 + 205 * PvNode - 223 * !ttCapture - corrValAdj
-                                 - 959 * ttMoveHistory / 131072 - (ss->ply > rootDepth) * 45;
+                                 - 959 * ttMoveHistory / 131072 - (ss->ply > rootDepth) * 45
+                                 - (ss + 1)->ttHit * 50;
                 int tripleMargin = 80 + 276 * PvNode - 249 * !ttCapture + 86 * ss->ttPv - corrValAdj
-                                 - (ss->ply * 2 > rootDepth * 3) * 53;
+                                 - (ss->ply * 2 > rootDepth * 3) * 53
+                                 - (ss + 1)->ttHit * 50;
 
                 extension =
                   1 + (value < singularBeta - doubleMargin) + (value < singularBeta - tripleMargin);


### PR DESCRIPTION
## Summary
- propagate transposition table hit info to child stack
- reduce singular extension margins when child node hit TT

## Testing
- `./revolution-dev_v2.40_130925 bench`

------
https://chatgpt.com/codex/tasks/task_e_68c693d947c483279fb688f3b7ec58d1