### PR TITLE
Update engine identifier to revolution v.2.74-dev240925-EXP

### DIFF
--- a/docs/testing/book_move_time_experience.md
+++ b/docs/testing/book_move_time_experience.md
@@ -18,7 +18,7 @@ the previous search.
 ## Test procedure
 
 1. Launch the freshly built binary (e.g. `./build/revolution` or
-   `./src/revolution-2.73-dev-230925-wk`) and switch to UCI mode by sending `uci` and
+   `./src/revolution-v.2.74-dev240925-EXP`) and switch to UCI mode by sending `uci` and
    waiting for `uciok`.
 2. Enable the logger so that the session can be inspected afterwards:
    `setoption name Debug Log File value book-regression.log`.

--- a/docs/training/hyperparameter_schedule.md
+++ b/docs/training/hyperparameter_schedule.md
@@ -1,7 +1,7 @@
 # NNUE Training Hyperparameter Schedule (UHO 2024 8mv +0.85/+0.94)
 
 This plan refines the final phase of the NNUE training run used for the UHO 2024 8-move suite (+0.85/+0.94). The focus is to
-extract sharper tactical play from revolution 2.73-dev-230925-wk while limiting overfitting to the white side of the starting book.
+extract sharper tactical play from revolution v.2.74-dev240925-EXP while limiting overfitting to the white side of the starting book.
 
 ## Learning-rate schedule
 

--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -8,7 +8,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "FASTCHESS=C:\fastchess\fastchess.exe"
-set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution-2.73-dev-230925-wk.exe"
+set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution-v.2.74-dev240925-EXP.exe"
 set "ENGINE_BASE=C:\fastchess\revolution-base\revolution-dev_v2.40_130925.exe"
 set "DIR_NEW=C:\fastchess\revolution-ad"
 set "DIR_BASE=C:\fastchess\revolution-base"
@@ -97,7 +97,7 @@ if errorlevel 2 goto :sprt
 set "GATING_DONE=1"
 echo Running gating match (%GATING_GAMES% games) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.73-dev-230925-wk" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution v.2.74-dev240925-EXP" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^
@@ -142,7 +142,7 @@ if defined GATING_PERCENT (
 :sprt
 echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.73-dev-230925-wk" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution v.2.74-dev240925-EXP" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution-2.73-dev-230925-wk"
+ENGINE="$ROOT_DIR/src/revolution-v.2.74-dev240925-EXP"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/revolution-2.73-dev-230925-wk}"
+ENGINE="${ENGINE:-$ROOT_DIR/src/revolution-v.2.74-dev240925-EXP}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +15,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name="revolution 2.73-dev-230925-wk" \
+  -engine cmd="$ENGINE" name="revolution v.2.74-dev240925-EXP" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution-2.73-dev-230925-wk"
+ENGINE="$ROOT_DIR/src/revolution-v.2.74-dev240925-EXP"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution-2.73-dev-230925-wk"
+DEFAULT_ENGINE = ROOT / "src" / "revolution-v.2.74-dev240925-EXP"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -19,9 +19,9 @@ def run_bench(engine, name, value):
     raise RuntimeError("Unexpected bench output")
 
 def main():
-    p = argparse.ArgumentParser(description="SPSA tuning for revolution 2.73-dev-230925-wk")
+    p = argparse.ArgumentParser(description="SPSA tuning for revolution v.2.74-dev240925-EXP")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution-2.73-dev-230925-wk")
+    p.add_argument("--engine", default="src/revolution-v.2.74-dev240925-EXP")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution-2.73-dev-230925-wk.exe
+        EXE = revolution-v.2.74-dev240925-EXP.exe
 else
-        EXE = revolution-2.73-dev-230925-wk
+        EXE = revolution-v.2.74-dev240925-EXP
 endif
 
 ### Installation dir definitions
@@ -859,11 +859,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 # UCI "id name" string shown in GUIs.
 # Defaults:
-#   - ENGINE_NAME: "revolution-2.73-dev-230925-wk"
+#   - ENGINE_NAME: "revolution v.2.74-dev240925-EXP"
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
-#   make ENGINE_NAME="revolution-2.73-dev-230925-wk" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= revolution-2.73-dev-230925-wk
+#   make ENGINE_NAME="revolution v.2.74-dev240925-EXP" ENGINE_BUILD_DATE=20250907
+ENGINE_NAME        ?= revolution\ v.2.74-dev240925-EXP
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -123,7 +123,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution 2.73-dev-230925-wk"
+            // Force a stable, explicit UCI name so GUIs show "revolution v.2.74-dev240925-EXP"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution-2.73-dev-230925-wk"
+    #define ENGINE_NAME "revolution v.2.74-dev240925-EXP"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- bump the embedded ENGINE_NAME string to `revolution v.2.74-dev240925-EXP` and align the makefile defaults/binary names with the new tag
- refresh scripts and documentation so automation, matches and guides reference the updated executable name and UCI id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3ddc247a08327a4bb255fe925bf6b