### PR TITLE
Ensure architecture name and Windows suffix in engine id

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -31,7 +31,7 @@ set_arch_loongarch64() {
   if check_flags 'lasx'; then
     true_arch='loongarch64-lasx'
   elif check_flags 'lsx'; then
-    true_arch='lonngarch64-lsx'
+    true_arch='loongarch64-lsx'
   else
     true_arch='loongarch64'
   fi

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -121,6 +121,12 @@ std::string engine_version_info() {
 
     std::string fullName = ENGINE_NAME;
 
+#if defined(_WIN32)
+    constexpr std::string_view kExecutableExtension = ".exe";
+#else
+    constexpr std::string_view kExecutableExtension = "";
+#endif
+
 #if defined(ARCH)
     constexpr std::string_view arch = stringify(ARCH);
 
@@ -132,6 +138,14 @@ std::string engine_version_info() {
         fullName.append(arch);
     }
 #endif
+
+    if (!kExecutableExtension.empty()
+        && (fullName.size() < kExecutableExtension.size()
+            || fullName.compare(fullName.size() - kExecutableExtension.size(),
+                                kExecutableExtension.size(),
+                                kExecutableExtension)
+                 != 0))
+        fullName.append(kExecutableExtension);
 
     return fullName;
 }


### PR DESCRIPTION
## Summary
- append the architecture-specific executable suffix when reporting the engine name on Windows so GUIs display the full binary identity
- fix the loongarch LSX autodetection typo so native builds pick the proper architecture string

## Testing
- make build ARCH=x86-64-sse41-popcnt COMP=gcc -j4

------
https://chatgpt.com/codex/tasks/task_e_68caa18885e08327b5e3264323ff1dd3