### PR TITLE
Add DEBUG logging for evaluations

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -217,6 +217,11 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     e.last_optimism = optimism;
     e.v             = v;
 
+#ifdef DEBUG
+    sync_cout << "info string dbg eval stm="
+              << (pos.side_to_move() == Color::WHITE ? 'w' : 'b') << " value=" << v << sync_endl;
+#endif
+
     return v;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -511,6 +511,12 @@ void Search::Worker::iterative_deepening() {
     while (++rootDepth < MAX_PLY && !threads.stop
            && !(limits.depth && mainThread && rootDepth > limits.depth))
     {
+#ifdef DEBUG
+        const Value dbgRootEval = evaluate(rootPos);
+        sync_cout << "info string dbg root depth=" << int(rootDepth)
+                  << " stm=" << (rootPos.side_to_move() == Color::WHITE ? 'w' : 'b')
+                  << " value=" << dbgRootEval << sync_endl;
+#endif
         // Age out PV variability metric
         if (mainThread)
             totBestMoveChanges /= 2;


### PR DESCRIPTION
## Summary
- guard the evaluation debug output in `Eval::evaluate()` behind DEBUG so it only appears in debug builds
- add a DEBUG-only log at the start of each root iteration to show the recalculated static evaluation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca7bfd4e3083279522ec2495d3f90b