### PR TITLE
Restore Stockfish green NNUE defaults

### DIFF
--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -10,7 +10,7 @@ def run_bench(engine, name, value):
     proc = subprocess.Popen(
         [engine], cwd=engine_dir, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
     )
-    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-ae6a388e4a1a.nnue\n"
+    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-1c0000000000.nnue\n"
     cmd += f"setoption name {name} value {int(value)}\nbench\nquit\n"
     out, _ = proc.communicate(cmd)
     for line in out.splitlines():

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // names or the location where these constants are defined, as they are used in
 // the Makefile/Fishtest.
-inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-ae6a388e4a1a.nnue";
-inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-baff1ede1f90.nnue";
+inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-1c0000000000.nnue";
+inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-37f18f62d772.nnue";
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -46,8 +46,8 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, "nn-ae6a388e4a1a.nnue");
-INCBIN(EmbeddedNNUESmall, "nn-baff1ede1f90.nnue");
+INCBIN(EmbeddedNNUEBig, "nn-1c0000000000.nnue");
+INCBIN(EmbeddedNNUESmall, "nn-37f18f62d772.nnue");
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
@@ -58,9 +58,9 @@ const unsigned int         gEmbeddedNNUESmallSize    = 1;
 #endif
 
 static_assert(Stockfish::Eval::EvalFileDefaultNameBig
-              == std::string_view{"nn-ae6a388e4a1a.nnue"});
+              == std::string_view{"nn-1c0000000000.nnue"});
 static_assert(Stockfish::Eval::EvalFileDefaultNameSmall
-              == std::string_view{"nn-baff1ede1f90.nnue"});
+              == std::string_view{"nn-37f18f62d772.nnue"});
 
 namespace {
 


### PR DESCRIPTION
## Summary
- switch the default big and small NNUE network names back to the Stockfish-vetted green networks
- update the embedded network declarations and SPSA helper script to reference the restored defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc03ff620c8327be3dd2f1716993e4