### PR TITLE
Ensure depth-limited searches run an iteration

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -497,8 +497,9 @@ void Search::Worker::iterative_deepening() {
     int searchAgainCounter = 0;
 
     // Start searches at depth 2 to skip the shallowest iteration and reach
-    // deeper analysis faster.
-    rootDepth = 1;
+    // deeper analysis faster, unless the user explicitly limits the search
+    // to depth 1 or lower where we still want to run a single iteration.
+    rootDepth = (limits.depth && limits.depth <= 1) ? Depth(0) : Depth(1);
 
     lowPlyHistory.fill(89);
 


### PR DESCRIPTION
## Summary
- update iterative deepening to start from depth zero when the search is limited to depth 1 so that one iteration still runs
- add a comment documenting the expected behaviour for shallow depth limits

## Testing
- `make -j build ARCH=x86-64`
- `./revolution_2.70_210925` (uci; position startpos; go depth 1)


------
https://chatgpt.com/codex/tasks/task_e_68d015eff5808327be34c70e962a94d6