### PR TITLE
Adjust NNUE small net fallback gating

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -37,6 +37,13 @@
 
 namespace Stockfish {
 
+namespace {
+
+constexpr int SMALLNET_MARGIN      = 236;
+constexpr int COMPLEXITY_THRESHOLD = 500;
+
+}  // namespace
+
 // Returns a static, purely materialistic evaluation of the position from
 // the point of view of the side to move. It can be divided by PawnValue to get
 // an approximation of the material advantage on the board in terms of pawns.
@@ -62,18 +69,19 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, accumulators, &caches.small)
                                        : networks.big.evaluate(pos, accumulators, &caches.big);
 
-    Value nnue = (125 * psqt + 131 * positional) / 128;
+    Value nnue          = (125 * psqt + 131 * positional) / 128;
+    int   nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (std::abs(nnue) < 236))
+    if (smallNet && (std::abs(nnue) < SMALLNET_MARGIN) && (nnueComplexity > COMPLEXITY_THRESHOLD))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
         nnue                       = (125 * psqt + 131 * positional) / 128;
         smallNet                   = false;
+        nnueComplexity             = std::abs(psqt - positional);
     }
 
     // Blend optimism and eval with nnue complexity
-    int nnueComplexity = std::abs(psqt - positional);
     optimism += optimism * nnueComplexity / 468;
     nnue -= nnue * nnueComplexity / 18000;
 


### PR DESCRIPTION
## Summary
- cache the small-net complexity before deciding whether to fall back to the big network
- gate re-evaluation on both a tuned NNUE margin and a complexity threshold, and keep the recomputed complexity after the fallback

## Testing
- `make -C src build ARCH=x86-64-sse41-popcnt`
- `./src/revolution_2.60_190925 bench`


------
https://chatgpt.com/codex/tasks/task_e_68ccf153d6388327a3a8f6af651fe1ff