### PR TITLE
Fix bench crash when setupStates is missing

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -276,14 +276,17 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 
     const std::string fen        = pos.fen();
     const bool        isChess960 = pos.is_chess960();
-    const StateInfo   rootState  = setupStates->back();
-
-    // After ownership transfer 'states' becomes empty, so if we stop the search
-    // and call 'go' again without setting a new position states.get() == nullptr.
-    assert(states.get() || setupStates.get());
 
     if (states.get())
         setupStates = std::move(states);  // Ownership transfer, states is now empty
+    else if (!setupStates)
+        setupStates = std::make_unique<std::deque<StateInfo>>();
+
+    // After ownership transfer 'states' becomes empty, so if we stop the search
+    // and call 'go' again without setting a new position states.get() == nullptr.
+    assert(setupStates && !setupStates->empty());
+
+    const StateInfo rootState = setupStates->back();
 
     // We use Position::set() to set root position across threads. But there are
     // some StateInfo fields (previous, pliesFromNull, capturedPiece) that cannot


### PR DESCRIPTION
## Summary
- ensure ThreadPool::start_thinking transfers the state stack before dereferencing it so that the bench command no longer segfaults when `states` is empty

## Testing
- ./revolution-2.45-dev-180925 bench 64 1 500 default nodes > bench-asan.log 2>&1
- ./revolution-2.45-dev-180925 bench 64 1 500 default nodes > bench-release.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68cc0df761f08327a7a0eb638555db64