### PR TITLE
Fix NNUE evaluation orientation for side to move

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -69,14 +69,16 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, accumulators, &caches.small)
                                        : networks.big.evaluate(pos, accumulators, &caches.big);
 
-    Value nnue          = (125 * psqt + 131 * positional) / 128;
+    Value rawNNUE        = (125 * psqt + 131 * positional) / 128;
+    Value nnue           = pos.side_to_move() == WHITE ? rawNNUE : -rawNNUE;
     int   nnueComplexity = std::abs(psqt - positional);
 
     // Re-evaluate the position when higher eval accuracy is worth the time spent
     if (smallNet && (std::abs(nnue) < SMALLNET_MARGIN) && (nnueComplexity > COMPLEXITY_THRESHOLD))
     {
         std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
-        nnue                       = (125 * psqt + 131 * positional) / 128;
+        rawNNUE                    = (125 * psqt + 131 * positional) / 128;
+        nnue                       = pos.side_to_move() == WHITE ? rawNNUE : -rawNNUE;
         smallNet                   = false;
         nnueComplexity             = std::abs(psqt - positional);
     }


### PR DESCRIPTION
## Summary
- ensure NNUE blended score is converted to the side-to-move perspective before use
- keep the recalculated small-network fallback consistent with the corrected orientation

## Testing
- `make build ARCH=x86-64-sse41-popcnt COMP=gcc -j2` *(fails: link error from existing tune.o object shipped with tree)*

------
https://chatgpt.com/codex/tasks/task_e_68d10737a1508327bccc7190d77664df