### PR TITLE
Ensure search runs even with book move

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -251,15 +251,17 @@ void Search::Worker::start_searching() {
                                      th->worker.get()->rootMoves.end(), bookMove));
             usedBook = true;
         }
-        else
+
+        if (bookMove == Move::none())
         {
             if ((bool) options["MCTS by Shashin"]) {
                 // Placeholder: Monte Carlo Tree Search integration point.
                 // Current build continues with standard alpha-beta search.
             }
-            threads.start_searching();  // start non-main threads
-            iterative_deepening();      // main thread start searching
         }
+
+        threads.start_searching();  // start non-main threads
+        iterative_deepening();      // main thread start searching
     }
 
     // When we reach the maximum depth, we can arrive here without a raise of


### PR DESCRIPTION
## Summary
- always kick off the normal search loop even when a book move was found
- keep the existing book-move flag for later experience updates while leaving room for future MCTS integration

## Testing
- cmake -S . -B build -GNinja *(fails: missing Qt5 development package in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd79cb50e88327bdf49c731ccbbb45