### PR TITLE
Align TT packing, update NNUE defaults, and adjust low-ply history

### DIFF
--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -10,7 +10,7 @@ def run_bench(engine, name, value):
     proc = subprocess.Popen(
         [engine], cwd=engine_dir, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
     )
-    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-1c0000000000.nnue\n"
+    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-ae6a388e4a1a.nnue\n"
     cmd += f"setoption name {name} value {int(value)}\nbench\nquit\n"
     out, _ = proc.communicate(cmd)
     for line in out.splitlines():

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // names or the location where these constants are defined, as they are used in
 // the Makefile/Fishtest.
-inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-1c0000000000.nnue";
-inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-37f18f62d772.nnue";
+inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-ae6a388e4a1a.nnue";
+inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-baff1ede1f90.nnue";
 
 namespace NNUE {
 struct Networks;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -190,7 +190,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
                 m.value = (*mainHistory)[static_cast<int>(us)][m.from_to()] +
                           (*continuationHistory[0])[pc][to];
                 if (ply < LOW_PLY_HISTORY_SIZE)
-                    m.value += 2 * (*lowPlyHistory)[ply][m.from_to()] / (1 + ply);
+                    m.value += (*lowPlyHistory)[ply][m.from_to()];
             }
         }
     }

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -46,8 +46,8 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, "nn-1c0000000000.nnue");
-INCBIN(EmbeddedNNUESmall, "nn-37f18f62d772.nnue");
+INCBIN(EmbeddedNNUEBig, "nn-ae6a388e4a1a.nnue");
+INCBIN(EmbeddedNNUESmall, "nn-baff1ede1f90.nnue");
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
@@ -58,9 +58,9 @@ const unsigned int         gEmbeddedNNUESmallSize    = 1;
 #endif
 
 static_assert(Stockfish::Eval::EvalFileDefaultNameBig
-              == std::string_view{"nn-1c0000000000.nnue"});
+              == std::string_view{"nn-ae6a388e4a1a.nnue"});
 static_assert(Stockfish::Eval::EvalFileDefaultNameSmall
-              == std::string_view{"nn-37f18f62d772.nnue"});
+              == std::string_view{"nn-baff1ede1f90.nnue"});
 
 namespace {
 

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <utility>
 
 #include "memory.h"
 #include "misc.h"
@@ -31,6 +32,41 @@
 
 namespace Stockfish {
 
+
+namespace {
+
+struct PackedEntry
+{
+    int16_t value16;
+    uint8_t bound;
+};
+
+PackedEntry pack_entry(Value value, Bound bound)
+{
+    // All valid scores fit into 16 bits once we have adjusted mates relative to ply.
+    assert(value >= -VALUE_NONE && value <= VALUE_NONE);
+    assert(bound >= Bound::BOUND_NONE && bound <= Bound::BOUND_EXACT);
+
+    PackedEntry packed{static_cast<int16_t>(value), static_cast<uint8_t>(bound)};
+
+    if (!is_valid(value))
+        packed.bound = static_cast<uint8_t>(Bound::BOUND_NONE);
+
+    return packed;
+}
+
+std::pair<Value, Bound> unpack_entry(int16_t packedValue, uint8_t bound)
+{
+    Value v    = Value(packedValue);
+    Bound type = static_cast<Bound>(bound & 0x3);
+
+    if (!is_valid(v))
+        type = Bound::BOUND_NONE;
+
+    return {v, type};
+}
+
+}  // namespace
 
 // TTEntry struct is the 10 bytes transposition table entry, defined as below:
 //
@@ -46,10 +82,12 @@ namespace Stockfish {
 // These fields are in the same order as accessed by TT::probe(), since memory is fastest sequentially.
 // Equally, the store order in save() matches this order.
 
-TTData TTEntry::read() const {
-    return TTData{Move(move16),           Value(value16),          Value(eval16),
-                  Depth(depth8 + DEPTH_ENTRY_OFFSET),
-                  Bound(genBound8 & 0x3), bool(genBound8 & 0x4), key16};
+TTData TTEntry::read() const
+{
+    auto [value, bound] = unpack_entry(value16, genBound8);
+
+    return TTData{Move(move16), value, Value(eval16),
+                  Depth(depth8 + DEPTH_ENTRY_OFFSET), bound, bool(genBound8 & 0x4), key16};
 }
 
 // `genBound8` is where most of the details are. We use the following constants to manipulate 5 leading generation bits
@@ -85,10 +123,13 @@ void TTEntry::save(
         assert(d > DEPTH_ENTRY_OFFSET);
         assert(d < 256 + DEPTH_ENTRY_OFFSET);
 
-        key16     = uint16_t(k);
-        depth8    = uint8_t(d - DEPTH_ENTRY_OFFSET);
-          genBound8 = uint8_t(generation8 | uint8_t(pv) << 2 | static_cast<uint8_t>(b));
-        value16   = int16_t(v);
+        key16  = uint16_t(k);
+        depth8 = uint8_t(d - DEPTH_ENTRY_OFFSET);
+
+        const PackedEntry packed = pack_entry(v, b);
+
+        genBound8 = uint8_t(generation8 | uint8_t(pv) << 2 | packed.bound);
+        value16   = packed.value16;
         eval16    = int16_t(ev);
     }
       else if (depth8 + DEPTH_ENTRY_OFFSET >= 5

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.42 160925"
+    #define ENGINE_NAME "revolution-dev 120925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- ensure transposition table entries pack mate scores and bounds consistently before writing and unpack them when probed
- simplify the low-ply history bonus for evasions to follow latest Stockfish changes
- refresh the default NNUE network identifiers and tuner script to the latest dev nets and bump the engine name to "revolution-dev 120925"

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c546f7dc83278a240a3639186c55