### PR TITLE
Restore experience orientation and update branding to 2.70

### DIFF
--- a/docs/testing/book_move_time_experience.md
+++ b/docs/testing/book_move_time_experience.md
@@ -18,7 +18,7 @@ the previous search.
 ## Test procedure
 
 1. Launch the freshly built binary (e.g. `./build/revolution` or
-   `./src/revolution_2.60_190925`) and switch to UCI mode by sending `uci` and
+   `./src/revolution_2.70_210925`) and switch to UCI mode by sending `uci` and
    waiting for `uciok`.
 2. Enable the logger so that the session can be inspected afterwards:
    `setoption name Debug Log File value book-regression.log`.

--- a/docs/testing/fastchess_sprt_relaunch.md
+++ b/docs/testing/fastchess_sprt_relaunch.md
@@ -1,7 +1,7 @@
 # Fastchess SPRT relaunch checklist
 
 This guide accompanies `scripts/fastchess_sprt_relaunch.bat` and captures the
-workflow recommended after the regression seen in the 2.60 vs 2.40 match.
+workflow recommended after the regression seen in the 2.70 vs 2.40 match.
 
 ## 1. Pre-SPRT gating match (sanity check)
 

--- a/docs/training/hyperparameter_schedule.md
+++ b/docs/training/hyperparameter_schedule.md
@@ -1,7 +1,7 @@
 # NNUE Training Hyperparameter Schedule (UHO 2024 8mv +0.85/+0.94)
 
 This plan refines the final phase of the NNUE training run used for the UHO 2024 8-move suite (+0.85/+0.94). The focus is to
-extract sharper tactical play from Revolution 2.60 while limiting overfitting to the white side of the starting book.
+extract sharper tactical play from Revolution 2.70 while limiting overfitting to the white side of the starting book.
 
 ## Learning-rate schedule
 

--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -8,7 +8,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "FASTCHESS=C:\fastchess\fastchess.exe"
-set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution_2.60_190925.exe"
+set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution_2.70_210925.exe"
 set "ENGINE_BASE=C:\fastchess\revolution-base\revolution-dev_v2.40_130925.exe"
 set "DIR_NEW=C:\fastchess\revolution-ad"
 set "DIR_BASE=C:\fastchess\revolution-base"
@@ -87,7 +87,7 @@ if errorlevel 2 goto :sprt
 set "GATING_DONE=1"
 echo Running gating match (%GATING_GAMES% games) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution_2.60_190925" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="Revolution_2.70_210925" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL% ^
@@ -132,7 +132,7 @@ if defined GATING_PERCENT (
 :sprt
 echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution_2.60_190925" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="Revolution_2.70_210925" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL% ^

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution_2.60_190925"
+ENGINE="$ROOT_DIR/src/revolution_2.70_210925"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/revolution_2.60_190925}"
+ENGINE="${ENGINE:-$ROOT_DIR/src/revolution_2.70_210925}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +15,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name="revolution 2.60 190925" \
+  -engine cmd="$ENGINE" name="Revolution 2.70 210925" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution_2.60_190925"
+ENGINE="$ROOT_DIR/src/revolution_2.70_210925"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution_2.60_190925"
+DEFAULT_ENGINE = ROOT / "src" / "revolution_2.70_210925"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -19,9 +19,9 @@ def run_bench(engine, name, value):
     raise RuntimeError("Unexpected bench output")
 
 def main():
