### PR TITLE
Update engine ID name

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution v.2.70 dev-210925"
+            // Force a stable, explicit UCI name so GUIs show "revolution 2.71-dev-220925-thsaf"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.70 dev-210925"
+    #define ENGINE_NAME "revolution 2.71-dev-220925-thsaf"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- set the engine name macro to "revolution 2.71-dev-220925-thsaf"
- refresh the UCI banner comment to mention the new identifier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d14107877c8327a456c508c50eec54