### PR TITLE
Restore revolution-dev v2.40 version identifiers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Revolution_v2.41_dev-150925.exe
+	EXE = revolution-dev_v2.40_130925.exe
 else
-        EXE = Revolution_v2.41_dev-150925
+	EXE = revolution-dev_v2.40_130925
 endif
 
 ### Installation dir definitions
@@ -862,11 +862,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "Revolution v.2.41 dev-150925"
+#- ENGINE_NAME : "revolution-dev v.2.40 130925"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "Revolution v.2.41 dev-150925" ENGINE_BUILD_DATE = 20250913
-ENGINE_NAME        ?= Revolution v.2.41 dev-150925
+#make ENGINE_NAME = "revolution-dev v.2.40 130925" ENGINE_BUILD_DATE = 20250913
+ENGINE_NAME        ?= revolution-dev v.2.40 130925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution v.2.41 dev-150925"
+            // Force a stable, explicit UCI name so GUIs show "revolution-dev v.2.40 130925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution v.2.41 dev-150925"
+    #define ENGINE_NAME "revolution-dev v.2.40 130925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- revert the Windows executable name and default ENGINE_NAME string to revolution-dev v.2.40 130925
- keep the UCI loop comment and version header aligned with the 2.40 identity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c89e4c3ec48327a26d5a6f184dcd41