### PR TITLE
Fix experience V2 header shadow warning

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -374,16 +374,16 @@ void Experience::load(const std::string& file) {
                     return true;
                 };
 
-                V2HeaderInfo header{};
-                bool         hasHeader = parse_v2_header(header);
+                V2HeaderInfo headerInfo{};
+                bool         hasHeader = parse_v2_header(headerInfo);
 
                 std::size_t entryOffset = sigV2.size();
                 std::size_t entrySize   = sizeof(SugaRBinV2Minimal);
 
                 if (hasHeader)
                 {
-                    entryOffset += header.headerBytes;
-                    entrySize = header.entrySize;
+                    entryOffset += headerInfo.headerBytes;
+                    entrySize = headerInfo.entrySize;
                 }
 
                 in.seekg(static_cast<std::streamoff>(entryOffset), std::ios::beg);


### PR DESCRIPTION
## Summary
- rename the V2 header parsing variable in `experience.cpp` to avoid shadowing the string header buffer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3a2f96be483278440dfa4b2ddc7bb