### PR TITLE
Improve experience file handling and tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ position startpos
 go movetime 5000
 ```
 
-Syzygy tablebases are automatically probed when `SyzygyPath` is set. Experience learning can be toggled via `Experience Enabled`, while `Experience Book` turns the cache into a soft opening book.
+Syzygy tablebases are automatically probed when `SyzygyPath` is set. Experience learning can be toggled via `Experience`, while `Experience Book` turns the cache into a soft opening book.
 
 ## License & Credits
 Revolution is distributed under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html). Because the engine incorporates Stockfish code, any redistribution must ship complete corresponding source, retain GPL notices, and document modifications.

--- a/docs/testing/book_move_time_experience.md
+++ b/docs/testing/book_move_time_experience.md
@@ -24,9 +24,9 @@ the previous search.
    `setoption name Debug Log File value book-regression.log`.
 3. Point the engine to the temporary experience file and make it writable:
    ```
-   setoption name Experience Enabled value true
+   setoption name Experience value true
    setoption name Experience Readonly value false
-   setoption name Experience File value /tmp/book-regression.exp
+   setoption name ExperienceFile value /tmp/book-regression.exp
    ```
 4. Disable both books for a single baseline search and start a new game:
    ```

--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -26,11 +26,11 @@ set "SYZYGY_PATH=C:\Syzygy"
 
 set "EXP_BLOCK_CHAIN="
 if /i "%BLOCK_EXP%"=="Y" (
-    set "EXP_BLOCK_CHAIN= ^|setoption name Experience Enabled value false"
+    set "EXP_BLOCK_CHAIN= ^|setoption name Experience value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Book value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Prior value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Concurrent value false"
-    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience File value <empty>"
+    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name ExperienceFile value <empty>"
 )
 
 rem -------- Test controls --------

--- a/scripts/gauntlet.cmd
+++ b/scripts/gauntlet.cmd
@@ -25,11 +25,11 @@ set "SYZYGY_PATH=C:\\Syzygy"
 
 set "EXP_BLOCK_CHAIN="
 if /i "%BLOCK_EXP%"=="Y" (
-    set "EXP_BLOCK_CHAIN= ^|setoption name Experience Enabled value false"
+    set "EXP_BLOCK_CHAIN= ^|setoption name Experience value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Book value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Prior value false"
     set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience Concurrent value false"
-    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name Experience File value <empty>"
+    set "EXP_BLOCK_CHAIN=!EXP_BLOCK_CHAIN!^|setoption name ExperienceFile value <empty>"
 )
 
 rem -------- Gauntlet controls --------

--- a/src/Makefile
+++ b/src/Makefile
@@ -56,7 +56,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp polybook.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp \
-        engine.cpp score.cpp memory.cpp experience.cpp
+        engine.cpp score.cpp memory.cpp experience.cpp experience_io.cpp
 
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/layers/affine_transform.h \
@@ -65,7 +65,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
 		nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h position.h \
                 search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
                 tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h \
-                experience.h
+                experience.h experience_io.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -18,11 +18,14 @@
 
 #include "engine.h"
 
+#include "experience_io.h"
+
 #include <algorithm>
 #include <cassert>
 #include <deque>
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string_view>
@@ -166,18 +169,108 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Book2 Width", Option(1, 1, 10));
 
