### PR TITLE
Update engine version string to 2.70 dev-190925

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution v.2.70 dev-210925"
+    #define ENGINE_NAME "revolution 2.70 dev-190925"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- set the engine's reported name to "revolution 2.70 dev-190925" so it appears in console and GUIs

## Testing
- cmake -S . -B build *(fails: missing Qt5 development package)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdf70eacc832794366dc81891ef41