### PR TITLE
Update engine version string to revolution v.2.70 dev-210925

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,11 +23,7 @@
 #include "tune.h"
 #include "bitboard.h"
 #include "position.h"
-
-#ifndef ENGINE_NAME
-    // override at build time with:  -DENGINE_NAME="\"Revolution 2.70 210925\""
-    #define ENGINE_NAME "Revolution 2.70 210925"
-#endif
+#include "version.h"
 
 using namespace Stockfish;
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -36,12 +36,7 @@
 #include <string_view>
 
 #include "types.h"
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.70 210925"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
-#endif
+#include "version.h"
 
 namespace Stockfish {
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -41,13 +41,7 @@
 #include "experience.h"
 #include "types.h"
 #include "ucioption.h"
-
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.70 210925"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""
-#endif
+#include "version.h"
 
 namespace Stockfish {
 
@@ -124,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "Revolution 2.70 210925"
+            // Force a stable, explicit UCI name so GUIs show "revolution v.2.70 dev-210925"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -19,13 +19,8 @@
 */
 
 #include "ucioption.h"
-// --- Engine identity (fallbacks; Makefile can override) ---
-#ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.70 210925"
-#endif
-#ifndef ENGINE_BUILD_DATE
-    #define ENGINE_BUILD_DATE ""  // build identifier
-#endif
+
+#include "version.h"
 
 
 #include <algorithm>

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "Revolution 2.70 210925"
+    #define ENGINE_NAME "revolution v.2.70 dev-210925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- centralize the engine name definition in `version.h`
- include the shared version header where the engine name is required so UCI output and logs show `revolution v.2.70 dev-210925`

## Testing
- cmake -S . -B build *(fails: missing Qt5 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd712b7a8832783904a445df8b09b