-    options.add("Experience Enabled", Option(true, [this](const Option& o) {
-                    if (bool(o))
-                        experience.load_async(options["Experience File"]);
-                    else
-                        experience.clear();
-                    return std::nullopt;
+    auto setOptionSilently = [this](const std::string& name, const std::string& value) {
+        if (!options.count(name))
+            return;
+        Option& opt = const_cast<Option&>(options[name]);
+        if (opt.currentValue != value)
+            opt.currentValue = value;
+    };
+
+    auto getExperienceFile = [this]() -> std::string {
+        if (options.count("ExperienceFile"))
+            return std::string(options["ExperienceFile"]);
+        if (options.count("Experience File"))
+            return std::string(options["Experience File"]);
+        return "experience.exp";
+    };
+
+    auto lower_ext = [](const std::string& filePath) -> std::string {
+        const auto dot = filePath.find_last_of('.');
+        if (dot == std::string::npos)
+            return {};
+        std::string ext = filePath.substr(dot);
+        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) {
+            return char(std::tolower(c));
+        });
+        return ext;
+    };
+
+    auto ensureExperienceReady = [this, &setOptionSilently, &getExperienceFile, &lower_ext](bool enable) -> std::optional<std::string> {
+        if (!enable)
+        {
+            experience.clear();
+            setOptionSilently("Experience", "false");
+            if (options.count("Experience Enabled"))
+                setOptionSilently("Experience Enabled", "false");
+            return std::nullopt;
+        }
+
+        const std::string file = getExperienceFile();
+        const std::string ext  = lower_ext(file);
+
+        if (ext == ".exp" && !Experience_OpenForReadWrite(file))
+        {
+            sync_cout << "info string Experience disabled due to file error: " << file << sync_endl;
+            experience.clear();
+            setOptionSilently("Experience", "false");
+            if (options.count("Experience Enabled"))
+                setOptionSilently("Experience Enabled", "false");
+            return std::nullopt;
+        }
+
+        experience.load_async(file);
+        sync_cout << "info string Experience OK: " << file << sync_endl;
+        setOptionSilently("Experience", "true");
+        if (options.count("Experience Enabled"))
+            setOptionSilently("Experience Enabled", "true");
+        return std::nullopt;
+    };
+
+    auto applyExperienceFile = [this, &setOptionSilently, &ensureExperienceReady](const std::string& value) -> std::optional<std::string> {
+        if (options.count("ExperienceFile"))
+            setOptionSilently("ExperienceFile", value);
+        if (options.count("Experience File"))
+            setOptionSilently("Experience File", value);
+        concurrentExperienceFile.clear();
+        if (options.count("Experience") && bool(options["Experience"]))
+            return ensureExperienceReady(true);
+        return std::nullopt;
+    };
+
+    options.add("Experience", Option(true, [this, &ensureExperienceReady](const Option& o) {
+                    return ensureExperienceReady(bool(o));
                 }));
 
-    options.add("Experience File", Option("experience.exp", [this](const Option& o) {
-                    if ((bool) options["Experience Enabled"])
-                        experience.load_async(o);
-                    concurrentExperienceFile.clear();
+    options.add("Experience Enabled", Option(true, [this, &ensureExperienceReady](const Option& o) {
+                    return ensureExperienceReady(bool(o));
+                }));
+
+    options.add("ExperienceFile", Option("experience.exp", [this, &applyExperienceFile](const Option& o) {
+                    return applyExperienceFile(std::string(o));
+                }));
+
+    options.add("Experience File", Option("experience.exp", [this, &applyExperienceFile](const Option& o) {
+                    return applyExperienceFile(std::string(o));
+                }));
+
+    options.add("ClearExperience", Option([this, &getExperienceFile, &lower_ext, &ensureExperienceReady](const Option&) {
+                    const std::string target = getExperienceFile();
+                    const std::string ext    = lower_ext(target);
+                    bool              ok     = false;
+                    if (ext == ".exp")
+                        ok = Experience_InitNew(target);
+                    if (!ok)
+                    {
+                        sync_cout << "info string ClearExperience failed for: " << target << sync_endl;
+                    }
+                    else
+                    {
+                        experience.clear();
+                        sync_cout << "info string Experience re-initialized at: " << target << sync_endl;
+                        if (options.count("Experience") && bool(options["Experience"]))
+                            ensureExperienceReady(true);
+                    }
                     return std::nullopt;
                 }));
 
@@ -256,9 +349,9 @@ void Engine::search_clear() {
     // keep their mappings alive until they also release.
     Tablebases::release();
 
-    if ((bool) options["Experience Enabled"] && !(bool) options["Experience Readonly"])
+    if ((bool) options["Experience"] && !(bool) options["Experience Readonly"])
     {
-        std::string file = options["Experience File"];
+        std::string file = options.count("ExperienceFile") ? std::string(options["ExperienceFile"]) : std::string(options["Experience File"]);
         if ((bool) options["Experience Concurrent"])
         {
             if (concurrentExperienceFile.empty())

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -1,4 +1,5 @@
 #include "experience.h"
+#include "experience_io.h"
 
 #include <algorithm>
 #include <array>
@@ -6,6 +7,7 @@
 #include <future>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -198,6 +200,50 @@ void Experience::load(const std::string& file) {
             return;
         }
         buffer.assign(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
+    }
+
+    if (!buffer.empty())
+    {
+        bool handledExpHeader = false;
+        if (buffer.size() >= sizeof(ExpHeader))
+        {
+            ExpHeader header{};
+            std::memcpy(&header, buffer.data(), sizeof(header));
+            if (Experience_IsCompatible(header))
+            {
+                handledExpHeader = true;
+                const std::size_t payload = buffer.size() - sizeof(ExpHeader);
+
+                if (payload == 0)
+                {
+                    sync_cout << "info string " << display
+                              << " -> Experience header detected (no entries)." << sync_endl;
+                }
+                else if (payload % header.record_size == 0)
+                {
+                    const std::size_t records = payload / header.record_size;
+                    sync_cout << "info string " << display
+                              << " -> Experience format with record size " << header.record_size
+                              << " is not supported yet; ignoring " << records
+                              << (records == 1 ? " record." : " records.") << sync_endl;
+                }
+                else
+                {
+                    sync_cout << "info string " << display
+                              << " -> Experience header detected but payload size " << payload
+                              << " does not align with record size " << header.record_size
+                              << "; ignoring file." << sync_endl;
+                }
+
+                table.clear();
+                brainLearnHeaderData.clear();
+                binaryFormat     = true;
+                brainLearnFormat = false;
+            }
+        }
+
+        if (handledExpHeader)
+            return;
     }
 
     std::istringstream in(buffer);

--- a/src/experience_io.cpp
+++ b/src/experience_io.cpp
@@ -1,0 +1,170 @@
+#include "experience_io.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <sys/stat.h>
+#    include <unistd.h>
+#endif
+
+namespace {
+
+#ifdef _WIN32
+bool fileExists(const std::string& path) {
+    DWORD attr = GetFileAttributesA(path.c_str());
+    return (attr != INVALID_FILE_ATTRIBUTES) && !(attr & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+std::int64_t fileSize(const std::string& path) {
+    WIN32_FILE_ATTRIBUTE_DATA data;
+    if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &data))
+        return -1;
+    LARGE_INTEGER size{};
+    size.HighPart = static_cast<LONG>(data.nFileSizeHigh);
+    size.LowPart  = data.nFileSizeLow;
+    return static_cast<std::int64_t>(size.QuadPart);
+}
+#else
+bool fileExists(const std::string& path) {
+    struct stat st {
+    };
+    return ::stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+}
+
+std::int64_t fileSize(const std::string& path) {
+    struct stat st {
+    };
+    if (::stat(path.c_str(), &st) != 0)
+        return -1;
+    return st.st_size;
+}
+#endif
+
+void log_err(const char* msg, const std::string& path) {
+    std::fprintf(stderr, "[Experience] %s: %s", msg, path.c_str());
+    if (errno) {
+        std::fprintf(stderr, " (errno=%d: %s)", errno, std::strerror(errno));
+    }
+    std::fprintf(stderr, "\n");
+}
+
+bool ensureWritable(const std::string& path, const void* data, std::size_t len, bool allowTruncate) {
+    std::FILE* f = std::fopen(path.c_str(), "rb+");
+    if (!f) {
+        errno = 0;
+        f     = std::fopen(path.c_str(), allowTruncate ? "wb+" : "rb+");
+        if (!f) {
+            log_err("open failed", path);
+            return false;
+        }
+        if (allowTruncate && data && len) {
+            if (std::fwrite(data, len, 1, f) != 1) {
+                log_err("write header failed", path);
+                std::fclose(f);
+                return false;
+            }
+            std::fflush(f);
+        }
+    }
+    std::fclose(f);
+    return true;
+}
+
+}  // namespace
+
+bool Experience_FileLooksLikeSugar(const ExpHeader& h) {
+    const char* raw = reinterpret_cast<const char*>(&h);
+    const char* sugarSig = "SugaR";
+    return std::memcmp(raw, sugarSig, std::strlen(sugarSig)) == 0;
+}
+
+bool Experience_ReadHeader(const std::string& path, ExpHeader& out) {
+    std::FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) {
+        log_err("open rb failed", path);
+        return false;
+    }
+    if (std::fread(&out, sizeof(out), 1, f) != 1) {
+        std::fclose(f);
+        log_err("short header", path);
+        return false;
+    }
+    std::fclose(f);
+    return true;
+}
+
+bool Experience_WriteHeader(const std::string& path, const ExpHeader& h) {
+    std::FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) {
+        log_err("open wb failed", path);
+        return false;
+    }
+    if (std::fwrite(&h, sizeof(h), 1, f) != 1) {
+        std::fclose(f);
+        log_err("write header failed", path);
+        return false;
+    }
+    std::fclose(f);
+    return true;
+}
+
+bool Experience_IsCompatible(const ExpHeader& h) {
+    if (h.magic != kMagic_Accepted1)
+        return false;
+    if (h.record_size != kEngineRecordSize)
+        return false;
+    return true;
+}
+
+bool Experience_InitNew(const std::string& path) {
+    ExpHeader h{};
+    h.magic       = kMagic_Accepted1;
+    h.ver_flags   = kDefaultVerFlags;
+    h.field3      = kDefaultField3;
+    h.field4      = kDefaultField4;
+    h.record_size = kEngineRecordSize;
+    h.marker      = kDefaultMarker;
+    return Experience_WriteHeader(path, h);
+}
+
+bool Experience_OpenForReadWrite(const std::string& path) {
+    const bool exists = fileExists(path);
+    if (exists) {
+        ExpHeader header{};
+        if (!Experience_ReadHeader(path, header)) {
+            std::int64_t size = fileSize(path);
+            if (size > 0 && size <= static_cast<std::int64_t>(sizeof(ExpHeader)))
+                return Experience_InitNew(path);
+            return false;
+        }
+
+        const bool sugarLegacy = Experience_FileLooksLikeSugar(header);
+        if (!Experience_IsCompatible(header)) {
+            if (sugarLegacy) {
+                // Legacy SugaR file: don't truncate, just ensure we can write
+                return ensureWritable(path, nullptr, 0, false);
+            }
+#ifdef _WIN32
+            std::int64_t size = -1;
+#else
+            std::int64_t size = fileSize(path);
+#endif
+            if (size > static_cast<std::int64_t>(sizeof(ExpHeader))) {
+                log_err("incompatible header detected; refusing to truncate non-header file", path);
+                return false;
+            }
+            log_err("incompatible header; re-initializing", path);
+            return Experience_InitNew(path);
+        }
+
+        return ensureWritable(path, &header, sizeof(header), true);
+    }
+
+    return Experience_InitNew(path);
+}
+

--- a/src/experience_io.h
+++ b/src/experience_io.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct ExpHeader {
+    std::uint32_t magic;
+    std::uint32_t ver_flags;
+    std::uint32_t field3;
+    std::uint32_t field4;
+    std::uint32_t record_size;
+    std::uint32_t marker;
+};
+
+constexpr std::uint32_t kMagic_Accepted1 = 0x562F59FB;
+constexpr std::uint32_t kEngineRecordSize = 796;
+constexpr std::uint32_t kDefaultVerFlags  = 0x8F8F01D4;
+constexpr std::uint32_t kDefaultField3    = 20;
+constexpr std::uint32_t kDefaultField4    = 123;
+constexpr std::uint32_t kDefaultMarker    = 1;
+
+bool Experience_OpenForReadWrite(const std::string& path);
+bool Experience_InitNew(const std::string& path);
+bool Experience_IsCompatible(const ExpHeader& h);
+bool Experience_ReadHeader(const std::string& path, ExpHeader& out);
+bool Experience_WriteHeader(const std::string& path, const ExpHeader& h);
+
+bool Experience_FileLooksLikeSugar(const ExpHeader& h);
+

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -282,7 +282,7 @@ void Search::Worker::start_searching() {
     {
         if (!limits.infinite && !limits.mate)
         {
-            if ((bool) options["Experience Enabled"])
+            if ((bool) options["Experience"])
             {
                 if ((bool) options["Experience Prior"])
                     preferredMove =
@@ -424,7 +424,7 @@ void Search::Worker::start_searching() {
     auto bestmove = UCIEngine::move(bestThread->rootMoves[0].pv[0], rootPos.is_chess960());
     main_manager()->updates.onBestmove(bestmove, ponder);
 
-    if (!usedBook && (bool) options["Experience Enabled"]
+    if (!usedBook && (bool) options["Experience"]
         && !(bool) options["Experience Readonly"])
     {
         if (Worker* experienceThread = thread_for_updates(bestThread))

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -134,8 +134,8 @@ void UCIEngine::loop() {
 
             sync_cout << "uciok" << sync_endl;
 
-            if ((bool) engine.get_options()["Experience Enabled"])
-                experience.load_async(engine.get_options()["Experience File"]);
+            if ((bool) engine.get_options()["Experience"])
+                experience.load_async(engine.get_options()["ExperienceFile"]);
         }
 
         else if (token == "setoption")

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -473,7 +473,7 @@ class TestNNUEThreadSafety(unittest.TestCase):
         self.engine.expect("uciok")
         self.engine.clear_output()
 
-        self.engine.setoption("Experience Enabled", "false")
+        self.engine.setoption("Experience", "false")
         self.engine.send_command("isready")
         self.engine.expect("readyok")
         self.engine.clear_output()
@@ -572,7 +572,7 @@ class TestNNUEThreadSafety(unittest.TestCase):
         engine.expect("uciok")
         engine.clear_output()
 
-        engine.setoption("Experience Enabled", "false")
+        engine.setoption("Experience", "false")
         engine.setoption("Threads", "1")
         engine.setoption("Hash", "16")
         engine.send_command("isready")

--- a/tools/exp_probe.cpp
+++ b/tools/exp_probe.cpp
@@ -1,0 +1,52 @@
+#include <cstdio>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#pragma pack(push, 1)
+struct ExpHeader {
+    std::uint32_t magic;
+    std::uint32_t ver_flags;
+    std::uint32_t field3;
+    std::uint32_t field4;
+    std::uint32_t record_size;
+    std::uint32_t marker;
+};
+#pragma pack(pop)
+static_assert(sizeof(ExpHeader) == 24, "header must be 24 bytes");
+
+static ExpHeader readHeader(const char* path) {
+    std::FILE* f = std::fopen(path, "rb");
+    if (!f)
+        throw std::runtime_error(std::string("open fail: ") + path);
+    ExpHeader h{};
+    if (std::fread(&h, sizeof(h), 1, f) != 1) {
+        std::fclose(f);
+        throw std::runtime_error("short read");
+    }
+    std::fclose(f);
+    return h;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: %s file1.exp [file2.exp...]\n", argv[0]);
+        return 1;
+    }
+    for (int i = 1; i < argc; ++i) {
+        try {
+            auto h = readHeader(argv[i]);
+            std::printf("File: %s\n", argv[i]);
+            std::printf("  magic       = 0x%08X\n", h.magic);
+            std::printf("  ver_flags   = 0x%08X\n", h.ver_flags);
+            std::printf("  field3      = %u (0x%08X)\n", h.field3, h.field3);
+            std::printf("  field4      = %u (0x%08X)\n", h.field4, h.field4);
+            std::printf("  record_size = %u (0x%08X)\n", h.record_size, h.record_size);
+            std::printf("  marker      = %u (0x%08X)\n", h.marker, h.marker);
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "[ERR] %s: %s\n", argv[i], e.what());
+        }
+    }
+    return 0;
+}
+

--- a/tools/exp_smoketest.cpp
+++ b/tools/exp_smoketest.cpp
@@ -1,0 +1,17 @@
+#include "experience_io.h"
+
+#include <cstdio>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc != 2) {
+        std::fprintf(stderr, "usage: %s path.exp\n", argv[0]);
+        return 1;
+    }
+
+    const std::string path = argv[1];
+    bool ok                 = Experience_OpenForReadWrite(path);
+    std::printf("%s\n", ok ? "OK" : "FAIL");
+    return ok ? 0 : 2;
+}
+


### PR DESCRIPTION
## Summary
- add reusable experience header I/O helpers plus command line probe and smoketest utilities
- integrate the Experience/ExperienceFile options with the new I/O layer, add a ClearExperience button, and keep legacy aliases while improving logging
- detect header-only .exp files so they no longer parse as BrainLearn data and update docs/scripts/tests to the new option names

## Testing
- make -C src build ARCH=x86-64

------
https://chatgpt.com/codex/tasks/task_e_68d3d6d24f308327b7c4bd8c398a1eb8