### PR TITLE
Add explicit games count to SPRT relaunch script

### DIFF
--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -150,7 +150,7 @@ echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
  -openings file="%BOOK%" format=pgn order=random -plies %BOOKPLIES% -repeat ^
  -adjudication movenumber=%ADJ_MOVES% score=%ADJ_MARGIN% -resign movecount=%RESIGN_MOVES% score=%RESIGN_SCORE% ^
  -sprt elo0=%ELO0% elo1=%ELO1% alpha=%ALPHA% beta=%BETA% ^
- -rounds %ROUNDS% -concurrency %CONCURRENCY% -recover ^
+ -games 2 -rounds %ROUNDS% -concurrency %CONCURRENCY% -recover ^
  -report penta=true ^
  -ratinginterval 1 -scoreinterval 1 -autosaveinterval 50 ^
  -pgnout "%SPRT_PGN%" ^


### PR DESCRIPTION
## Summary
- add `-games 2` to the SPRT fastchess relaunch invocation so the gauntlet is always started with a two-game chunk size

## Testing
- not run (Windows batch script cannot be executed in this Linux container)

------
https://chatgpt.com/codex/tasks/task_e_68cff134d9208327aef0490d2e09d61b