### PR TITLE
Improve blitz time heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - Updated engine identifier to "revolution v.1.2.0 dev- 070925".
 - Added time clamp in time management to limit excessive re-search time.
+- Tuned blitz time management to reduce time usage in short time controls.
 
 ## [1.20] - 2025-09-06
 ### Changed

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ this reserved buffer.
 setoption name Time Buffer value <milliseconds>
 ```
 
+Revolution automatically adjusts its time usage in blitz games (time controls
+of five minutes or less with minimal increment) to keep the search stable and
+avoid spending too much time on a single move.
+
 ## License
 
 Revolution is distributed under the **[GNU General Public License v3][gpl-link]** (GPLv3).

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -74,6 +74,8 @@ void TimeManagement::init(Search::LimitsType& limits,
         slowMover *= 0.8;  // 60s + 0ms
     else if (baseSeconds <= 180 && incSeconds >= 10)
         slowMover *= 1.05;  // 180s + 10s
+    else if (baseSeconds <= 300 && incSeconds <= 3)
+        slowMover *= 0.9;  // <=300s with small increment (blitz)
     else if (baseSeconds >= 960 && incSeconds == 0)
         slowMover *= 1.15;  // 960s + 0ms
 


### PR DESCRIPTION
## Summary
- tighten time allocation for blitz controls to favor search stability
- document blitz time heuristic in README and changelog

## Testing
- `make build ARCH=x86-64-sse41-popcnt -j2` *(fails: tt.o: file format not recognized)*
- `bash tests/perft.sh src/revolution.bin` *(fails: exit code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ea530d488327b44124fb4ba96ee9