### PR TITLE
Stop launching search when a book move is available

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -260,8 +260,11 @@ void Search::Worker::start_searching() {
             }
         }
 
-        threads.start_searching();  // start non-main threads
-        iterative_deepening();      // main thread start searching
+        if (!usedBook)
+        {
+            threads.start_searching();  // start non-main threads
+            iterative_deepening();      // main thread start searching
+        }
     }
 
     // When we reach the maximum depth, we can arrive here without a raise of


### PR DESCRIPTION
## Summary
- gate the launch of the iterative deepening threads so they are skipped whenever a book move has already been selected

## Testing
- `make -C src build ARCH=x86-64`
- Manual engine session: enabled Experience Book with a pre-populated entry and confirmed `go depth 20` returned the book move instantly
- Manual engine session: checked `go depth 20` from a position without experience/book support and observed a normal search

------
https://chatgpt.com/codex/tasks/task_e_68cd845022d88327a25550810b2385bd