### PR TITLE
Add scaffolding directories for project organization

### DIFF
--- a/src/engines/.gitkeep
+++ b/src/engines/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/engines/revolution base/.gitkeep
+++ b/src/engines/revolution base/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/engines/revolution dev/.gitkeep
+++ b/src/engines/revolution dev/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/games/.gitkeep
+++ b/src/games/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/openings/.gitkeep
+++ b/src/openings/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/openings/pgn/.gitkeep
+++ b/src/openings/pgn/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.

--- a/src/scripts/.gitkeep
+++ b/src/scripts/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to retain directory structure.


### PR DESCRIPTION
## Summary
- add placeholder directories under `src/engines` for the "revolution" engine variants
- introduce empty `games`, `openings/pgn`, and `scripts` directories under `src`
- include `.gitkeep` files so the new directories remain in version control

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd062616c88327b1564271fdf36f50