### PR TITLE
Implement TimeClamp to limit re-search storms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Updated engine identifier to "revolution v.1.2.0 dev- 070925".
+- Added time clamp in time management to limit excessive re-search time.
 
 ## [1.20] - 2025-09-06
 ### Changed

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -404,6 +404,7 @@ void Search::Worker::iterative_deepening() {
             // high/low, re-search with a bigger window until we don't fail
             // high/low anymore.
             int failedHighCnt = 0;
+            int reSearchCnt   = 0;
             while (true)
             {
                 // Adjust the effective depth searched, but ensure at least one
@@ -442,6 +443,8 @@ void Search::Worker::iterative_deepening() {
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
                     failedHighCnt = 0;
+                    ++reSearchCnt;
+
                     if (mainThread)
                         mainThread->stopOnPonderhit = false;
                 }
@@ -449,9 +452,18 @@ void Search::Worker::iterative_deepening() {
                 {
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
                     ++failedHighCnt;
+                    ++reSearchCnt;
                 }
                 else
                     break;
+
+                if (mainThread && limits.use_time_management()
+                    && elapsed() > static_cast<TimePoint>(mainThread->tm.optimum() * 1.35)
+                    && reSearchCnt > 0)
+                {
+                    threads.stop = true;
+                    break;
+                }
 
                 delta += delta / 3;
 


### PR DESCRIPTION
## Summary
- track number of re-searches at root and clamp search when elapsed time exceeds 135% of the planned optimum
- document TimeClamp addition in the changelog

## Testing
- `make build`
- `./Revolution_v2.41_dev-150925 bench 32 1 1`


------
https://chatgpt.com/codex/tasks/task_e_68c7dfbebc608327abb966bb8bb79dd7