-    p = argparse.ArgumentParser(description="SPSA tuning for revolution 2.60 190925")
+    p = argparse.ArgumentParser(description="SPSA tuning for Revolution 2.70 210925")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution_2.60_190925")
+    p.add_argument("--engine", default="src/revolution_2.70_210925")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -207,11 +207,20 @@ void Experience::load(const std::string& file) {
                 continue;
 
             std::istringstream iss(line);
-            std::string        keyStr, moveStr;
-            int                score, depth, count;
+            std::string keyStr, moveStr;
+            int         score, depth;
+            int         count = 1;
 
-            if (!(iss >> keyStr >> moveStr >> score >> depth >> count))
+            if (!(iss >> keyStr >> moveStr >> score >> depth))
                 continue;
+
+            if (!(iss >> count))
+            {
+                // Older text files omit the occurrence count. Treat them as
+                // having a single observation so we remain backward
+                // compatible instead of discarding the entire entry.
+                count = 1;
+            }
 
             auto parse = [](const std::string& s, uint64_t& out) {
                 std::istringstream ss(s);
@@ -351,6 +360,16 @@ void Experience::save(const std::string& file) const {
     sync_cout << "info string " << path << " <- Total moves: " << totalMoves
               << ". Total positions: " << totalPositions << sync_endl;
 }
+
+namespace {
+
+int oriented_score(const ExperienceEntry& entry, Color sideToMove)
+{
+    return sideToMove == Color::WHITE ? entry.score : -entry.score;
+}
+
+}  // namespace
+
 Move Experience::probe(Position& pos, int width, int evalImportance, int minDepth, int maxMoves) {
     if (!is_ready())
         return Move::none();
@@ -362,12 +381,16 @@ Move Experience::probe(Position& pos, int width, int evalImportance, int minDept
     if (vec.empty())
         return Move::none();
 
+    const Color sideToMove = pos.side_to_move();
+
     // Order moves by their historical evaluation and depth so that the most
     // promising moves come first.  This allows the engine to "learn" from
     // previous games by preferring moves with the best average score at the
     // deepest search.
     std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
-        return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
+        const int aScore = oriented_score(a, sideToMove) + evalImportance * a.depth;
+        const int bScore = oriented_score(b, sideToMove) + evalImportance * b.depth;
+        return aScore > bScore;
     });
 
     vec.resize(std::min<int>({maxMoves, width, static_cast<int>(vec.size())}));
@@ -383,6 +406,8 @@ Move Experience::probe(Position& pos, int width, int evalImportance, int minDept
 void Experience::update(Position& pos, Move move, int score, int depth) {
     if (!is_ready())
         return;
+    const int storedScore = pos.side_to_move() == Color::WHITE ? score : -score;
+
     auto& vec = table[pos.key()];
     for (auto& e : vec)
         if (e.move == move)
@@ -390,13 +415,13 @@ void Experience::update(Position& pos, Move move, int score, int depth) {
             // Update the stored statistics with a running average of the
             // evaluation.  This simple learning mechanism increases the score
             // reliability over time and retains the deepest search depth seen.
-            e.score = (e.score * e.count + score) / (e.count + 1);
+            e.score = (e.score * e.count + storedScore) / (e.count + 1);
             e.depth = std::max(e.depth, depth);
             e.count++;
             return;
         }
     // First encounter of this move in the current position.
-    vec.push_back({move, score, depth, 1});
+    vec.push_back({move, storedScore, depth, 1});
 }
 
 void Experience::show(const Position& pos, int evalImportance, int maxMoves) const {
@@ -408,17 +433,21 @@ void Experience::show(const Position& pos, int evalImportance, int maxMoves) con
         sync_cout << "info string No experience available" << sync_endl;
         return;
     }
-    auto vec = it->second;
+    auto  vec        = it->second;
+    Color sideToMove = pos.side_to_move();
     std::sort(vec.begin(), vec.end(), [&](const ExperienceEntry& a, const ExperienceEntry& b) {
-        return (a.score + evalImportance * a.depth) > (b.score + evalImportance * b.depth);
+        const int aScore = oriented_score(a, sideToMove) + evalImportance * a.depth;
+        const int bScore = oriented_score(b, sideToMove) + evalImportance * b.depth;
+        return aScore > bScore;
     });
     int shown = 0;
     for (const auto& e : vec)
     {
         if (shown++ >= maxMoves)
             break;
+        const int oriented = oriented_score(e, sideToMove);
         sync_cout << "info string " << UCIEngine::move(e.move, pos.is_chess960()) << " score "
-                  << e.score << " depth " << e.depth << " count " << e.count << sync_endl;
+                  << oriented << " depth " << e.depth << " count " << e.count << sync_endl;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,8 @@
 #include "position.h"
 
 #ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"revolution 2.60 190925\""
-    #define ENGINE_NAME "revolution 2.60 190925"
+    // override at build time with:  -DENGINE_NAME="\"Revolution 2.70 210925\""
+    #define ENGINE_NAME "Revolution 2.70 210925"
 #endif
 
 using namespace Stockfish;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -37,7 +37,7 @@
 
 #include "types.h"
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.60 190925"
+    #define ENGINE_NAME "Revolution 2.70 210925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -43,7 +43,7 @@
 #include "ucioption.h"
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.60 190925"
+    #define ENGINE_NAME "Revolution 2.70 210925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""
@@ -124,7 +124,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution 2.60 190925"
+            // Force a stable, explicit UCI name so GUIs show "Revolution 2.70 210925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,7 +21,7 @@
 #include "ucioption.h"
 // --- Engine identity (fallbacks; Makefile can override) ---
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.60 190925"
+    #define ENGINE_NAME "Revolution 2.70 210925"
 #endif
 #ifndef ENGINE_BUILD_DATE
     #define ENGINE_BUILD_DATE ""  // build identifier

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.60 190925"
+    #define ENGINE_NAME "Revolution 2.70 210925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- restore side-to-move aware scoring in the experience table and keep compatibility with legacy text dumps
- surface the new release identity as "Revolution 2.70 210925" across sources, scripts, and docs

## Testing
- cmake -S . -B build *(fails: missing Qt5 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc563d44c8327857b171ae4e0d5e0