### PR TITLE
Remove Revolution-specific UCI toggles and align core logic with Stockfish 17.1

### DIFF
--- a/docs/pipelines/xp_plan.json
+++ b/docs/pipelines/xp_plan.json
@@ -4,10 +4,7 @@
   "stages": [
     {
       "name": "baseline",
-      "description": "Reference runs using the conservative 040825 search defaults.",
-      "uci_options": {
-        "Use 040825 Search": "true"
-      },
+      "description": "Reference runs using the standard search defaults.",
       "runs": [
         {
           "label": "startpos_depth16",
@@ -31,9 +28,6 @@
       "name": "xp2_xp7_stability",
       "description": "Re-run stability suite after adjusting aspiration, ordering, LMR and TT policy.",
       "notes": "Apply XP-2, XP-6, XP-3 and XP-7 heuristics before executing this stage.",
-      "uci_options": {
-        "Use 040825 Search": "false"
-      },
       "runs": [
         {
           "label": "startpos_depth18",
@@ -57,9 +51,6 @@
       "name": "xp1_xp8_blitz",
       "description": "Blitz oriented checks with time clamp, late move pruning and selective quiescence.",
       "notes": "Enable XP-1, XP-5 and XP-8 settings before running.",
-      "uci_options": {
-        "Use 040825 Search": "false"
-      },
       "runs": [
         {
           "label": "startpos_movetime2000",
@@ -84,9 +75,6 @@
       "description": "Optional evaluation and root-bias checks triggered when instability is observed.",
       "optional": true,
       "notes": "Run only if logs indicate erratic evaluation swings or root bias.",
-      "uci_options": {
-        "Use 040825 Search": "false"
-      },
       "runs": [
         {
           "label": "evaluation_guard_depth14",

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -28,8 +28,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#include <iomanip>
-#include <random>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -113,27 +111,9 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Move Overhead", Option(10, 0, 5000));
 
-    options.add("BlackTimeFactor", Option(105, 100, 200));
-
     options.add("nodestime", Option(0, 0, 10000));
 
     options.add("Time Buffer", Option(50, 0, 5000));
-
-    // Toggle for using the safer 040825 search settings. Cached in GSearch so
-    // that hot paths do not need to query the option map repeatedly.
-    options.add("Use 040825 Search", Option(true, [](const Option& o) {
-                    GSearch.conservative = bool(o);
-                    return std::nullopt;
-                }));
-
-    options.add("BlackAggression", Option(0, 0, 100, [](const Option& o) {
-                    GSearch.blackAggression = int(o);
-                    return std::nullopt;
-                }));
-
-    // Initialise cached search tuning with the default values of the options
-    GSearch.conservative    = options["Use 040825 Search"];
-    GSearch.blackAggression = options["BlackAggression"];
 
     options.add("UCI_Chess960", Option(false));
 
@@ -198,7 +178,6 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience File", Option("experience.exp", [this](const Option& o) {
                     if ((bool) options["Experience Enabled"])
                         experience.load_async(o);
-                    concurrentExperienceFile.clear();
                     return std::nullopt;
                 }));
 
@@ -211,18 +190,6 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience Book", Option(false));
     options.add("Experience Book Max Moves", Option(100, 1, 100));
     options.add("Experience Book Min Depth", Option(4, 1, 255));
-    options.add("Experience Concurrent", Option(false, [this](const Option&) {
-                    concurrentExperienceFile.clear();
-                    return std::nullopt;
-                }));
-
-    // Optional experimental evaluation tweak that adapts weights based on
-    // simple positional cues. Disabled by default so it does not alter
-    // standard play unless explicitly requested by the user.
-    options.add("Adaptive Style", Option(false, [](const Option& o) {
-                    Eval::set_adaptive_style(bool(o));
-                    return std::nullopt;
-                }));
 
     options.add(  //
       "EvalFile", Option(Eval::EvalFileDefaultNameBig.data(), [this](const Option& o) {
@@ -266,27 +233,7 @@ void Engine::search_clear() {
     Tablebases::release();
 
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
-    {
-        std::string file = options["Experience File"];
-        if ((bool) options["Experience Concurrent"])
-        {
-            if (concurrentExperienceFile.empty())
-            {
-                std::random_device rd;
-                uint64_t           r = (uint64_t(rd()) << 32) ^ rd();
-                std::ostringstream oss;
-                oss << std::hex << std::setfill('0') << std::setw(16) << r;
-                std::string suffix = oss.str();
-                auto        p      = file.find_last_of('.');
-                if (p != std::string::npos)
-                    concurrentExperienceFile = file.substr(0, p) + "-" + suffix + file.substr(p);
-                else
-                    concurrentExperienceFile = file + "-" + suffix;
-            }
-            file = concurrentExperienceFile;
-        }
-        experience.save(file);
-    }
+        experience.save(options["Experience File"]);
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -123,7 +123,6 @@ class Engine {
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
 
-    std::string concurrentExperienceFile;
 };
 
 }  // namespace Stockfish

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -31,7 +31,6 @@
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
 #include "position.h"
-#include "search.h"
 #include "types.h"
 #include "uci.h"
 #include "nnue/nnue_accumulator.h"
@@ -91,54 +90,7 @@ thread_local EvalCacheEntry eval_cache[EVAL_CACHE_SIZE];
 
 namespace {
 
-// Basic positional cues used to slightly bias evaluation depending on the
-// phase of the game. The intent is to provide a light-weight and easily
-// switchable mechanism to alter style without replicating any particular
-// engine's approach.
-struct StyleIndicators {
-    int pressure;  // attackers on the opposing king
-    int shield;    // defenders near our own king
-    int center;    // friendly pieces controlling the central squares
-};
-
-// Collect the above indicators from the current position.
-StyleIndicators gather_indicators(const Position& pos) {
-    StyleIndicators ind{};
-    Square          enemyKing = pos.square<KING>(~pos.side_to_move());
-    Square          ownKing   = pos.square<KING>(pos.side_to_move());
-
-    ind.pressure      = popcount(pos.attackers_to(enemyKing));
-    ind.shield        = popcount(pos.attackers_to(ownKing));
-    Bitboard centerBB = square_bb(SQ_D4) | square_bb(SQ_E4) | square_bb(SQ_D5) | square_bb(SQ_E5);
-    ind.center        = popcount(pos.pieces(pos.side_to_move()) & centerBB);
-    return ind;
-}
-
-// Compute an adjustment based on the indicators and the current evaluation.
-Value adaptive_style_bonus(const StyleIndicators& ind, Value current) {
-    int atkW = current > 50 ? 3 : 1;
-    int defW = current < -50 ? 3 : 1;
-    int balW = 2;
-
-    int bonus = atkW * ind.pressure + balW * ind.center - defW * ind.shield;
-    return Value(bonus);
-}
-
-[[maybe_unused]] Value adaptive_style_bonus(const Position& pos, Value current) {
-    return adaptive_style_bonus(gather_indicators(pos), current);
-}
-
-// Simple tempo bonus favoring the side to move
-Value tempo_bonus(const Position& pos) {
-    return pos.side_to_move() == Color::WHITE ? Value(10) : Value(-10);
-}
-
 }  // namespace
-
-namespace Eval {
-static bool adaptive_style = false;
-void        set_adaptive_style(bool enabled) { adaptive_style = enabled; }
-}  // namespace Eval
 
 // Returns a static, purely materialistic evaluation of the position from
 // the point of view of the side to move. It can be divided by PawnValue to get
@@ -183,17 +135,6 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     bool  smallNet = use_smallnet(pos);
     Value psqt = 0, positional = 0;
-
-    StyleIndicators indicators{};
-    bool             haveIndicators = false;
-    const auto       ensure_indicators = [&]() -> const StyleIndicators& {
-        if (!haveIndicators)
-        {
-            indicators     = gather_indicators(pos);
-            haveIndicators = true;
-        }
-        return indicators;
-    };
 
     if (smallNet)
     {
@@ -263,31 +204,7 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;
 
-    v += tempo_bonus(pos);
-
-    if (pos.side_to_move() == Color::BLACK && GSearch.blackAggression > 0)
-    {
-        const StyleIndicators& ind = ensure_indicators();
-        const int              mobilityBonus       = ind.center;
-        const int              kingAttackPotential = ind.pressure;
-
-        v += (GSearch.blackAggression * mobilityBonus) / 100;
-        v += (GSearch.blackAggression * kingAttackPotential) / 100;
-    }
-
     // Guarantee evaluation does not hit the tablebase range
-    v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
-
-    // Optional style-based tweak which slightly biases the score depending on
-    // basic positional indicators. This does not aim to implement any specific
-    // style but merely demonstrates how evaluation terms can be combined.
-    if (adaptive_style)
-    {
-        const StyleIndicators& ind = ensure_indicators();
-        v += adaptive_style_bonus(ind, Value(v));
-        v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
-    }
-
     v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
 
     // Store result and the optimism used for the final `v`.
@@ -343,26 +260,6 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
     Value v = psqt + positional;
     v       = pos.side_to_move() == Color::WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
-
-    if (pos.side_to_move() == Color::BLACK && GSearch.blackAggression > 0)
-    {
-        const StyleIndicators ind                 = gather_indicators(pos);
-        const int              mobilityBonus       = ind.center;
-        const int              kingAttackPotential = ind.pressure;
-        const Value            mobilityAdjustment = Value((GSearch.blackAggression * mobilityBonus) / 100);
-        const Value            kingAttackAdjustment =
-          Value((GSearch.blackAggression * kingAttackPotential) / 100);
-
-        const Value displayMobility =
-          pos.side_to_move() == Color::WHITE ? mobilityAdjustment : -mobilityAdjustment;
-        const Value displayKingAttack =
-          pos.side_to_move() == Color::WHITE ? kingAttackAdjustment : -kingAttackAdjustment;
-
-        ss << "Black aggression (mobility)      "
-           << 0.01 * UCIEngine::to_cp(displayMobility, pos) << " (white side)\n";
-        ss << "Black aggression (king attack)   "
-           << 0.01 * UCIEngine::to_cp(displayKingAttack, pos) << " (white side)\n";
-    }
 
     v = evaluate(networks, pos, accumulators, *caches, VALUE_ZERO);
     v = pos.side_to_move() == Color::WHITE ? v : -v;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -51,9 +51,6 @@ Value evaluate(const NNUE::Networks&          networks,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
-
-// Toggle for optional style-based evaluation adjustments.
-void set_adaptive_style(bool enabled);
 }  // namespace Eval
 
 }  // namespace Stockfish

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -57,9 +57,6 @@ namespace Stockfish {
 
 namespace TB = Tablebases;
 
-// Global search tuning instance
-SearchTuning GSearch;
-
 void syzygy_extend_pv(const OptionsMap&            options,
                       const Search::LimitsType&    limits,
                       Stockfish::Position&         pos,
@@ -319,15 +316,8 @@ void Search::Worker::start_searching() {
         return;
     }
 
-    int evaluationCp = 0;
-    {
-        Value currentEval = evaluate(rootPos);
-        if (is_valid(currentEval))
-            evaluationCp = UCIEngine::to_cp(currentEval, rootPos);
-    }
-
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
-                            main_manager()->originalTimeAdjust, evaluationCp);
+                            main_manager()->originalTimeAdjust);
     tt.new_search();
 
     Move preferredMove = Move::none();

--- a/src/search.h
+++ b/src/search.h
@@ -44,15 +44,6 @@
 
 namespace Stockfish {
 
-// Global search tuning flags cached at engine start to avoid repeated
-// option lookups during the search.
-struct SearchTuning {
-    bool conservative    = true;  // Mirrors the "Use 040825 Search" UCI option
-    int  blackAggression = 0;     // Cached "BlackAggression" UCI option value
-};
-
-extern SearchTuning GSearch;
-
 // Different node types, used as a template parameter
 enum NodeType {
     NonPV,

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -28,8 +28,6 @@
 
 namespace Stockfish {
 
-TimeModel GTime;
-
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
 
@@ -50,8 +48,7 @@ void TimeManagement::init(Search::LimitsType& limits,
                           Color               us,
                           int                 ply,
                           const OptionsMap&   options,
-                          double&             originalTimeAdjust,
-                          int                 evaluationCp) {
+                          double&             originalTimeAdjust) {
     TimePoint npmsec = TimePoint(options["nodestime"]);
 
     // If we have no time, we don't need to fully initialize TM.
@@ -64,9 +61,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (limits.time[usIdx] == 0)
         return;
 
-    TimePoint moveOverhead =
-      GSearch.conservative ? TimePoint(GTime.move_overhead_ms)
-                           : TimePoint(options["Move Overhead"]);
+    TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 
     // optScale is a percentage of available time to use for the current move.
     // maxScale is a multiplier applied to optimumTime.
@@ -141,41 +136,19 @@ void TimeManagement::init(Search::LimitsType& limits,
     maximumTime =
       TimePoint(std::min(0.825179 * limits.time[usIdx] - moveOverhead, maxScale * optimumTime)) - 10;
 
-    if (GSearch.conservative)
-    {
-        int64_t time_left_ms = limits.time[usIdx];
-        int64_t inc_ms       = limits.inc[usIdx];
-
-        int64_t base         = std::max<int64_t>(GTime.min_think_ms, optimumTime);
-        int64_t dyn_overhead = GTime.move_overhead_ms;
-        if (inc_ms < 200)
-            dyn_overhead += 10;
-
-        int64_t budget = std::max<int64_t>(GTime.min_think_ms, base - dyn_overhead);
-        budget =
-          std::min<int64_t>(budget,
-                            std::max<int64_t>(0, time_left_ms - GTime.panic_margin_ms));
-        optimumTime = maximumTime = TimePoint(budget);
-    }
-
-    if (us == Color::BLACK && evaluationCp <= -50)
-    {
-        double factor = options["BlackTimeFactor"] / 100.0;
-        optimumTime   = TimePoint(optimumTime * factor);
-        maximumTime   = TimePoint(maximumTime * factor);
-        maximumTime   = std::max(maximumTime, optimumTime);
-    }
-
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
 
-    TimePoint minimumThinkingTime =
-      GSearch.conservative ? TimePoint(GTime.min_think_ms) : TimePoint(0);
-    TimePoint safetyBuffer =
-      GSearch.conservative ? TimePoint(GTime.panic_margin_ms)
-                           : TimePoint(options["Time Buffer"]);
-    optimumTime                   = std::max(optimumTime, minimumThinkingTime);
-    maximumTime                   = std::max(maximumTime - safetyBuffer, minimumThinkingTime);
+    TimePoint safetyBuffer = TimePoint(options["Time Buffer"]);
+    if (safetyBuffer > 0)
+    {
+        if (maximumTime > safetyBuffer)
+            maximumTime -= safetyBuffer;
+        else
+            maximumTime = TimePoint(0);
+    }
+
+    maximumTime = std::max(maximumTime, optimumTime);
 }
 
 }  // namespace Stockfish

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -25,16 +25,6 @@
 
 namespace Stockfish {
 
-// Configuration used by the conservative time manager when the
-// "Use 040825 Search" option is enabled.
-struct TimeModel {
-    int64_t min_think_ms     = 30;  // Minimum thinking time per move
-    int64_t move_overhead_ms = 20;  // Static overhead to subtract
-    int64_t panic_margin_ms  = 80;  // Time reserved to avoid flagging
-};
-
-extern TimeModel GTime;
-
 class OptionsMap;
 enum class Color : int8_t;
 
@@ -50,8 +40,7 @@ class TimeManagement {
               Color               us,
               int                 ply,
               const OptionsMap&   options,
-              double&             originalTimeAdjust,
-              int                 evaluationCp);
+              double&             originalTimeAdjust);
 
     TimePoint optimum() const;
     TimePoint maximum() const;


### PR DESCRIPTION
## Summary
- remove custom UCI options (BlackTimeFactor, Use 040825 Search, BlackAggression, Adaptive Style, Experience Concurrent) and simplify experience saving
- align time management and evaluation paths with Stockfish 17.1 behaviour while retaining Revolution experience/polyglot support
- update documentation to drop references to the removed options

## Testing
- make build ARCH=x86-64-sse41-popcnt -j

------
https://chatgpt.com/codex/tasks/task_e_68c8ab3edcf08327adde89569f7dbb5d