### PR TITLE
Adjust black time allocation under negative evaluations

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -115,6 +115,8 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Slow Mover", Option(100, 10, 1000));
 
+    options.add("BlackTimeFactor", Option(105, 100, 200));
+
     options.add("nodestime", Option(0, 0, 10000));
 
     options.add("Minimum Thinking Time", Option(20, 0, 5000));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -319,8 +319,15 @@ void Search::Worker::start_searching() {
         return;
     }
 
+    int evaluationCp = 0;
+    {
+        Value currentEval = evaluate(rootPos);
+        if (is_valid(currentEval))
+            evaluationCp = UCIEngine::to_cp(currentEval, rootPos);
+    }
+
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
-                            main_manager()->originalTimeAdjust);
+                            main_manager()->originalTimeAdjust, evaluationCp);
     tt.new_search();
 
     Move preferredMove = Move::none();

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -50,7 +50,8 @@ void TimeManagement::init(Search::LimitsType& limits,
                           Color               us,
                           int                 ply,
                           const OptionsMap&   options,
-                          double&             originalTimeAdjust) {
+                          double&             originalTimeAdjust,
+                          int                 evaluationCp) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
     // If we have no time, we don't need to fully initialize TM.
@@ -170,6 +171,14 @@ void TimeManagement::init(Search::LimitsType& limits,
           std::min<int64_t>(budget,
                             std::max<int64_t>(0, time_left_ms - GTime.panic_margin_ms));
         optimumTime = maximumTime = TimePoint(budget);
+    }
+
+    if (us == Color::BLACK && evaluationCp <= -50)
+    {
+        double factor = options["BlackTimeFactor"] / 100.0;
+        optimumTime   = TimePoint(optimumTime * factor);
+        maximumTime   = TimePoint(maximumTime * factor);
+        maximumTime   = std::max(maximumTime, optimumTime);
     }
 
     if (options["Ponder"])

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include "misc.h"
+#include "types.h"
 
 namespace Stockfish {
 
@@ -50,7 +51,8 @@ class TimeManagement {
               Color               us,
               int                 ply,
               const OptionsMap&   options,
-              double&             originalTimeAdjust);
+              double&             originalTimeAdjust,
+              int                 evaluationCp);
 
     TimePoint optimum() const;
     TimePoint maximum() const;


### PR DESCRIPTION
## Summary
- add a BlackTimeFactor spin option to let users scale black's time usage
- compute the current root evaluation in centipawns and pass it into TimeManagement::init
- scale optimum and maximum time for black moves when the evaluation is ≤ -50 cp

## Testing
- make -j build ARCH=x86-64-sse41-popcnt

------
https://chatgpt.com/codex/tasks/task_e_68c8807b15b483279247855d621588d2