### PR TITLE
Disable experience file handling for fastchess SPRT testing

### DIFF
--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -29,8 +29,6 @@ if /i "%BLOCK_EXP%"=="Y" (
     set "EXP_BLOCK_CHAIN= ^|setoption name Experience Enabled value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Book value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Prior value false"
-    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Concurrent value false"
-    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience File value <empty>"
 )
 
 rem -------- Test controls --------

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -28,8 +28,6 @@
 #include <string_view>
 #include <utility>
 #include <vector>
-#include <iomanip>
-#include <random>
 
 #include "evaluate.h"
 #include "misc.h"
@@ -167,18 +165,8 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Book2 Width", Option(1, 1, 10));
 
-    options.add("Experience Enabled", Option(true, [this](const Option& o) {
-                    if (bool(o))
-                        experience.load_async(options["Experience File"]);
-                    else
-                        experience.clear();
-                    return std::nullopt;
-                }));
-
-    options.add("Experience File", Option("experience.exp", [this](const Option& o) {
-                    if ((bool) options["Experience Enabled"])
-                        experience.load_async(o);
-                    concurrentExperienceFile.clear();
+    options.add("Experience Enabled", Option(false, [](const Option&) {
+                    experience.clear();
                     return std::nullopt;
                 }));
 
@@ -191,10 +179,6 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience Book", Option(false));
     options.add("Experience Book Max Moves", Option(100, 1, 100));
     options.add("Experience Book Min Depth", Option(4, 1, 255));
-    options.add("Experience Concurrent", Option(false, [this](const Option&) {
-                    concurrentExperienceFile.clear();
-                    return std::nullopt;
-                }));
 
     // MonteCarlo Tree Search section (experimental: thanks to original Stephan
     // Nicolet work)
@@ -264,27 +248,7 @@ void Engine::search_clear() {
     Tablebases::release();
 
     if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
-    {
-        std::string file = options["Experience File"];
-        if ((bool) options["Experience Concurrent"])
-        {
-            if (concurrentExperienceFile.empty())
-            {
-                std::random_device rd;
-                uint64_t           r = (uint64_t(rd()) << 32) ^ rd();
-                std::ostringstream oss;
-                oss << std::hex << std::setfill('0') << std::setw(16) << r;
-                std::string suffix = oss.str();
-                auto        p      = file.find_last_of('.');
-                if (p != std::string::npos)
-                    concurrentExperienceFile = file.substr(0, p) + "-" + suffix + file.substr(p);
-                else
-                    concurrentExperienceFile = file + "-" + suffix;
-            }
-            file = concurrentExperienceFile;
-        }
-        experience.save(file);
-    }
+        experience.clear();
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -124,8 +124,6 @@ class Engine {
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;
-
-    std::string concurrentExperienceFile;
 };
 
 }  // namespace Stockfish

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution v.2.70 dev-210925"
+            // Force a stable, explicit UCI name so GUIs show "revolution-dev-2209252kstc"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"
@@ -128,9 +128,6 @@ void UCIEngine::loop() {
             sync_cout_end();
 
             sync_cout << "uciok" << sync_endl;
-
-            if ((bool) engine.get_options()["Experience Enabled"])
-                experience.load_async(engine.get_options()["Experience File"]);
         }
 
         else if (token == "setoption")

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.70 dev-210925"
+    #define ENGINE_NAME "revolution-dev-2209252kstc"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- disable the UCI Experience File and related concurrent-saving logic so builds no longer touch disk
- keep experience learning options but default the feature to off and clear any cached data when toggled
- rename the engine to `revolution-dev-2209252kstc` and remove stale FastChess harness option overrides

## Testing
- cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release *(fails: missing Qt5 package)*

------
https://chatgpt.com/codex/tasks/task_e_68d117f118988327b711fcdc954aef36