### PR TITLE
Align Revolution 2.45 identification and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.45] - 2025-09-18
+### Changed
+- Updated engine identifier to "revolution v.2.45 180925" for consistent UCI naming across Fritz 20, Cutechess, and dedicated hardware.
+- Documented the two embedded NNUE evaluation files included with the engine to simplify deployment.
+
 ## [1.2.0-dev] - 2025-09-07
 ### Added
 - UCI option `Time Buffer` to reserve time on each move.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Revolution Chess Engine
 
-**Version v1.2.0 dev-070925**
+**Version v.2.45 180925**
 
 <div align="center">
   <img src="[https://ijccrl.com/wp-content/uploads/2025/08/revolution.png]" 
@@ -17,6 +17,8 @@
 ## Overview
 
 **Revolution** is a free, open-source UCI chess engine derived from **Stockfish**. Jorge Ruiz Centelles, with credit to ChatGPT, modifies and extends the code to explore new concepts. The engine implements cutting-edge search algorithms combined with neural network evaluation. Derived from fundamental chess programming principles, Revolution analyzes positions through parallelized alpha-beta search enhanced with null-move pruning and late move reductions.
+
+The engine identifies itself to any UCI-compatible GUI (including Fritz 20 and Cutechess) as **`revolution v.2.45 180925`**. This naming is also embedded into the executable so that chess computers display the same identifier during startup.
 
 As a UCI-compliant engine, Revolution operates through **standard chess interfaces** without an integrated graphical interface. Users must employ compatible chess GUIs (Arena, Scid vs PC, etc.) for board visualization and move input. Consult your GUI documentation for implementation details.
 
@@ -39,7 +41,11 @@ The distribution includes:
 - `COPYING.txt` ([GNU GPLv3 license][gpl-link])
 - `AUTHORS` (contributor acknowledgments)
 - `src/` (source code with platform-specific Makefiles)
-- Neural network weights (`revolution.nnue`)
+- Embedded neural network weights (`nn-ae6a388e4a1a.nnue` and `nn-baff1ede1f90.nnue`)
+
+### Embedded Neural Networks
+
+Revolution v.2.45 180925 integrates **two** NNUE evaluation files directly into the engine binary: a full-size network (`nn-ae6a388e4a1a.nnue`) and a compact network (`nn-baff1ede1f90.nnue`). The engine automatically selects the requested network at runtime, keeping the deployment lightweight for dedicated chess computers and other constrained environments.
 
 ## Contributing
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -116,7 +116,7 @@ class Logger {
 
 // Returns the full name of the current Revolution version. Append the
 // compilation architecture (when available) so GUIs show a fully qualified
-// identifier such as "revolution 2.45 dev-180925 x86-64-sse41-popcnt".
+// identifier such as "revolution v.2.45 180925 x86-64-sse41-popcnt".
 std::string engine_version_info() {
 
     std::string fullName = ENGINE_NAME;

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.45 dev-180925"
+    #define ENGINE_NAME "revolution v.2.45 180925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- update the engine identifier string to `revolution v.2.45 180925` so GUIs display the correct version
- describe the new identifier and the pair of embedded NNUE networks in the README
- record the 2.45 release notes documenting the naming change and bundled NNUE files

## Testing
- make build -j2 ARCH=x86-64-sse41-popcnt *(fails: network download for nn-ae6a388e4a1a.nnue was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4ce8bb248327b2c166cc8856e170