### PR TITLE
Restore SugaR experience orientation flip

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -178,13 +178,23 @@ void Experience::load(const std::string& file) {
             {
                 BinV2 e;
                 while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                    insert_entry(e.key, e.move, e.value, e.depth, e.count);
+                {
+                    int value = e.value;
+                    if (e.key & Zobrist::side)
+                        value = -value;
+                    insert_entry(e.key, e.move, value, e.depth, e.count);
+                }
             }
             else
             {
                 BinV1 e;
                 while (in.read(reinterpret_cast<char*>(&e), sizeof(e)))
-                    insert_entry(e.key, e.move, e.value, e.depth, 1);
+                {
+                    int value = e.value;
+                    if (e.key & Zobrist::side)
+                        value = -value;
+                    insert_entry(e.key, e.move, value, e.depth, 1);
+                }
             }
         }
     }

--- a/tests/sugar_black_flip_test.cpp
+++ b/tests/sugar_black_flip_test.cpp
@@ -121,17 +121,15 @@ int main() {
     const Move winningMove(SQ_H1, SQ_G1);
     const Move losingMove(SQ_H1, SQ_H2);
 
-    // SugaR experience files already store evaluations from the side-to-move
-    // perspective, matching what experience.save() produces.
     const BinV2 winningRecord{key,
                               static_cast<std::uint32_t>(winningMove.raw()),
-                              500,
+                              -500,
                               12,
                               1,
                               {0, 0}};
     const BinV2 losingRecord{key,
                              static_cast<std::uint32_t>(losingMove.raw()),
-                             -400,
+                             400,
                              12,
                              1,
                              {0, 0}};
@@ -199,15 +197,15 @@ int main() {
     for (const auto& rec : stored)
         storedScores.emplace(rec.move, rec.value);
 
-    if (storedScores[winningRecord.move] != winningRecord.value)
+    if (storedScores[winningRecord.move] != -winningRecord.value)
     {
-        std::cerr << "Winning move score changed unexpectedly" << std::endl;
+        std::cerr << "Winning move score was not flipped" << std::endl;
         return 1;
     }
 
-    if (storedScores[losingRecord.move] != losingRecord.value)
+    if (storedScores[losingRecord.move] != -losingRecord.value)
     {
-        std::cerr << "Losing move score changed unexpectedly" << std::endl;
+        std::cerr << "Losing move score was not flipped" << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- restore the side-to-move reorientation when loading SugaR BinV1/BinV2 entries
- update the sugar_black_flip regression to expect the flipped scores again

## Testing
- `build-tests/sugar_black_flip_test`
- `build-tests/brainlearn_black_flip_test`


------
https://chatgpt.com/codex/tasks/task_e_68ce1906fc80832798c26d1ceae6be7f