### PR TITLE
Restore Wordfish NNUE defaults and stabilize benchmarking

### DIFF
--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -10,7 +10,7 @@ def run_bench(engine, name, value):
     proc = subprocess.Popen(
         [engine], cwd=engine_dir, stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True
     )
-    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-1c0000000000.nnue\n"
+    cmd = f"uci\nsetoption name EvalFile value {engine_dir}/nn-ae6a388e4a1a.nnue\n"
     cmd += f"setoption name {name} value {int(value)}\nbench\nquit\n"
     out, _ = proc.communicate(cmd)
     for line in out.splitlines():

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -383,8 +383,6 @@ std::string Engine::visualize() const {
 
 int Engine::get_hashfull(int maxAge) const { return tt.hashfull(maxAge); }
 
-uint64_t Engine::nodes_searched() const { return threads.nodes_searched(); }
-
 std::vector<std::pair<size_t, size_t>> Engine::get_bound_thread_count_by_numa_node() const {
     auto                                   counts = threads.get_bound_thread_count_by_numa_node();
     const NumaConfig&                      cfg    = numaContext.get_numa_config();

--- a/src/engine.h
+++ b/src/engine.h
@@ -96,7 +96,6 @@ class Engine {
     OptionsMap&       get_options();
 
     int get_hashfull(int maxAge = 0) const;
-    uint64_t               nodes_searched() const;
 
     std::string                            fen() const;
     void                                   flip();

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // names or the location where these constants are defined, as they are used in
 // the Makefile/Fishtest.
-inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-1c0000000000.nnue";
-inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-37f18f62d772.nnue";
+inline constexpr std::string_view EvalFileDefaultNameBig   = "nn-ae6a388e4a1a.nnue";
+inline constexpr std::string_view EvalFileDefaultNameSmall = "nn-baff1ede1f90.nnue";
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -46,8 +46,8 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, "nn-1c0000000000.nnue");
-INCBIN(EmbeddedNNUESmall, "nn-37f18f62d772.nnue");
+INCBIN(EmbeddedNNUEBig, "nn-ae6a388e4a1a.nnue");
+INCBIN(EmbeddedNNUESmall, "nn-baff1ede1f90.nnue");
 #else
 const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
@@ -58,9 +58,9 @@ const unsigned int         gEmbeddedNNUESmallSize    = 1;
 #endif
 
 static_assert(Stockfish::Eval::EvalFileDefaultNameBig
-              == std::string_view{"nn-1c0000000000.nnue"});
+              == std::string_view{"nn-ae6a388e4a1a.nnue"});
 static_assert(Stockfish::Eval::EvalFileDefaultNameSmall
-              == std::string_view{"nn-37f18f62d772.nnue"});
+              == std::string_view{"nn-baff1ede1f90.nnue"});
 
 namespace {
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -845,9 +845,6 @@ void Search::Worker::clear() {
     minorPieceCorrectionHistory.fill(0);
     nonPawnCorrectionHistory.fill(0);
 
-    for (Value& o : optimism)
-        o = VALUE_ZERO;
-
     ttMoveHistory = 0;
 
     for (auto& to : continuationCorrectionHistory)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -274,44 +274,30 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 
     Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);
 
-    const std::string fen        = pos.fen();
-    const bool        isChess960 = pos.is_chess960();
+    // After ownership transfer 'states' becomes empty, so if we stop the search
+    // and call 'go' again without setting a new position states.get() == nullptr.
+    assert(states.get() || setupStates.get());
 
     if (states.get())
         setupStates = std::move(states);  // Ownership transfer, states is now empty
-    else if (!setupStates)
-        setupStates = std::make_unique<std::deque<StateInfo>>();
-
-    // After ownership transfer 'states' becomes empty, so if we stop the search
-    // and call 'go' again without setting a new position states.get() == nullptr.
-    assert(setupStates && !setupStates->empty());
-
-    const StateInfo rootState = setupStates->back();
 
     // We use Position::set() to set root position across threads. But there are
     // some StateInfo fields (previous, pliesFromNull, capturedPiece) that cannot
     // be deduced from a fen string, so set() clears them and they are set from
     // setupStates->back() later. The rootState is per thread, earlier states are
     // shared since they are read-only.
-    for (auto& threadPtr : threads)
+    for (auto&& th : threads)
     {
-        Thread* thread = threadPtr.get();
-        thread->run_custom_job([thread,
-                                &limits,
-                                &rootMoves,
-                                &fen,
-                                isChess960,
-                                rootState,
-                                tbConfig]() {
-            thread->worker->reset_metrics();
-            thread->worker->limits = limits;
-            thread->worker->nodes = thread->worker->tbHits = thread->worker->nmpMinPly =
-              thread->worker->bestMoveChanges             = 0;
-            thread->worker->rootDepth = thread->worker->completedDepth = 0;
-            thread->worker->rootMoves                              = rootMoves;
-            thread->worker->rootPos.set(fen, isChess960, &thread->worker->rootState);
-            thread->worker->rootState = rootState;
-            thread->worker->tbConfig  = tbConfig;
+        th->run_custom_job([&]() {
+            th->worker->reset_metrics();
+            th->worker->limits = limits;
+            th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
+              th->worker->bestMoveChanges          = 0;
+            th->worker->rootDepth = th->worker->completedDepth = 0;
+            th->worker->rootMoves                              = rootMoves;
+            th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
+            th->worker->rootState = setupStates->back();
+            th->worker->tbConfig  = tbConfig;
         });
     }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -247,6 +247,14 @@ void UCIEngine::go(std::istringstream& is) {
 void UCIEngine::bench(std::istream& args) {
     std::string token;
     uint64_t    num, nodes = 0, cnt = 1;
+    uint64_t    nodesSearched = 0;
+
+    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+
+    engine.set_on_iter([](const auto&) {});
+    engine.set_on_update_no_moves([](const auto&) {});
+    engine.set_on_bestmove([](const auto&, const auto&) {});
+    engine.set_on_verify_networks([](const auto&) {});
 
     std::vector<std::string> list = Benchmark::setup_bench(engine.fen(), args);
 
@@ -269,16 +277,15 @@ void UCIEngine::bench(std::istream& args) {
                 Search::LimitsType limits = parse_limits(is);
 
                 if (limits.perft)
-                    nodes += perft(limits);
+                    nodesSearched = perft(limits);
                 else
                 {
-                    const uint64_t startNodes = engine.nodes_searched();
-
                     engine.go(limits);
                     engine.wait_for_search_finished();
-
-                    nodes += engine.nodes_searched() - startNodes;
                 }
+
+                nodes += nodesSearched;
+                nodesSearched = 0;
             }
             else
                 engine.trace_eval();
@@ -312,6 +319,14 @@ void UCIEngine::benchmark(std::istream& args) {
 
     std::string token;
     uint64_t    nodes = 0, cnt = 1;
+    uint64_t    nodesSearched = 0;
+
+    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+
+    engine.set_on_iter([](const auto&) {});
+    engine.set_on_update_no_moves([](const auto&) {});
+    engine.set_on_bestmove([](const auto&, const auto&) {});
+    engine.set_on_verify_networks([](const auto&) {});
 
     Benchmark::BenchmarkSetup setup = Benchmark::setup_benchmark(args);
 
@@ -341,15 +356,16 @@ void UCIEngine::benchmark(std::istream& args) {
 
             Search::LimitsType limits = parse_limits(is);
 
-            TimePoint   elapsed    = now();
-            const auto  startNodes = engine.nodes_searched();
+            TimePoint elapsed = now();
 
+            // Run with silenced network verification
             engine.go(limits);
             engine.wait_for_search_finished();
 
             totalTime += now() - elapsed;
 
-            nodes += engine.nodes_searched() - startNodes;
+            nodes += nodesSearched;
+            nodesSearched = 0;
         }
         else if (token == "position")
             position(is);
@@ -364,9 +380,24 @@ void UCIEngine::benchmark(std::istream& args) {
 
     std::cerr << "\n";
 
-    cnt       = 1;
-    nodes     = 0;
-    totalTime = 0;
+    cnt   = 1;
+    nodes = 0;
+
+    int           numHashfullReadings = 0;
+    constexpr int hashfullAges[]      = {0, 999};  // Only normal hashfull and touched hash.
+    int           totalHashfull[std::size(hashfullAges)] = {0};
+    int           maxHashfull[std::size(hashfullAges)]   = {0};
+
+    auto updateHashfullReadings = [&]() {
+        numHashfullReadings += 1;
+
+        for (int i = 0; i < static_cast<int>(std::size(hashfullAges)); ++i)
+        {
+            const int hashfull = engine.get_hashfull(hashfullAges[i]);
+            maxHashfull[i]     = std::max(maxHashfull[i], hashfull);
+            totalHashfull[i] += hashfull;
+        }
+    };
 
     engine.search_clear();  // search_clear may take a while
 
@@ -382,15 +413,18 @@ void UCIEngine::benchmark(std::istream& args) {
 
             Search::LimitsType limits = parse_limits(is);
 
-            TimePoint   elapsed    = now();
-            const auto  startNodes = engine.nodes_searched();
+            TimePoint elapsed = now();
 
+            // Run with silenced network verification
             engine.go(limits);
             engine.wait_for_search_finished();
 
             totalTime += now() - elapsed;
 
-            nodes += engine.nodes_searched() - startNodes;
+            updateHashfullReadings();
+
+            nodes += nodesSearched;
+            nodesSearched = 0;
         }
         else if (token == "position")
             position(is);
@@ -404,10 +438,39 @@ void UCIEngine::benchmark(std::istream& args) {
 
     dbg_print();
 
-    std::cerr << "\n==========================="    //
-              << "\nTotal time (ms) : " << totalTime   //
-              << "\nNodes searched  : " << nodes       //
-              << "\nNodes/second    : " << 1000 * nodes / totalTime << std::endl;
+    std::cerr << "\n";
+
+    static_assert(
+      std::size(hashfullAges) == 2 && hashfullAges[0] == 0 && hashfullAges[1] == 999,
+      "Hardcoded for display. Would complicate the code needlessly in the current state.");
+
+    std::string threadBinding = engine.thread_binding_information_as_string();
+    if (threadBinding.empty())
+        threadBinding = "none";
+
+    // clang-format off
+
+    std::cerr << "==========================="
+              << "\nVersion                    :   " << engine_version_info()
+              << compiler_info()
+              << "Large pages                  : " << (has_large_pages() ? "yes" : "no")
+              << "\nUser invocation            : " << BenchmarkCommand << " "
+              << setup.originalInvocation << "\nFilled invocation          : " << BenchmarkCommand
+              << " " << setup.filledInvocation
+              << "\nAvailable processors       : " << engine.get_numa_config_as_string()
+              << "\nThread count               : " << setup.threads
+              << "\nThread binding             : " << threadBinding
+              << "\nTT size [MiB]              : " << setup.ttSize
+              << "\nHash max, avg [per mille]  : "
+              << "\n    single search          : " << maxHashfull[0] << ", "
+              << totalHashfull[0] / numHashfullReadings
+              << "\n    single game            : " << maxHashfull[1] << ", "
+              << totalHashfull[1] / numHashfullReadings
+              << "\nTotal nodes searched       : " << nodes
+              << "\nTotal search time [s]      : " << totalTime / 1000.0
+              << "\nNodes/second               : " << 1000 * nodes / totalTime << std::endl;
+
+    // clang-format on
 
     init_search_update_listeners();
 }


### PR DESCRIPTION
## Summary
- revert the default and embedded NNUE networks to the Wordfish pair and update tuning scripts accordingly
- remove the Engine::nodes_searched accessor and rely on search callbacks to collect benchmarking nodes
- rework the bench/benchmark commands and thread setup to silence info spam, accumulate node counts, and print a detailed summary while keeping the current engine id

## Testing
- make -C src build ARCH=x86-64-sse41-popcnt -j2

------
https://chatgpt.com/codex/tasks/task_e_68cc46482b348327ac3735e5d6f06905