### PR TITLE
Fix optimism initialization and refresh engine version strings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution-dev_160925.exe
+        EXE = revolution-2.45-dev-180925.exe
 else
-        EXE = revolution-dev_160925
+        EXE = revolution-2.45-dev-180925
 endif
 
 ### Installation dir definitions
@@ -856,11 +856,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution 4.40 170925"
+#- ENGINE_NAME : "revolution 2.45 dev-180925"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution 4.40 170925" ENGINE_BUILD_DATE = 20250913
-ENGINE_NAME        ?= revolution 4.40 170925
+#make ENGINE_NAME = "revolution 2.45 dev-180925" ENGINE_BUILD_DATE = 20250918
+ENGINE_NAME        ?= revolution 2.45 dev-180925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -116,7 +116,7 @@ class Logger {
 
 // Returns the full name of the current Revolution version. Append the
 // compilation architecture (when available) so GUIs show a fully qualified
-// identifier such as "revolution 4.40 170925 x86-64-sse41-popcnt".
+// identifier such as "revolution 2.45 dev-180925 x86-64-sse41-popcnt".
 std::string engine_version_info() {
 
     std::string fullName = ENGINE_NAME;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,6 +845,9 @@ void Search::Worker::clear() {
     minorPieceCorrectionHistory.fill(0);
     nonPawnCorrectionHistory.fill(0);
 
+    for (Value& o : optimism)
+        o = VALUE_ZERO;
+
     ttMoveHistory = 0;
 
     for (auto& to : continuationCorrectionHistory)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -119,7 +119,7 @@ void UCIEngine::loop() {
         else if (token == "uci")
         {
             // Force a stable, explicit UCI name so GUIs show the architecture-aware
-            // identifier (for example "revolution 4.40 170925 x86-64-sse41-popcnt").
+            // identifier (for example "revolution 2.45 dev-180925 x86-64-sse41-popcnt").
             sync_cout_start();
             std::cout
               << "id name " << engine_version_info() << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 4.40 170925"
+    #define ENGINE_NAME "revolution 2.45 dev-180925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- zero-initialize each worker's optimism counters when resetting the search state so evaluation scaling starts from a known baseline
- update the default engine name/version strings and produced binary name to `revolution 2.45 dev-180925` for consistent reporting in builds and UCI output

## Testing
- `make -C src build ARCH=x86-64`
- `./src/revolution-2.45-dev-180925 bench 64 1 13` *(terminated early once output stability was verified)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf0298a0c8327b49ca9f1496be43c