### PR TITLE
Adjust search reductions for black to move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1164,6 +1164,9 @@ Value Search::Worker::search(
         // Null move dynamic reduction based on depth
         Depth R = 3 + depth / 4;
 
+        if (us == Color::BLACK)
+            R = std::max<Depth>(Depth(1), R - 1);
+
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
         ss->continuationCorrectionHistory = &continuationCorrectionHistory[NO_PIECE][0];
@@ -1556,6 +1559,9 @@ moves_loop:  // When in check, search starts here
         {
             // Apply a simple reduction limited between one ply and the remaining depth
             Depth d = std::max(1, newDepth - r / 1024);
+
+            if (us == Color::BLACK)
+                ++d;
 
             ss->reduction = newDepth - d;
             metrics.record_lmr(ss->reduction);


### PR DESCRIPTION
## Summary
- lower null-move reduction by a ply when the side to move is Black so those positions search a little deeper
- relax the LMR reduced depth for Black moves by extending the reduced search one ply

## Testing
- `make build -C src`
- `python3 tests/instrumented.py src/Revolution_v2.41_dev-150925` *(fails: waits for "Stockfish" banner)*

------
https://chatgpt.com/codex/tasks/task_e_68c880874d98832797c9ae7be149a448