### PR TITLE
Update engine identity to revolution 2.60 190925

### DIFF
--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Launch a local fishtest worker for tuning Wordfish.
+# Launch a local fishtest worker for tuning revolution.
 # Requires a fishtest repository cloned locally.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish"
+ENGINE="$ROOT_DIR/src/revolution_2.60_190925"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run automated matches between Wordfish and another UCI engine using cutechess-cli.
+# Run automated matches between revolution and another UCI engine using cutechess-cli.
 # Usage: scripts/match.sh /path/to/opponent [games] [timecontrol]
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/wordfish}"
+ENGINE="${ENGINE:-$ROOT_DIR/src/revolution_2.60_190925}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +15,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name=Wordfish \
+  -engine cmd="$ENGINE" name="revolution 2.60 190925" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# Run perft validation on the Wordfish engine.
+# Run perft validation on the revolution engine.
 # Builds the engine if needed and executes the existing test suite.
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/wordfish"
+ENGINE="$ROOT_DIR/src/revolution_2.60_190925"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution"
+DEFAULT_ENGINE = ROOT / "src" / "revolution_2.60_190925"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Simple SPSA tuner for the Wordfish engine."""
+"""Simple SPSA tuner for the revolution engine."""
 import argparse
 import os
 import random
@@ -19,9 +19,9 @@ def run_bench(engine, name, value):
     raise RuntimeError("Unexpected bench output")
 
 def main():
-    p = argparse.ArgumentParser(description="SPSA tuning for Wordfish")
+    p = argparse.ArgumentParser(description="SPSA tuning for revolution 2.60 190925")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/wordfish")
+    p.add_argument("--engine", default="src/revolution_2.60_190925")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = wordfish_190825_v2.42.exe
+        EXE = revolution_2.60_190925.exe
 else
-        EXE = wordfish_190825_v2.42
+        EXE = revolution_2.60_190925
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "Wordfish 2.42-190825"
+#   - ENGINE_NAME: "revolution 2.60 190925"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="Wordfish 2.42-190825" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= Wordfish 2.42-190825
+#   make ENGINE_NAME="revolution 2.60 190925" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= revolution 2.60 190925
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Wordfish 2.42-190825\""
-    #define ENGINE_NAME "Wordfish 2.42-190825"
+    // override at build time with:  -DENGINE_NAME="\"revolution 2.60 190925\""
+    #define ENGINE_NAME "revolution 2.60 190925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
+    #define ENGINE_NAME "revolution 2.60 190925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -118,7 +118,7 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Wordfish version.
+// Returns the full name of the current revolution version.
 std::string engine_version_info() { return std::string(ENGINE_NAME); }
 
 // Update author information

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
+    #define ENGINE_NAME "revolution 2.60 190925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -124,7 +124,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Wordfish 1.0"
+            // Force a stable, explicit UCI name so GUIs show "revolution 2.60 190925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Wordfish 2.42-190825"
+    #define ENGINE_NAME "revolution 2.60 190925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""  // build identifier

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.2.45 180925"
+    #define ENGINE_NAME "revolution 2.60 190925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- update the default engine name macros and Makefile configuration so the UCI banner, console output, and builds identify as "revolution 2.60 190925"
- adjust helper scripts to point to the renamed binary and use the new engine name in tooling output

## Testing
- `make -C src build ARCH=x86-64 -j2`


------
https://chatgpt.com/codex/tasks/task_e_68cce8ec81b0832782862a8a55229e53