### PR TITLE
Fix SugaR experience orientation handling

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -178,23 +178,13 @@ void Experience::load(const std::string& file) {
             {
                 BinV2 e;
                 while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                {
-                    int value = e.value;
-                    if (e.key & Zobrist::side)
-                        value = -value;
-                    insert_entry(e.key, e.move, value, e.depth, e.count);
-                }
+                    insert_entry(e.key, e.move, e.value, e.depth, e.count);
             }
             else
             {
                 BinV1 e;
                 while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                {
-                    int value = e.value;
-                    if (e.key & Zobrist::side)
-                        value = -value;
-                    insert_entry(e.key, e.move, value, e.depth, 1);
-                }
+                    insert_entry(e.key, e.move, e.value, e.depth, 1);
             }
         }
     }

--- a/tests/brainlearn_black_flip_test.cpp
+++ b/tests/brainlearn_black_flip_test.cpp
@@ -6,11 +6,69 @@
 #include "bitboard.h"
 #include "experience.h"
 #include "position.h"
+#include "uci.h"
+#include "tt.h"
 
 namespace Stockfish {
 namespace Zobrist {
 extern Key side;
 }  // namespace Zobrist
+std::string UCIEngine::square(Square s) {
+    return std::string{char('a' + file_of(s)), char('1' + rank_of(s))};
+}
+
+std::string UCIEngine::move(Move m, bool chess960) {
+    (void) chess960;
+    return square(m.from_sq()) + square(m.to_sq());
+}
+
+TTEntry* TranspositionTable::first_entry(const Key) const {
+    return nullptr;
+}
+
+void* std_aligned_alloc(size_t alignment, size_t size) {
+    if (alignment < sizeof(void*))
+        alignment = sizeof(void*);
+    size = ((size + alignment - 1) / alignment) * alignment;
+    return std::aligned_alloc(alignment, size);
+}
+
+void std_aligned_free(void* ptr) {
+    std::free(ptr);
+}
+
+void* aligned_large_pages_alloc(size_t size) {
+    return std_aligned_alloc(4096, size);
+}
+
+void aligned_large_pages_free(void* mem) {
+    std_aligned_free(mem);
+}
+
+bool has_large_pages() {
+    return false;
+}
+
+namespace Tablebases {
+
+int MaxCardinality = 0;
+
+WDLScore probe_wdl(Position&, ProbeState* result) {
+    if (result)
+        *result = FAIL;
+    return WDLDraw;
+}
+
+int probe_dtz(Position&, ProbeState* result) {
+    if (result)
+        *result = FAIL;
+    return 0;
+}
+
+void init(const std::string&, bool) {}
+void release() {}
+
+}  // namespace Tablebases
 }  // namespace Stockfish
 
 namespace {

--- a/tests/sugar_black_flip_test.cpp
+++ b/tests/sugar_black_flip_test.cpp
@@ -121,15 +121,17 @@ int main() {
     const Move winningMove(SQ_H1, SQ_G1);
     const Move losingMove(SQ_H1, SQ_H2);
 
+    // SugaR experience files already store evaluations from the side-to-move
+    // perspective, matching what experience.save() produces.
     const BinV2 winningRecord{key,
                               static_cast<std::uint32_t>(winningMove.raw()),
-                              -500,
+                              500,
                               12,
                               1,
                               {0, 0}};
     const BinV2 losingRecord{key,
                              static_cast<std::uint32_t>(losingMove.raw()),
-                             400,
+                             -400,
                              12,
                              1,
                              {0, 0}};
@@ -197,15 +199,15 @@ int main() {
     for (const auto& rec : stored)
         storedScores.emplace(rec.move, rec.value);
 
-    if (storedScores[winningRecord.move] != -winningRecord.value)
+    if (storedScores[winningRecord.move] != winningRecord.value)
     {
-        std::cerr << "Winning move score was not flipped" << std::endl;
+        std::cerr << "Winning move score changed unexpectedly" << std::endl;
         return 1;
     }
 
-    if (storedScores[losingRecord.move] != -losingRecord.value)
+    if (storedScores[losingRecord.move] != losingRecord.value)
     {
-        std::cerr << "Losing move score was not flipped" << std::endl;
+        std::cerr << "Losing move score changed unexpectedly" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- Preserve SugaR-native experience scores on load by only flipping external BrainLearn values
- Update the SugaR black flip test data to match the engine's saved orientation and verify scores stay unchanged
- Provide minimal engine stubs in the BrainLearn flip test so it can run in isolation

## Testing
- tests/sugar_black_flip_test
- tests/brainlearn_black_flip_test

------
https://chatgpt.com/codex/tasks/task_e_68ce01eb7da08327833b00b96f877504