### PR TITLE
Fix BrainLearn score orientation for black

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -14,9 +14,14 @@
 #include <zlib.h>
 
 #include "misc.h"
+#include "position.h"
 #include "uci.h"
 
 namespace Stockfish {
+
+namespace Zobrist {
+extern Key side;
+}
 
 Experience experience;
 
@@ -142,7 +147,12 @@ void Experience::load(const std::string& file) {
             };
             BinBL e;
             while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                insert_entry(e.key, e.move, e.value, e.depth, 1);
+            {
+                int value = e.value;
+                if (e.key & Zobrist::side)
+                    value = -value;
+                insert_entry(e.key, e.move, value, e.depth, 1);
+            }
         }
         else
         {

--- a/tests/brainlearn_black_flip_test.cpp
+++ b/tests/brainlearn_black_flip_test.cpp
@@ -1,0 +1,97 @@
+#include <cassert>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#include "bitboard.h"
+#include "experience.h"
+#include "position.h"
+
+namespace Stockfish {
+namespace Zobrist {
+extern Key side;
+}  // namespace Zobrist
+}  // namespace Stockfish
+
+namespace {
+
+struct BinBL {
+    std::uint64_t key;
+    std::int32_t  depth;
+    std::int32_t  value;
+    std::uint16_t move;
+    std::uint16_t pad;
+    std::int32_t  perf;
+};
+
+std::filesystem::path make_temp_path(const std::string& name) {
+    auto dir = std::filesystem::temp_directory_path();
+    return dir / std::filesystem::path(name);
+}
+
+}  // namespace
+
+int main() {
+    using namespace Stockfish;
+
+    Bitboards::init();
+    Position::init();
+
+    Position pos;
+    StateInfo st;
+    pos.set("8/8/8/8/8/8/4K3/7k b - - 0 1", false, &st);
+    const Key key = pos.key();
+
+    if ((key & Zobrist::side) == 0)
+    {
+        std::cerr << "Test setup error: key does not have black-to-move flag" << std::endl;
+        return 1;
+    }
+
+    const BinBL record{key, 12, 42, 0, 0, 0};
+
+    const auto inputPath  = make_temp_path("brainlearn_black_flip_input.blk");
+    const auto outputPath = make_temp_path("brainlearn_black_flip_output.blk");
+
+    {
+        std::ofstream out(inputPath, std::ios::binary);
+        if (!out)
+        {
+            std::cerr << "Failed to create input file" << std::endl;
+            return 1;
+        }
+        out.write(reinterpret_cast<const char*>(&record), sizeof(record));
+    }
+
+    Experience exp;
+    exp.load(inputPath.string());
+    exp.save(outputPath.string());
+
+    BinBL stored{};
+    {
+        std::ifstream in(outputPath, std::ios::binary);
+        if (!in)
+        {
+            std::cerr << "Failed to open output file" << std::endl;
+            return 1;
+        }
+        in.read(reinterpret_cast<char*>(&stored), sizeof(stored));
+        if (!in)
+        {
+            std::cerr << "Failed to read stored record" << std::endl;
+            return 1;
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(inputPath, ec);
+    std::filesystem::remove(outputPath, ec);
+
+    if (stored.value != -record.value)
+    {
+        std::cerr << "Stored value was not flipped for black-to-move record" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- include position.h in experience.cpp so BrainLearn keys can inspect Zobrist::side
- negate stored values for BrainLearn records that correspond to black to move before inserting
- add a regression test that loads a black-to-move BrainLearn record and ensures the saved score is flipped

## Testing
- tests/brainlearn_black_flip_test


------
https://chatgpt.com/codex/tasks/task_e_68cda72d0d548327b1f745405d44feb3