### PR TITLE
Add search metrics instrumentation and pipeline runner

### DIFF
--- a/docs/pipelines/xp_plan.json
+++ b/docs/pipelines/xp_plan.json
@@ -1,0 +1,103 @@
+{
+  "description": "Automated metrics pipeline covering the XP experiment roadmap.",
+  "output_subdir": "xp_metrics",
+  "stages": [
+    {
+      "name": "baseline",
+      "description": "Reference runs using the conservative 040825 search defaults.",
+      "uci_options": {
+        "Use 040825 Search": "true"
+      },
+      "runs": [
+        {
+          "label": "startpos_depth16",
+          "commands": [
+            "ucinewgame",
+            "position startpos",
+            "go depth 16"
+          ]
+        },
+        {
+          "label": "complex_endgame_depth18",
+          "commands": [
+            "ucinewgame",
+            "position fen r1b2r1k/pp1p2pp/2p5/2B1q3/8/8/P1PN2PP/R4RK1 w - - 0 18",
+            "go depth 18"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xp2_xp7_stability",
+      "description": "Re-run stability suite after adjusting aspiration, ordering, LMR and TT policy.",
+      "notes": "Apply XP-2, XP-6, XP-3 and XP-7 heuristics before executing this stage.",
+      "uci_options": {
+        "Use 040825 Search": "false"
+      },
+      "runs": [
+        {
+          "label": "startpos_depth18",
+          "commands": [
+            "ucinewgame",
+            "position startpos",
+            "go depth 18"
+          ]
+        },
+        {
+          "label": "tb_rank_depth20",
+          "commands": [
+            "ucinewgame",
+            "position fen 2rq1rk1/1b3pp1/p3pn1p/1p2P3/3P1P2/2NBB2P/PP3QP1/2RR2K1 w - - 0 19",
+            "go depth 20"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xp1_xp8_blitz",
+      "description": "Blitz oriented checks with time clamp, late move pruning and selective quiescence.",
+      "notes": "Enable XP-1, XP-5 and XP-8 settings before running.",
+      "uci_options": {
+        "Minimum Thinking Time": "0",
+        "Use 040825 Search": "false"
+      },
+      "runs": [
+        {
+          "label": "startpos_movetime2000",
+          "commands": [
+            "ucinewgame",
+            "position startpos",
+            "go movetime 2000"
+          ]
+        },
+        {
+          "label": "sharp_fen_movetime2500",
+          "commands": [
+            "ucinewgame",
+            "position fen 2r2rk1/1bqn1pp1/p3pn1p/1p1p4/3P1P2/2NBPN1P/PP3QP1/2RR2K1 w - - 0 19",
+            "go movetime 2500"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "xp9_xp10_safeguards",
+      "description": "Optional evaluation and root-bias checks triggered when instability is observed.",
+      "optional": true,
+      "notes": "Run only if logs indicate erratic evaluation swings or root bias.",
+      "uci_options": {
+        "Use 040825 Search": "false"
+      },
+      "runs": [
+        {
+          "label": "evaluation_guard_depth14",
+          "commands": [
+            "ucinewgame",
+            "position fen 2r2rk1/1bqn1pp1/p3pn1p/1p1p4/3P1P2/2NBPN1P/PP3QP1/2RR2K1 w - - 0 19",
+            "go depth 14"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Automation helper to gather Revolution search metrics for XP experiments."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
+DEFAULT_ENGINE = ROOT / "src" / "revolution"
+
+
+class UCIProcess:
+    def __init__(self, binary: Path) -> None:
+        self.proc = subprocess.Popen(
+            [str(binary)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        if self.proc.stdin is None or self.proc.stdout is None:
+            raise RuntimeError("Failed to start engine process")
+
+    def send(self, command: str) -> None:
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(command + "\n")
+        self.proc.stdin.flush()
+
+    def collect_until(self, predicate: Callable[[str], bool]) -> List[str]:
+        assert self.proc.stdout is not None
+        lines: List[str] = []
+        while True:
+            line = self.proc.stdout.readline()
+            if not line:
+                raise RuntimeError("Engine closed the connection unexpectedly")
+            stripped = line.rstrip("\n")
+            lines.append(stripped)
+            if predicate(stripped):
+                break
+        return lines
+
+    def expect(self, token: str) -> None:
+        self.collect_until(lambda line: line.strip() == token)
+
+    def quit(self) -> None:
+        try:
+            self.send("quit")
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+
+
+def sanitize_label(label: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in label)
+
+
+def round_value(value: float, digits: int = 4) -> float:
+    return round(value, digits)
+
+
+def summarize_metrics(metrics: Dict) -> Dict:
+    iterations: List[Dict] = metrics.get("iterations", [])
+    total_nodes = sum(int(item.get("nodes", 0)) for item in iterations)
+    total_time_ms = sum(int(item.get("time_ms", 0)) for item in iterations)
+    iteration_count = len(iterations)
+    avg_re_searches = (
+        sum(int(item.get("re_searches", 0)) for item in iterations) / iteration_count
+        if iteration_count
+        else 0.0
+    )
+    final_depth = iterations[-1]["depth"] if iteration_count else 0
+    aspiration = metrics.get("aspiration", {})
+    tt = metrics.get("tt", {})
+    null_move = metrics.get("null_move", {})
+    lmr_hist = metrics.get("lmr", {}).get("histogram", {})
+    lmp_counts = metrics.get("lmp", {})
+
+    probes = int(tt.get("probes", 0))
+    hits = int(tt.get("hits", 0))
+    hit_rate = hits / probes if probes else 0.0
+    stores = int(tt.get("stores", 0))
+    replacements = int(tt.get("replacements", 0))
+    replace_rate = replacements / stores if stores else 0.0
+
+    nmp_calls = int(null_move.get("calls", 0))
+    nmp_cutoffs = int(null_move.get("cutoffs", 0))
+    nmp_cutoff_rate = nmp_cutoffs / nmp_calls if nmp_calls else 0.0
+
+    total_lmr = 0
+    weighted_reduction = 0
+    for bucket, count in lmr_hist.items():
+        value = int(str(bucket).rstrip("+"))
+        weighted_reduction += value * int(count)
+        total_lmr += int(count)
+    lmr_avg = weighted_reduction / total_lmr if total_lmr else 0.0
+
+    total_lmp = sum(int(v) for v in lmp_counts.values())
+
+    nps = (total_nodes * 1000.0 / total_time_ms) if total_time_ms else 0.0
+
+    return {
+        "final_depth": final_depth,
+        "iterations": iteration_count,
+        "avg_re_searches": round_value(avg_re_searches),
+        "aspiration_re_searches": int(aspiration.get("re_searches", 0)),
+        "aspiration_fail_highs": int(aspiration.get("fail_highs", 0)),
+        "aspiration_fail_lows": int(aspiration.get("fail_lows", 0)),
+        "total_nodes": total_nodes,
+        "total_time_ms": total_time_ms,
+        "nps": round_value(nps),
+        "tt_hit_rate": round_value(hit_rate),
+        "tt_replace_rate": round_value(replace_rate),
+        "tt_probes": probes,
+        "tt_replacements": replacements,
+        "nmp_calls": nmp_calls,
+        "nmp_cutoffs": nmp_cutoffs,
+        "nmp_cutoff_rate": round_value(nmp_cutoff_rate),
+        "lmr_events": total_lmr,
+        "lmr_avg_reduction": round_value(lmr_avg),
+        "lmp_prunes": total_lmp,
+    }
+
+
+def aggregate_summary(run_summaries: List[Dict]) -> Dict:
+    if not run_summaries:
+        return {}
+
+    keys_to_mean = [
+        "avg_re_searches",
+        "nps",
+        "tt_hit_rate",
+        "tt_replace_rate",
+        "nmp_cutoff_rate",
+        "lmr_avg_reduction",
+    ]
+    aggregate: Dict[str, float] = {}
+    for key in keys_to_mean:
+        aggregate[f"mean_{key}"] = round_value(
+            statistics.fmean(run["summary"][key] for run in run_summaries)
+        )
+
+    total_nodes = sum(run["summary"]["total_nodes"] for run in run_summaries)
+    total_time = sum(run["summary"]["total_time_ms"] for run in run_summaries)
+    aggregate["total_nodes"] = total_nodes
+    aggregate["total_time_ms"] = total_time
+    aggregate["overall_nps"] = round_value(total_nodes * 1000.0 / total_time) if total_time else 0.0
+    aggregate["total_lmr_events"] = sum(run["summary"]["lmr_events"] for run in run_summaries)
+    aggregate["total_lmp_prunes"] = sum(run["summary"]["lmp_prunes"] for run in run_summaries)
+    aggregate["total_aspiration_re_searches"] = sum(
+        run["summary"]["aspiration_re_searches"] for run in run_summaries
+    )
+    aggregate["total_nmp_cutoffs"] = sum(run["summary"]["nmp_cutoffs"] for run in run_summaries)
+    aggregate["max_depth"] = max(run["summary"]["final_depth"] for run in run_summaries)
+
+    return aggregate
+
+
+def run_stage(
+    engine_path: Path,
+    stage: Dict,
+    output_dir: Path,
+    include_optional: bool,
+) -> Optional[Dict]:
+    if stage.get("optional") and not include_optional:
+        print(f"Skipping optional stage '{stage['name']}'")
+        return None
+
+    stage_dir = output_dir / sanitize_label(stage["name"])
+    stage_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"\n=== Stage: {stage['name']} ===")
+    if stage.get("description"):
+        print(stage["description"])
+    if stage.get("notes"):
+        print(f"Notes: {stage['notes']}")
+
+    engine = UCIProcess(engine_path)
+    try:
+        engine.send("uci")
+        engine.expect("uciok")
+
+        stage_options = stage.get("uci_options", {})
+        for name, value in stage_options.items():
+            engine.send(f"setoption name {name} value {value}")
+        engine.send("isready")
+        engine.expect("readyok")
+
+        run_summaries: List[Dict] = []
+        for idx, run in enumerate(stage.get("runs", []), start=1):
+            label = sanitize_label(run.get("label", f"run_{idx}"))
+            metrics_file = stage_dir / f"{label}_metrics.json"
+
+            engine.send(f"setoption name Metrics Log File value {metrics_file}")
+            engine.send("isready")
+            engine.expect("readyok")
+
+            log_lines: List[str] = []
+            for command in run.get("commands", []):
+                engine.send(command)
+                if command.strip().startswith("go "):
+                    log_lines.extend(engine.collect_until(lambda line: line.startswith("bestmove")))
+                else:
+                    time.sleep(0.01)
+
+            if not metrics_file.exists():
+                raise RuntimeError(f"Metrics file {metrics_file} was not produced")
+
+            with metrics_file.open("r", encoding="utf-8") as handle:
+                metrics_data = json.load(handle)
+
+            summary = summarize_metrics(metrics_data)
+            run_summaries.append(
+                {
+                    "label": label,
+                    "metrics_file": metrics_file.name,
+                    "summary": summary,
+                }
+            )
+
+            log_path = stage_dir / f"{label}.log"
+            if log_lines:
+                log_path.write_text("\n".join(log_lines), encoding="utf-8")
+
+            print(
+                f"  Run {label}: depth {summary['final_depth']} | nodes {summary['total_nodes']} | "
+                f"NPS {summary['nps']} | TT hit-rate {summary['tt_hit_rate']}"
+            )
+
+        engine.send("quit")
+        engine.proc.wait(timeout=5)
+    finally:
+        if engine.proc.poll() is None:
+            engine.quit()
+
+    aggregate = aggregate_summary(run_summaries)
+    stage_summary = {
+        "name": stage["name"],
+        "description": stage.get("description", ""),
+        "notes": stage.get("notes", ""),
+        "runs": run_summaries,
+        "aggregate": aggregate,
+    }
+
+    with (stage_dir / "summary.json").open("w", encoding="utf-8") as handle:
+        json.dump(stage_summary, handle, indent=2)
+
+    return stage_summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Revolution metrics pipeline")
+    parser.add_argument("--engine", type=Path, default=DEFAULT_ENGINE, help="Path to engine binary")
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN, help="Path to plan JSON file")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Directory where stage artifacts are written (defaults to plan output)",
+    )
+    parser.add_argument(
+        "--include-optional",
+        action="store_true",
+        help="Also execute stages marked as optional",
+    )
+    args = parser.parse_args()
+
+    if not args.engine.exists():
+        parser.error(f"Engine binary {args.engine} does not exist")
+    if not args.plan.exists():
+        parser.error(f"Plan file {args.plan} does not exist")
+
+    with args.plan.open("r", encoding="utf-8") as handle:
+        plan = json.load(handle)
+
+    plan_output = plan.get("output_subdir", "metrics_runs")
+    base_output = args.output or (ROOT / plan_output)
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    output_dir = Path(base_output).expanduser().resolve() / timestamp
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Writing artifacts to {output_dir}")
+
+    stage_summaries: List[Dict] = []
+    for stage in plan.get("stages", []):
+        summary = run_stage(args.engine, stage, output_dir, args.include_optional)
+        if summary is not None:
+            stage_summaries.append(summary)
+
+    overall_path = output_dir / "pipeline_summary.json"
+    overall_data = {
+        "plan": args.plan.name,
+        "timestamp": timestamp,
+        "stages": [summary["name"] for summary in stage_summaries],
+    }
+    overall_path.write_text(json.dumps(overall_data, indent=2), encoding="utf-8")
+    print(f"Pipeline complete. Summary written to {overall_path}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -76,6 +76,8 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
+    options.add("Metrics Log File", Option(""));
+
     options.add(  //
       "NumaPolicy", Option("auto", [this](const Option& o) {
           set_numa_config_from_option(o);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -26,10 +26,12 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <deque>
+#include <fstream>
 #include <initializer_list>
 #include <iostream>
-#include <deque>
 #include <ratio>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -145,6 +147,144 @@ void update_all_stats(const Position& pos,
 
 }  // namespace
 
+namespace {
+
+std::string_view lmp_reason_name(LatePruneReason reason)
+{
+    switch (reason)
+    {
+        case LatePruneReason::SkipQuietPhase:
+            return "skip_quiet";
+        case LatePruneReason::CaptureFutility:
+            return "capture_futility";
+        case LatePruneReason::CaptureSee:
+            return "capture_see";
+        case LatePruneReason::HistoryPrune:
+            return "history";
+        case LatePruneReason::LateMovePrune:
+            return "late_move";
+        case LatePruneReason::ParentFutility:
+            return "parent_futility";
+        case LatePruneReason::QuietSee:
+            return "quiet_see";
+        case LatePruneReason::Count:
+            break;
+    }
+
+    return "unknown";
+}
+
+}  // namespace
+
+void SearchMetrics::reset()
+{
+    aspirationReSearches = aspirationFailHighs = aspirationFailLows = 0;
+    ttProbes = ttHits = ttStores = ttReplacements = 0;
+    nullMoveCalls = nullMoveCutoffs = 0;
+    lmrHistogram.fill(0);
+    lmpReasons.fill(0);
+    iterations.clear();
+}
+
+void SearchMetrics::merge(const SearchMetrics& other)
+{
+    aspirationReSearches += other.aspirationReSearches;
+    aspirationFailHighs += other.aspirationFailHighs;
+    aspirationFailLows += other.aspirationFailLows;
+
+    ttProbes += other.ttProbes;
+    ttHits += other.ttHits;
+    ttStores += other.ttStores;
+    ttReplacements += other.ttReplacements;
+
+    nullMoveCalls += other.nullMoveCalls;
+    nullMoveCutoffs += other.nullMoveCutoffs;
+
+    for (size_t i = 0; i < lmrHistogram.size(); ++i)
+        lmrHistogram[i] += other.lmrHistogram[i];
+
+    for (size_t i = 0; i < lmpReasons.size(); ++i)
+        lmpReasons[i] += other.lmpReasons[i];
+
+    iterations.insert(iterations.end(), other.iterations.begin(), other.iterations.end());
+}
+
+void SearchMetrics::record_iteration(const IterationMetrics& metric)
+{
+    iterations.push_back(metric);
+}
+
+void SearchMetrics::record_lmr(int reduction)
+{
+    const int capped         = std::max(0, reduction);
+    const size_t bucketIndex = std::min<size_t>(lmrHistogram.size() - 1, static_cast<size_t>(capped));
+    lmrHistogram[bucketIndex]++;
+}
+
+void SearchMetrics::record_lmp(LatePruneReason reason)
+{
+    const size_t idx = static_cast<size_t>(reason);
+    if (idx < lmpReasons.size())
+        lmpReasons[idx]++;
+}
+
+std::string SearchMetrics::to_json() const
+{
+    std::ostringstream oss;
+    oss << "{\n";
+    oss << "  \"aspiration\": {\"re_searches\": " << aspirationReSearches
+        << ", \"fail_highs\": " << aspirationFailHighs
+        << ", \"fail_lows\": " << aspirationFailLows << "},\n";
+    oss << "  \"tt\": {\"probes\": " << ttProbes
+        << ", \"hits\": " << ttHits
+        << ", \"stores\": " << ttStores
+        << ", \"replacements\": " << ttReplacements << "},\n";
+    oss << "  \"null_move\": {\"calls\": " << nullMoveCalls
+        << ", \"cutoffs\": " << nullMoveCutoffs << "},\n";
+
+    oss << "  \"iterations\": [\n";
+    for (size_t i = 0; i < iterations.size(); ++i)
+    {
+        const auto& metric = iterations[i];
+        oss << "    {\"depth\": " << metric.depth
+            << ", \"re_searches\": " << metric.reSearches
+            << ", \"fail_highs\": " << metric.failHighs
+            << ", \"fail_lows\": " << metric.failLows
+            << ", \"nodes\": " << metric.nodes
+            << ", \"time_ms\": " << metric.elapsedTimeMs << "}";
+        if (i + 1 < iterations.size())
+            oss << ",";
+        oss << "\n";
+    }
+    oss << "  ],\n";
+
+    oss << "  \"lmr\": {\"histogram\": {";
+    for (size_t i = 0; i < lmrHistogram.size(); ++i)
+    {
+        if (i)
+            oss << ", ";
+        oss << '\"';
+        if (i == lmrHistogram.size() - 1)
+            oss << i << "+";
+        else
+            oss << i;
+        oss << "\": " << lmrHistogram[i];
+    }
+    oss << "}},\n";
+
+    oss << "  \"lmp\": {";
+    for (size_t i = 0; i < lmpReasons.size(); ++i)
+    {
+        if (i)
+            oss << ", ";
+        oss << '\"' << lmp_reason_name(static_cast<LatePruneReason>(i)) << "\": " << lmpReasons[i];
+    }
+    oss << "}\n";
+
+    oss << "}";
+    return oss.str();
+}
+
 Search::Worker::Worker(SharedState&                    sharedState,
                        std::unique_ptr<ISearchManager> sm,
                        size_t                          threadId,
@@ -169,6 +309,7 @@ void Search::Worker::ensure_network_replicated() {
 
 void Search::Worker::start_searching() {
 
+    reset_metrics();
     accumulatorStack.reset();
 
     // Non-main threads go directly to iterative_deepening()
@@ -291,7 +432,20 @@ void Search::Worker::start_searching() {
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
         experience.update(rootPos, bestThread->rootMoves[0].pv[0], bestThread->rootMoves[0].score,
                           bestThread->completedDepth);
+
+    if (is_mainthread())
+    {
+        const std::string metricsPath = options["Metrics Log File"];
+        if (!metricsPath.empty())
+        {
+            std::ofstream out(metricsPath);
+            if (out)
+                out << threads.collect_metrics().to_json() << std::endl;
+        }
+    }
 }
+
+void Search::Worker::reset_metrics() { metrics.reset(); }
 
 // Main iterative deepening loop. It calls search()
 // repeatedly with increasing depth until the allocated thinking time has been
@@ -375,6 +529,13 @@ void Search::Worker::iterative_deepening() {
         if (!threads.increaseDepth)
             searchAgainCounter++;
 
+        const int      iterationDepth      = rootDepth;
+        const uint64_t iterationStartNodes = threads.nodes_searched();
+        const TimePoint iterationStartTime = elapsed_time();
+        uint32_t       iterationReSearches = 0;
+        uint32_t       iterationFailHighs  = 0;
+        uint32_t       iterationFailLows   = 0;
+
         // MultiPV loop. We perform a full root search for each PV line
         for (pvIdx = 0; pvIdx < multiPV; ++pvIdx)
         {
@@ -442,6 +603,8 @@ void Search::Worker::iterative_deepening() {
                     beta  = alpha;
                     alpha = std::max(bestValue - delta, -VALUE_INFINITE);
 
+                    ++metrics.aspirationFailLows;
+                    ++iterationFailLows;
                     failedHighCnt = 0;
                     ++reSearchCnt;
 
@@ -451,6 +614,8 @@ void Search::Worker::iterative_deepening() {
                 else if (bestValue >= beta)
                 {
                     beta = std::min(bestValue + delta, VALUE_INFINITE);
+                    ++metrics.aspirationFailHighs;
+                    ++iterationFailHighs;
                     ++failedHighCnt;
                     ++reSearchCnt;
                 }
@@ -469,6 +634,9 @@ void Search::Worker::iterative_deepening() {
 
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
+
+            metrics.aspirationReSearches += reSearchCnt;
+            iterationReSearches += reSearchCnt;
 
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
@@ -506,6 +674,24 @@ void Search::Worker::iterative_deepening() {
             lastBestPV        = rootMoves[0].pv;
             lastBestScore     = rootMoves[0].score;
             lastBestMoveDepth = rootDepth;
+        }
+
+        if (mainThread)
+        {
+            IterationMetrics metric;
+            metric.depth       = iterationDepth;
+            metric.reSearches  = iterationReSearches;
+            metric.failHighs   = iterationFailHighs;
+            metric.failLows    = iterationFailLows;
+            const uint64_t iterationEndNodes = threads.nodes_searched();
+            metric.nodes = iterationEndNodes >= iterationStartNodes
+                              ? iterationEndNodes - iterationStartNodes
+                              : iterationEndNodes;
+            const TimePoint iterationEndTime = elapsed_time();
+            metric.elapsedTimeMs = iterationEndTime >= iterationStartTime
+                                      ? static_cast<uint64_t>(iterationEndTime - iterationStartTime)
+                                      : 0ULL;
+            metrics.record_iteration(metric);
         }
 
         if (!mainThread)
@@ -621,6 +807,31 @@ void Search::Worker::undo_move(Position& pos, const Move move) {
 }
 
 void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
+
+std::tuple<bool, TTData, TTWriter> Search::Worker::probe_tt(Key key)
+{
+    metrics.ttProbes++;
+    auto result = tt.probe(key);
+    if (std::get<0>(result))
+        metrics.ttHits++;
+    return result;
+}
+
+void Search::Worker::store_tt(TTWriter& writer,
+                              Key       key,
+                              Value     value,
+                              bool      pv,
+                              Bound     bound,
+                              Depth     depth,
+                              Move      move,
+                              Value     eval)
+{
+    const bool replacing = writer.is_replacing();
+    writer.write(key, value, pv, bound, depth, move, eval, tt.generation());
+    metrics.ttStores++;
+    if (replacing)
+        metrics.ttReplacements++;
+}
 
 
 // Reset histories, usually before a new game
@@ -746,7 +957,7 @@ Value Search::Worker::search(
     // Step 4. Transposition table lookup
     excludedMove                   = ss->excludedMove;
     posKey                         = pos.key();
-    auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+    auto [ttHit, ttData, ttWriter] = probe_tt(posKey);
     assert(!ttHit || ttData.key16 == uint16_t(posKey));
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
@@ -787,7 +998,7 @@ Value Search::Worker::search(
             {
                 pos.do_move(ttData.move, st);
                 Key nextPosKey                             = pos.key();
-                auto [ttHitNext, ttDataNext, ttWriterNext] = tt.probe(nextPosKey);
+                auto [ttHitNext, ttDataNext, ttWriterNext] = probe_tt(nextPosKey);
                 assert(!ttHitNext || ttDataNext.key16 == uint16_t(nextPosKey));
                 pos.undo_move(ttData.move);
 
@@ -840,9 +1051,8 @@ Value Search::Worker::search(
                   if (b == Bound::BOUND_EXACT
                       || (b == Bound::BOUND_LOWER ? value >= beta : value <= alpha))
                   {
-                      ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, b,
-                                     std::min(MAX_PLY - 1, depth + 6), Move::none(), VALUE_NONE,
-                                     tt.generation());
+                      store_tt(ttWriter, posKey, value_to_tt(value, ss->ply), ss->ttPv, b,
+                               std::min(MAX_PLY - 1, depth + 6), Move::none(), VALUE_NONE);
 
                     return value;
                 }
@@ -891,8 +1101,8 @@ Value Search::Worker::search(
         ss->staticEval = eval = to_corrected_static_eval(unadjustedStaticEval, correctionValue);
 
         // Static evaluation is saved as it was before adjustment by correction history
-          ttWriter.write(posKey, VALUE_NONE, ss->ttPv, Bound::BOUND_NONE, DEPTH_UNSEARCHED, Move::none(),
-                         unadjustedStaticEval, tt.generation());
+          store_tt(ttWriter, posKey, VALUE_NONE, ss->ttPv, Bound::BOUND_NONE, DEPTH_UNSEARCHED, Move::none(),
+                   unadjustedStaticEval);
     }
 
     // Use static evaluation difference to improve quiet move ordering
@@ -958,6 +1168,7 @@ Value Search::Worker::search(
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
         ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
 
+        metrics.nullMoveCalls++;
         do_null_move(pos, st);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);
@@ -968,7 +1179,10 @@ Value Search::Worker::search(
         if (nullValue >= beta && !is_win(nullValue))
         {
             if (nmpMinPly || depth < 16)
+            {
+                metrics.nullMoveCutoffs++;
                 return nullValue;
+            }
 
             assert(!nmpMinPly);  // Recursive verification is not allowed
 
@@ -981,7 +1195,10 @@ Value Search::Worker::search(
             nmpMinPly = 0;
 
             if (v >= beta)
+            {
+                metrics.nullMoveCutoffs++;
                 return nullValue;
+            }
         }
     }
 
@@ -1035,8 +1252,8 @@ Value Search::Worker::search(
             if (value >= probCutBeta)
             {
                 // Save ProbCut data into transposition table
-                  ttWriter.write(posKey, value_to_tt(value, ss->ply), ss->ttPv, Bound::BOUND_LOWER,
-                                 probCutDepth + 1, move, unadjustedStaticEval, tt.generation());
+                  store_tt(ttWriter, posKey, value_to_tt(value, ss->ply), ss->ttPv, Bound::BOUND_LOWER,
+                           probCutDepth + 1, move, unadjustedStaticEval);
 
                 if (!is_decisive(value))
                     return value - (probCutBeta - beta);
@@ -1122,7 +1339,10 @@ moves_loop:  // When in check, search starts here
         {
             // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold
             if (moveCount >= (3 + depth * depth) / (2 - improving))
+            {
+                metrics.record_lmp(LatePruneReason::SkipQuietPhase);
                 mp.skip_quiet_moves();
+            }
 
             // Reduced depth of the next LMR search
             int lmrDepth = newDepth - r / 1024;
@@ -1139,7 +1359,10 @@ moves_loop:  // When in check, search starts here
                                         + 240 * (move.to_sq() == prevSq) + PieceValue[capturedPiece]
                                         + 100 * captHist / 1024;
                     if (futilityValue <= alpha)
+                    {
+                        metrics.record_lmp(LatePruneReason::CaptureFutility);
                         continue;
+                    }
                 }
 
                 // SEE based pruning for captures and checks
@@ -1155,7 +1378,10 @@ moves_loop:  // When in check, search starts here
 
                     // avoid pruning sacrifices of our last piece for stalemate
                     if (!mayStalemateTrap)
+                    {
+                        metrics.record_lmp(LatePruneReason::CaptureSee);
                         continue;
+                    }
                 }
             }
             else
@@ -1166,7 +1392,10 @@ moves_loop:  // When in check, search starts here
 
                 // Continuation history based pruning
                 if (history < -4361 * depth)
+                {
+                    metrics.record_lmp(LatePruneReason::HistoryPrune);
                     continue;
+                }
 
                 history += 71 * mainHistory[static_cast<int>(us)][move.from_to()] / 32;
 
@@ -1176,7 +1405,10 @@ moves_loop:  // When in check, search starts here
                 // have been tried without raising alpha, prune the remainder
                 if (lmrDepth < 1 && moveCount > 10
                     && ss->staticEval + Value(50 * moveCount) <= alpha)
+                {
+                    metrics.record_lmp(LatePruneReason::LateMovePrune);
                     continue;
+                }
 
                 // Retuned futility pruning margins and depth scaling
                 Value baseFutility = (bestMove ? 40 : 180);
@@ -1191,6 +1423,7 @@ moves_loop:  // When in check, search starts here
                     if (bestValue <= futilityValue && !is_decisive(bestValue)
                         && !is_win(futilityValue))
                         bestValue = futilityValue;
+                    metrics.record_lmp(LatePruneReason::ParentFutility);
                     continue;
                 }
 
@@ -1198,7 +1431,10 @@ moves_loop:  // When in check, search starts here
 
                 // Prune moves with negative SEE
                 if (!pos.see_ge(move, -26 * lmrDepth * lmrDepth))
+                {
+                    metrics.record_lmp(LatePruneReason::QuietSee);
                     continue;
+                }
             }
         }
 
@@ -1322,6 +1558,7 @@ moves_loop:  // When in check, search starts here
             Depth d = std::max(1, newDepth - r / 1024);
 
             ss->reduction = newDepth - d;
+            metrics.record_lmr(ss->reduction);
             value         = -search<NonPV>(pos, ss + 1, -(alpha + 1), -alpha, d, true);
             ss->reduction = 0;
 
@@ -1534,12 +1771,12 @@ moves_loop:  // When in check, search starts here
     // Write gathered information in transposition table. Note that the
     // static evaluation is saved as it was before correction history.
     if (!excludedMove && !(rootNode && pvIdx))
-          ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), ss->ttPv,
-                         bestValue >= beta    ? Bound::BOUND_LOWER
-                         : PvNode && bestMove ? Bound::BOUND_EXACT
-                                              : Bound::BOUND_UPPER,
-                         moveCount != 0 ? depth : std::min(MAX_PLY - 1, depth + 6), bestMove,
-                         unadjustedStaticEval, tt.generation());
+          store_tt(ttWriter, posKey, value_to_tt(bestValue, ss->ply), ss->ttPv,
+                   bestValue >= beta    ? Bound::BOUND_LOWER
+                   : PvNode && bestMove ? Bound::BOUND_EXACT
+                                        : Bound::BOUND_UPPER,
+                   moveCount != 0 ? depth : std::min(MAX_PLY - 1, depth + 6), bestMove,
+                   unadjustedStaticEval);
 
     // Adjust correction history
     if (!ss->inCheck && !(bestMove && pos.capture(bestMove))
@@ -1612,7 +1849,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
     // Step 3. Transposition table lookup
     posKey                         = pos.key();
-    auto [ttHit, ttData, ttWriter] = tt.probe(posKey);
+    auto [ttHit, ttData, ttWriter] = probe_tt(posKey);
     // Need further processing of the saved data
     ss->ttHit    = ttHit;
     ttData.move  = ttHit ? ttData.move : Move::none();
@@ -1663,9 +1900,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
             if (!is_decisive(bestValue))
                 bestValue = (bestValue + beta) / 2;
             if (!ss->ttHit)
-                  ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), false, Bound::BOUND_LOWER,
-                                 DEPTH_UNSEARCHED, Move::none(), unadjustedStaticEval,
-                                 tt.generation());
+                  store_tt(ttWriter, posKey, value_to_tt(bestValue, ss->ply), false, Bound::BOUND_LOWER,
+                           DEPTH_UNSEARCHED, Move::none(), unadjustedStaticEval);
             return bestValue;
         }
 
@@ -1799,9 +2035,9 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
     // Save gathered info in transposition table. The static evaluation
     // is saved as it was before adjustment by correction history.
-    ttWriter.write(posKey, value_to_tt(bestValue, ss->ply), pvHit,
-                   bestValue >= beta ? Bound::BOUND_LOWER : Bound::BOUND_UPPER, DEPTH_QS, bestMove,
-                   unadjustedStaticEval, tt.generation());
+    store_tt(ttWriter, posKey, value_to_tt(bestValue, ss->ply), pvHit,
+             bestValue >= beta ? Bound::BOUND_LOWER : Bound::BOUND_UPPER, DEPTH_QS, bestMove,
+             unadjustedStaticEval);
 
     assert(bestValue > -VALUE_INFINITE && bestValue < VALUE_INFINITE);
 

--- a/src/search.h
+++ b/src/search.h
@@ -39,6 +39,7 @@
 #include "score.h"
 #include "syzygy/tbprobe.h"
 #include "timeman.h"
+#include "tt.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -63,6 +64,52 @@ class ThreadPool;
 class OptionsMap;
 
 namespace Search {
+
+struct IterationMetrics {
+    int      depth          = 0;
+    uint32_t reSearches     = 0;
+    uint32_t failHighs      = 0;
+    uint32_t failLows       = 0;
+    uint64_t nodes          = 0;
+    uint64_t elapsedTimeMs  = 0;
+};
+
+enum class LatePruneReason : uint8_t {
+    SkipQuietPhase = 0,
+    CaptureFutility,
+    CaptureSee,
+    HistoryPrune,
+    LateMovePrune,
+    ParentFutility,
+    QuietSee,
+    Count
+};
+
+struct SearchMetrics {
+    uint64_t aspirationReSearches = 0;
+    uint64_t aspirationFailHighs  = 0;
+    uint64_t aspirationFailLows   = 0;
+
+    uint64_t ttProbes       = 0;
+    uint64_t ttHits         = 0;
+    uint64_t ttStores       = 0;
+    uint64_t ttReplacements = 0;
+
+    uint64_t nullMoveCalls   = 0;
+    uint64_t nullMoveCutoffs = 0;
+
+    std::array<uint64_t, 16>                                     lmrHistogram{};
+    std::array<uint64_t, static_cast<size_t>(LatePruneReason::Count)> lmpReasons{};
+
+    std::vector<IterationMetrics> iterations;
+
+    void        reset();
+    void        merge(const SearchMetrics& other);
+    void        record_iteration(const IterationMetrics& metric);
+    void        record_lmr(int reduction);
+    void        record_lmp(LatePruneReason reason);
+    std::string to_json() const;
+};
 
 // Stack struct keeps track of the information we need to remember from nodes
 // shallower and deeper in the tree during the search. Each search thread has
@@ -289,6 +336,8 @@ class Worker {
     // It searches from the root position and outputs the "bestmove".
     void start_searching();
 
+    void reset_metrics();
+
     bool is_mainthread() const { return threadIdx == 0; }
 
     void ensure_network_replicated();
@@ -317,6 +366,16 @@ class Worker {
     void do_null_move(Position& pos, StateInfo& st);
     void undo_move(Position& pos, const Move move);
     void undo_null_move(Position& pos);
+
+    std::tuple<bool, TTData, TTWriter> probe_tt(Key key);
+    void store_tt(TTWriter& writer,
+                  Key       key,
+                  Value     value,
+                  bool      pv,
+                  Bound     bound,
+                  Depth     depth,
+                  Move      move,
+                  Value     eval);
 
     // This is the main search function, for both PV and non-PV nodes
     template<NodeType nodeType>
@@ -372,6 +431,8 @@ class Worker {
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;
     Eval::NNUE::AccumulatorCaches refreshTable;
+
+    SearchMetrics metrics;
 
     friend class Stockfish::ThreadPool;
     friend class SearchManager;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -133,6 +133,14 @@ Search::SearchManager* ThreadPool::main_manager() { return main_thread()->worker
 uint64_t ThreadPool::nodes_searched() const { return accumulate(&Search::Worker::nodes); }
 uint64_t ThreadPool::tb_hits() const { return accumulate(&Search::Worker::tbHits); }
 
+Search::SearchMetrics ThreadPool::collect_metrics() const
+{
+    Search::SearchMetrics aggregated;
+    for (auto&& th : threads)
+        aggregated.merge(th->worker->metrics);
+    return aggregated;
+}
+
 // Creates/destroys threads to match the requested number.
 // Created and launched threads will immediately go to sleep in idle_loop.
 // Upon resizing, threads are recreated to allow for binding if necessary.
@@ -281,6 +289,7 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     for (auto&& th : threads)
     {
         th->run_custom_job([&]() {
+            th->worker->reset_metrics();
             th->worker->limits = limits;
             th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
               th->worker->bestMoveChanges          = 0;

--- a/src/thread.h
+++ b/src/thread.h
@@ -141,6 +141,7 @@ class ThreadPool {
     Thread*                main_thread() const { return threads.front().get(); }
     uint64_t               nodes_searched() const;
     uint64_t               tb_hits() const;
+    Search::SearchMetrics  collect_metrics() const;
     Thread*                get_best_thread() const;
     void                   start_searching();
     void                   wait_for_search_finished() const;

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -116,6 +116,11 @@ void TTWriter::write(
     tt->table[clusterIndex].entry[entryIndex].save(k, v, pv, b, d, m, ev, generation8);
 }
 
+bool TTWriter::is_replacing() const
+{
+    return tt->table[clusterIndex].entry[entryIndex].is_occupied();
+}
+
 
 // Sets the size of the transposition table,
 // measured in megabytes. Transposition table consists

--- a/src/tt.h
+++ b/src/tt.h
@@ -100,6 +100,7 @@ static_assert(sizeof(Cluster) == 32, "Suboptimal Cluster size");
 struct TTWriter {
    public:
     void write(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
+    bool is_replacing() const;
 
    private:
     friend class TranspositionTable;


### PR DESCRIPTION
## Summary
- add a SearchMetrics container and JSON export to capture aspiration, TT, null-move, and pruning statistics
- instrument the search flow and thread pool to record per-iteration data, aggregate metrics, and write to a configurable log
- provide a run_metrics_pipeline.py helper and default XP plan to automate staged metric collection

## Testing
- `make build -j2 ARCH=x86-64-sse41-popcnt`


------
https://chatgpt.com/codex/tasks/task_e_68c831b9d0fc8327995fe0f3c20c5da6