### PR TITLE
Add skeleton directories for Reckless module

### DIFF
--- a/src/reckless/board/.gitkeep
+++ b/src/reckless/board/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to keep the board directory tracked by git.

--- a/src/reckless/nnue/.gitkeep
+++ b/src/reckless/nnue/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to keep the nnue directory tracked by git.

--- a/src/reckless/tools/.gitkeep
+++ b/src/reckless/tools/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to keep the tools directory tracked by git.

--- a/src/reckless/types/.gitkeep
+++ b/src/reckless/types/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder file to keep the types directory tracked by git.


### PR DESCRIPTION
## Summary
- create the new src/reckless directory tree with board, nnue, tools, and types subdirectories
- add placeholder .gitkeep files so the empty directories remain tracked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdee2fabc08327a7d6522afc707be4