### PR TITLE
Align time management with Stockfish defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Additional late move pruning for quiet moves at low depth.
 
 ### Changed
-- Updated engine identifier to "revolution v.1.2.0 dev- 070925".
+- Updated engine identifier to "revolution-dev 160925".
+- Removed UCI options `Minimum Thinking Time` and `Slow Mover` to align with Stockfish defaults.
 - Added time clamp in time management to limit excessive re-search time.
 - Tuned blitz time management to reduce time usage in short time controls.
 

--- a/README.md
+++ b/README.md
@@ -102,17 +102,6 @@ The file is loaded at engine startup and updated after each game if `Experience 
 
 ## UCI Options
 
-### Minimum Thinking Time
-
-The `Minimum Thinking Time` option ensures the engine spends at least a
-specified number of milliseconds searching for a move, even if it finds
-a good one instantly. This avoids extremely fast, low-quality replies.
-Set it with:
-
-```
-setoption name Minimum Thinking Time value <milliseconds>
-```
-
 ### Time Buffer
 
 The `Time Buffer` option reserves a small amount of time on each move to

--- a/docs/pipelines/xp_plan.json
+++ b/docs/pipelines/xp_plan.json
@@ -58,7 +58,6 @@
       "description": "Blitz oriented checks with time clamp, late move pruning and selective quiescence.",
       "notes": "Enable XP-1, XP-5 and XP-8 settings before running.",
       "uci_options": {
-        "Minimum Thinking Time": "0",
         "Use 040825 Search": "false"
       },
       "runs": [

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-	EXE = revolution-dev_v2.40_130925.exe
+        EXE = revolution-dev_160925.exe
 else
-	EXE = revolution-dev_v2.40_130925
+        EXE = revolution-dev_160925
 endif
 
 ### Installation dir definitions
@@ -862,11 +862,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution-dev v.2.40 130925"
+#- ENGINE_NAME : "revolution-dev 160925"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution-dev v.2.40 130925" ENGINE_BUILD_DATE = 20250913
-ENGINE_NAME        ?= revolution-dev v.2.40 130925
+#make ENGINE_NAME = "revolution-dev 160925" ENGINE_BUILD_DATE = 20250913
+ENGINE_NAME        ?= revolution-dev 160925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -113,13 +113,9 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Move Overhead", Option(10, 0, 5000));
 
-    options.add("Slow Mover", Option(100, 10, 1000));
-
     options.add("BlackTimeFactor", Option(105, 100, 200));
 
     options.add("nodestime", Option(0, 0, 10000));
-
-    options.add("Minimum Thinking Time", Option(20, 0, 5000));
 
     options.add("Time Buffer", Option(50, 0, 5000));
 
@@ -252,10 +248,6 @@ std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960
 
 void Engine::go(Search::LimitsType& limits) {
     assert(limits.perft == 0);
-
-    TimePoint minTime = TimePoint(options["Minimum Thinking Time"]);
-    if (limits.movetime && limits.movetime < minTime)
-        limits.movetime = minTime;
 
     verify_networks();
 

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -59,26 +59,14 @@ void TimeManagement::init(Search::LimitsType& limits,
     startTime    = limits.startTime;
     useNodesTime = npmsec != 0;
 
-    if (limits.time[static_cast<int>(us)] == 0)
+    const int usIdx = static_cast<int>(us);
+
+    if (limits.time[usIdx] == 0)
         return;
 
     TimePoint moveOverhead =
       GSearch.conservative ? TimePoint(GTime.move_overhead_ms)
                            : TimePoint(options["Move Overhead"]);
-    double slowMover = GSearch.conservative ? GTime.slow_mover
-                                            : options["Slow Mover"] / 100.0;
-
-    // Adjust time usage heuristics for common time controls
-    double baseSeconds = double(limits.time[static_cast<int>(us)]) / 1000.0;
-    double incSeconds  = double(limits.inc[static_cast<int>(us)]) / 1000.0;
-    if (baseSeconds <= 60 && incSeconds == 0)
-        slowMover *= 0.8;  // 60s + 0ms
-    else if (baseSeconds <= 180 && incSeconds >= 10)
-        slowMover *= 1.05;  // 180s + 10s
-    else if (baseSeconds <= 300 && incSeconds <= 3)
-        slowMover *= 0.9;  // <=300s with small increment (blitz)
-    else if (baseSeconds >= 960 && incSeconds == 0)
-        slowMover *= 1.15;  // 960s + 0ms
 
     // optScale is a percentage of available time to use for the current move.
     // maxScale is a multiplier applied to optimumTime.
@@ -90,12 +78,12 @@ void TimeManagement::init(Search::LimitsType& limits,
     // must be much lower than the real engine speed.
     if (useNodesTime)
     {
-        if (availableNodes == -1)                       // Only once at game start
-            availableNodes = npmsec * limits.time[static_cast<int>(us)];  // Time is in msec
+        if (availableNodes == -1)                 // Only once at game start
+            availableNodes = npmsec * limits.time[usIdx];  // Time is in msec
 
         // Convert from milliseconds to nodes
-        limits.time[static_cast<int>(us)] = TimePoint(availableNodes);
-        limits.inc[static_cast<int>(us)] *= npmsec;
+        limits.time[usIdx] = TimePoint(availableNodes);
+        limits.inc[usIdx] *= npmsec;
         limits.npmsec = npmsec;
         moveOverhead *= npmsec;
     }
@@ -103,7 +91,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     // These numbers are used where multiplications, divisions or comparisons
     // with constants are involved.
     const int64_t   scaleFactor = useNodesTime ? npmsec : 1;
-    const TimePoint scaledTime  = limits.time[static_cast<int>(us)] / scaleFactor;
+    const TimePoint scaledTime  = limits.time[usIdx] / scaleFactor;
 
     // Maximum move horizon
     int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
@@ -115,8 +103,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     // Make sure timeLeft is > 0 since we may use it as a divisor
     TimePoint timeLeft =
       std::max(TimePoint(1),
-               limits.time[static_cast<int>(us)]
-                 + (limits.inc[static_cast<int>(us)] * (centiMTG - 100) - moveOverhead * (200 + centiMTG)) / 100);
+               limits.time[usIdx]
+                 + (limits.inc[usIdx] * (centiMTG - 100) - moveOverhead * (200 + centiMTG)) / 100);
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed the actual available
@@ -132,9 +120,10 @@ void TimeManagement::init(Search::LimitsType& limits,
         double optConstant  = std::min(0.0032116 + 0.000321123 * logTimeInSec, 0.00508017);
         double maxConstant  = std::max(3.3977 + 3.03950 * logTimeInSec, 2.94761);
 
-        optScale = std::min(0.0121431 + std::pow(ply + 2.94693, 0.461073) * optConstant,
-                            0.213035 * limits.time[static_cast<int>(us)] / timeLeft)
-                 * originalTimeAdjust;
+        optScale =
+          std::min(0.0121431 + std::pow(ply + 2.94693, 0.461073) * optConstant,
+                   0.213035 * limits.time[usIdx] / timeLeft)
+          * originalTimeAdjust;
 
         maxScale = std::min(6.67704, maxConstant + ply / 11.9847);
     }
@@ -143,23 +132,19 @@ void TimeManagement::init(Search::LimitsType& limits,
     else
     {
         optScale =
-          std::min((0.88 + ply / 116.4) / (centiMTG / 100.0),
-                   0.88 * limits.time[static_cast<int>(us)] / timeLeft);
+          std::min((0.88 + ply / 116.4) / (centiMTG / 100.0), 0.88 * limits.time[usIdx] / timeLeft);
         maxScale = 1.3 + 0.11 * (centiMTG / 100.0);
     }
-
-    optScale *= slowMover;
 
     // Limit the maximum possible time for this move
     optimumTime = TimePoint(optScale * timeLeft);
     maximumTime =
-      TimePoint(std::min(0.90 * limits.time[static_cast<int>(us)] - moveOverhead,
-                          maxScale * optimumTime)) - 10;
+      TimePoint(std::min(0.825179 * limits.time[usIdx] - moveOverhead, maxScale * optimumTime)) - 10;
 
     if (GSearch.conservative)
     {
-        int64_t time_left_ms = limits.time[static_cast<int>(us)];
-        int64_t inc_ms       = limits.inc[static_cast<int>(us)];
+        int64_t time_left_ms = limits.time[usIdx];
+        int64_t inc_ms       = limits.inc[usIdx];
 
         int64_t base         = std::max<int64_t>(GTime.min_think_ms, optimumTime);
         int64_t dyn_overhead = GTime.move_overhead_ms;
@@ -185,8 +170,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         optimumTime += optimumTime / 4;
 
     TimePoint minimumThinkingTime =
-      GSearch.conservative ? TimePoint(GTime.min_think_ms)
-                           : TimePoint(options["Minimum Thinking Time"]);
+      GSearch.conservative ? TimePoint(GTime.min_think_ms) : TimePoint(0);
     TimePoint safetyBuffer =
       GSearch.conservative ? TimePoint(GTime.panic_margin_ms)
                            : TimePoint(options["Time Buffer"]);

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -28,10 +28,9 @@ namespace Stockfish {
 // Configuration used by the conservative time manager when the
 // "Use 040825 Search" option is enabled.
 struct TimeModel {
-    int64_t min_think_ms    = 30;   // Minimum thinking time per move
+    int64_t min_think_ms     = 30;  // Minimum thinking time per move
     int64_t move_overhead_ms = 20;  // Static overhead to subtract
     int64_t panic_margin_ms  = 80;  // Time reserved to avoid flagging
-    double  slow_mover       = 1.00;  // Scale factor for optimum time
 };
 
 extern TimeModel GTime;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution-dev v.2.40 130925"
+            // Force a stable, explicit UCI name so GUIs show "revolution-dev 160925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution-dev v.2.40 130925"
+    #define ENGINE_NAME "revolution-dev 160925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- align the time-management logic with the bfc70005-14-PR Stockfish baseline while preserving Revolution-specific tuning hooks
- remove the Slow Mover and Minimum Thinking Time UCI options and simplify the `go` handler to rely on the shared time manager
- update the engine identifier to `revolution-dev 160925` and refresh documentation and configs that referenced the retired options

## Testing
- make build -C src -j2

------
https://chatgpt.com/codex/tasks/task_e_68c8a0c223148327944f3a187fdea641