### PR TITLE
Handle pawn capture availability in qsearch stalemate check

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1924,9 +1924,30 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     if (!ss->inCheck && !moveCount && !pos.non_pawn_material(us)
         && type_of(pos.captured_piece()) >= ROOK)
     {
-        if (!((us == WHITE ? shift<NORTH>(pos.pieces(us, PAWN))
-                           : shift<SOUTH>(pos.pieces(us, PAWN)))
-              & ~pos.pieces()))  // no pawn pushes available
+        const Bitboard pawns        = pos.pieces(us, PAWN);
+        const Bitboard emptySquares = ~pos.pieces();
+        const Bitboard enemyPieces  = pos.pieces(~us);
+        const Square   epSquare     = pos.ep_square();
+        const Bitboard epTarget     = epSquare != SQ_NONE ? square_bb(epSquare) : 0;
+
+        Bitboard pawnPushes, pawnCaptures;
+
+        if (us == WHITE)
+        {
+            const Bitboard singlePushes = shift<NORTH>(pawns) & emptySquares;
+            const Bitboard doublePushes = shift<NORTH>(singlePushes & Rank3BB) & emptySquares;
+            pawnPushes                  = singlePushes | doublePushes;
+            pawnCaptures = pawn_attacks_bb<WHITE>(pawns) & (enemyPieces | epTarget);
+        }
+        else
+        {
+            const Bitboard singlePushes = shift<SOUTH>(pawns) & emptySquares;
+            const Bitboard doublePushes = shift<SOUTH>(singlePushes & Rank6BB) & emptySquares;
+            pawnPushes                  = singlePushes | doublePushes;
+            pawnCaptures = pawn_attacks_bb<BLACK>(pawns) & (enemyPieces | epTarget);
+        }
+
+        if (!pawnPushes && !pawnCaptures)
         {
             pos.state()->checkersBB = Rank1BB;  // search for legal king-moves only
             if (!MoveList<LEGAL>(pos).size())   // stalemate

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -384,6 +384,32 @@ class TestInteractive(metaclass=OrderedClassMembers):
 
         self.stockfish.starts_with("bestmove c6d7")
 
+    def test_only_pawn_capture_prevents_false_stalemate(self):
+        self.stockfish.send_command("ucinewgame")
+        self.stockfish.send_command(
+            "position fen 8/7k/4p3/3pP3/5n2/5n2/4n3/7K w - d6 0 1"
+        )
+        self.stockfish.send_command("go depth 5")
+
+        def callback(output):
+            if output.startswith("bestmove"):
+                assert output.startswith("bestmove e5d6")
+                return True
+
+            return False
+
+        self.stockfish.check_output(callback)
+
+        history = [line for line in self.stockfish.get_output() if line.startswith("info depth")]
+        assert history, "Search did not report any info depth lines"
+
+        match = re.search(r"score (cp|mate) (-?\d+)", history[-1])
+        assert match is not None
+
+        score_type, value = match.group(1), int(match.group(2))
+        if score_type == "cp":
+            assert value != 0
+
     def test_fen_position_with_moves_with_mate_go_depth_and_searchmoves(self):
         self.stockfish.send_command("ucinewgame")
         self.stockfish.send_command(


### PR DESCRIPTION
## Summary
- compute pawn push and capture bitboards before entering the king-only stalemate probe in qsearch
- require both pushes and captures to be absent so legitimate pawn captures cannot be dismissed as draws
- extend the interactive regression suite with a FEN where an en-passant capture is the sole legal reply

## Testing
- python3 - <<'PY'
import sys, pathlib
sys.path.append(str(pathlib.Path('tests').resolve()))
from types import SimpleNamespace
import instrumented as instr

instr.args = SimpleNamespace(
    valgrind=False,
    valgrind_thread=False,
    sanitizer_undefined=False,
    sanitizer_thread=False,
    none=True,
    stockfish_path='src/2.71-dev-220925-thsaf',
)

interactive = instr.TestInteractive()
interactive.beforeAll()
try:
    interactive.test_only_pawn_capture_prevents_false_stalemate()
    interactive.afterEach()
finally:
    interactive.afterAll()
print('isolated pawn capture test passed')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d177fb95e88327b7e6dfcb5faa4acb