### PR TITLE
Reduce bench logging during PGO run

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -247,12 +247,13 @@ void UCIEngine::bench(std::istream& args) {
     std::string token;
     uint64_t    num, nodes = 0, cnt = 1;
     uint64_t    nodesSearched = 0;
-    const auto& options       = engine.get_options();
 
-    engine.set_on_update_full([&](const auto& i) {
-        nodesSearched = i.nodes;
-        on_update_full(i, options["UCI_ShowWDL"]);
-    });
+    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+
+    engine.set_on_iter([](const auto&) {});
+    engine.set_on_update_no_moves([](const auto&) {});
+    engine.set_on_bestmove([](const auto&, const auto&) {});
+    engine.set_on_verify_networks([](const auto&) {});
 
     std::vector<std::string> list = Benchmark::setup_bench(engine.fen(), args);
 
@@ -308,8 +309,7 @@ void UCIEngine::bench(std::istream& args) {
               << "\nNodes searched  : " << nodes    //
               << "\nNodes/second    : " << 1000 * nodes / elapsed << std::endl;
 
-    // reset callback, to not capture a dangling reference to nodesSearched
-    engine.set_on_update_full([&](const auto& i) { on_update_full(i, options["UCI_ShowWDL"]); });
+    init_search_update_listeners();
 }
 
 void UCIEngine::benchmark(std::istream& args) {


### PR DESCRIPTION
## Summary
- silence the bench command's search callbacks so the PGO benchmark no longer floods the log
- restore the default search listeners once bench has finished running

## Testing
- `make -C src build ARCH=x86-64`


------
https://chatgpt.com/codex/tasks/task_e_68ca941eced08327841e106d3a3f5a5d