### PR TITLE
Silence unused adaptive style helper

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -124,7 +124,7 @@ Value adaptive_style_bonus(const StyleIndicators& ind, Value current) {
     return Value(bonus);
 }
 
-Value adaptive_style_bonus(const Position& pos, Value current) {
+[[maybe_unused]] Value adaptive_style_bonus(const Position& pos, Value current) {
     return adaptive_style_bonus(gather_indicators(pos), current);
 }
 


### PR DESCRIPTION
## Summary
- mark the Position overload of `adaptive_style_bonus` as maybe_unused so clang no longer warns about it when unused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c888ba53388327a7341b0e42796f81