### PR TITLE
Fix engine name escaping and clean unused lambda captures

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -863,7 +863,7 @@ endif
 #   - ENGINE_BUILD_DATE: optional build identifier
 # You can override on the command line:
 #   make ENGINE_NAME="revolution v.2.74-dev240925-EXP" ENGINE_BUILD_DATE=20250907
-ENGINE_NAME        ?= revolution\ v.2.74-dev240925-EXP
+ENGINE_NAME        ?= revolution v.2.74-dev240925-EXP
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -227,7 +227,7 @@ Engine::Engine(std::optional<std::string> path) :
         return std::nullopt;
     };
 
-    auto applyExperienceFile = [this, &setOptionSilently, &ensureExperienceReady](const std::string& value) -> std::optional<std::string> {
+    auto applyExperienceFile = [&setOptionSilently, &ensureExperienceReady](const std::string& value) -> std::optional<std::string> {
         if (options.count("ExperienceFile"))
             setOptionSilently("ExperienceFile", value);
         if (options.count("Experience File"))
@@ -238,19 +238,19 @@ Engine::Engine(std::optional<std::string> path) :
         return std::nullopt;
     };
 
-    options.add("Experience", Option(true, [this, &ensureExperienceReady](const Option& o) {
+    options.add("Experience", Option(true, [&ensureExperienceReady](const Option& o) {
                     return ensureExperienceReady(bool(o));
                 }));
 
-    options.add("Experience Enabled", Option(true, [this, &ensureExperienceReady](const Option& o) {
+    options.add("Experience Enabled", Option(true, [&ensureExperienceReady](const Option& o) {
                     return ensureExperienceReady(bool(o));
                 }));
 
-    options.add("ExperienceFile", Option("experience.exp", [this, &applyExperienceFile](const Option& o) {
+    options.add("ExperienceFile", Option("experience.exp", [&applyExperienceFile](const Option& o) {
                     return applyExperienceFile(std::string(o));
                 }));
 
-    options.add("Experience File", Option("experience.exp", [this, &applyExperienceFile](const Option& o) {
+    options.add("Experience File", Option("experience.exp", [&applyExperienceFile](const Option& o) {
                     return applyExperienceFile(std::string(o));
                 }));
 


### PR DESCRIPTION
## Summary
- define the default `ENGINE_NAME` without a literal backslash so the generated macro expands to a clean string literal
- drop unused `this` captures from the experience-related option callbacks in `engine.cpp`

## Testing
- `make -C src build ARCH=x86-64-sse41-popcnt COMP=clang -j2` *(fails: `clang++` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3dfe8cea883279be7bef80486e1dc