### PR TITLE
Fix thread initialization capture in start_thinking

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -274,6 +274,10 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 
     Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
 
+    const std::string fen        = pos.fen();
+    const bool        isChess960 = pos.is_chess960();
+    const StateInfo   rootState  = setupStates->back();
+
     // After ownership transfer 'states' becomes empty, so if we stop the search
     // and call 'go' again without setting a new position states.get() == nullptr.
     assert(states.get() || setupStates.get());
@@ -286,18 +290,25 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     // be deduced from a fen string, so set() clears them and they are set from
     // setupStates->back() later. The rootState is per thread, earlier states are
     // shared since they are read-only.
-    for (auto&& th : threads)
+    for (auto& threadPtr : threads)
     {
-        th->run_custom_job([&]() {
-            th->worker->reset_metrics();
-            th->worker->limits = limits;
-            th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
-              th->worker->bestMoveChanges          = 0;
-            th->worker->rootDepth = th->worker->completedDepth = 0;
-            th->worker->rootMoves                              = rootMoves;
-            th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
-            th->worker->rootState = setupStates->back();
-            th->worker->tbConfig  = tbConfig;
+        Thread* thread = threadPtr.get();
+        thread->run_custom_job([thread,
+                                &limits,
+                                &rootMoves,
+                                &fen,
+                                isChess960,
+                                rootState,
+                                tbConfig]() {
+            thread->worker->reset_metrics();
+            thread->worker->limits = limits;
+            thread->worker->nodes = thread->worker->tbHits = thread->worker->nmpMinPly =
+              thread->worker->bestMoveChanges             = 0;
+            thread->worker->rootDepth = thread->worker->completedDepth = 0;
+            thread->worker->rootMoves                              = rootMoves;
+            thread->worker->rootPos.set(fen, isChess960, &thread->worker->rootState);
+            thread->worker->rootState = rootState;
+            thread->worker->tbConfig  = tbConfig;
         });
     }
 


### PR DESCRIPTION
## Summary
- reuse the current position FEN and state when preparing threads for a new search
- capture each Thread pointer by value so every worker updates its own state instead of racing on the last element

## Testing
- `make build -j2` *(fails: `timeman.o: file not recognized: file format not recognized`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc08bf7c8c8327a24ff470453439d7