### PR TITLE
Ensure experience book flushes on quit

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -106,7 +106,12 @@ void UCIEngine::loop() {
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
         is >> std::skipws >> token;
 
-        if (token == "quit" || token == "stop")
+        if (token == "quit")
+        {
+            engine.stop();
+            engine.search_clear();
+        }
+        else if (token == "stop")
             engine.stop();
 
         // The GUI sends 'ponderhit' to tell that the user has played the expected move.


### PR DESCRIPTION
## Summary
- call `Engine::search_clear()` when processing a `quit` command so learned experience is saved before exit

## Testing
- `cmake -S . -B build -G Ninja` *(fails: missing Qt5 package in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c963cb6c8327857b1da175644a56