### PR TITLE
Handle missing Falcon network gracefully

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -373,7 +373,7 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
-    networks->falcon.verify(options["FalconFile"], onVerifyNetworks);
+    networks->falcon.verify_optional(options["FalconFile"], onVerifyNetworks);
 }
 
 void Engine::load_networks() {

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -18,7 +18,9 @@
 
 #include "network.h"
 
+#include <algorithm>
 #include <cassert>
+#include <cctype>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -295,6 +297,46 @@ void Network<Arch, Transformer>::verify(std::string                             
           + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
           + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))");
     }
+}
+
+
+template<typename Arch, typename Transformer>
+bool Network<Arch, Transformer>::verify_optional(
+  std::string evalfilePath, const std::function<void(std::string_view)>& f) const {
+    if (evalfilePath.empty())
+        evalfilePath = evalFile.defaultName;
+
+    std::string normalized = evalfilePath;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    const bool requested = !normalized.empty() && normalized != "none";
+
+    if (evalFile.current != evalfilePath || evalFile.current == "None")
+    {
+        if (requested && f)
+        {
+            f("WARNING: Optional network file " + evalfilePath
+              + " was not loaded; continuing without Falcon evaluations.");
+        }
+        return false;
+    }
+
+    if (f)
+    {
+        auto storage = weights_handle();
+        if (!storage)
+            return true;
+
+        size_t size = sizeof(*storage->featureTransformer) + sizeof(Arch) * LayerStacks;
+        f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
+          + "MiB, (" + std::to_string(storage->featureTransformer->InputDimensions) + ", "
+          + std::to_string(storage->network[0].TransformedFeatureDimensions) + ", "
+          + std::to_string(storage->network[0].FC_0_OUTPUTS) + ", "
+          + std::to_string(storage->network[0].FC_1_OUTPUTS) + ", 1))");
+    }
+
+    return true;
 }
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -86,6 +86,8 @@ class Network {
 
 
     void verify(std::string evalfilePath, const std::function<void(std::string_view)>&) const;
+    bool verify_optional(std::string evalfilePath,
+                         const std::function<void(std::string_view)>&) const;
     NnueEvalTrace trace_evaluate(const Position&                         pos,
                                  AccumulatorStack&                       accumulatorStack,
                                  AccumulatorCaches::Cache<FTDimensions>* cache) const;


### PR DESCRIPTION
## Summary
- guard the Falcon network verification so missing weights no longer abort engine startup
- add an optional verification helper that warns via `onVerifyNetworks` when the Falcon file is unavailable

## Testing
- `cmake -S . -B build -GNinja` *(fails: Qt5 development files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cda7124a58832787c08b1b3f79a955