### PR TITLE
Harden experience database handling

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -185,6 +185,13 @@ Engine::Engine(std::optional<std::string> path) :
         return "experience.exp";
     };
 
+    auto getExperienceBuckets = [this]() -> std::uint32_t {
+        if (options.count("Experience Buckets"))
+            return Experience_NormalizeBucketCount(
+              static_cast<std::uint32_t>(int(options["Experience Buckets"])));
+        return kDefaultExperienceBuckets;
+    };
+
     auto lower_ext = [](const std::string& filePath) -> std::string {
         const auto dot = filePath.find_last_of('.');
         if (dot == std::string::npos)
@@ -196,7 +203,11 @@ Engine::Engine(std::optional<std::string> path) :
         return ext;
     };
 
-    auto ensureExperienceReady = [this, &setOptionSilently, &getExperienceFile, &lower_ext](bool enable) -> std::optional<std::string> {
+    auto ensureExperienceReady = [this,
+                                  &setOptionSilently,
+                                  &getExperienceFile,
+                                  &getExperienceBuckets,
+                                  &lower_ext](bool enable) -> std::optional<std::string> {
         if (!enable)
         {
             experience.clear();
@@ -209,7 +220,18 @@ Engine::Engine(std::optional<std::string> path) :
         const std::string file = getExperienceFile();
         const std::string ext  = lower_ext(file);
 
-        if (ext == ".exp" && !Experience_OpenForReadWrite(file))
+        bool        readOnly = options.count("Experience Readonly")
+                            && bool(options["Experience Readonly"]);
+        bool        openOk   = true;
+
+        if (ext == ".exp")
+        {
+            auto openResult = Experience_OpenForReadWrite(file, getExperienceBuckets());
+            openOk          = openResult.ok;
+            readOnly        = openResult.readOnly;
+        }
+
+        if (!openOk)
         {
             sync_cout << "info string Experience disabled due to file error: " << file << sync_endl;
             experience.clear();
@@ -218,6 +240,9 @@ Engine::Engine(std::optional<std::string> path) :
                 setOptionSilently("Experience Enabled", "false");
             return std::nullopt;
         }
+
+        if (options.count("Experience Readonly"))
+            setOptionSilently("Experience Readonly", readOnly ? "true" : "false");
 
         experience.load_async(file);
         sync_cout << "info string Experience OK: " << file << sync_endl;
@@ -246,6 +271,11 @@ Engine::Engine(std::optional<std::string> path) :
                     return ensureExperienceReady(bool(o));
                 }));
 
+    options.add("Experience Buckets",
+                Option(static_cast<double>(kDefaultExperienceBuckets),
+                       static_cast<int>(kMinExperienceBuckets),
+                       static_cast<int>(kMaxExperienceBuckets)));
+
     options.add("ExperienceFile", Option("experience.exp", [applyExperienceFile](const Option& o) {
                     return applyExperienceFile(std::string(o));
                 }));
@@ -254,12 +284,16 @@ Engine::Engine(std::optional<std::string> path) :
                     return applyExperienceFile(std::string(o));
                 }));
 
-    options.add("ClearExperience", Option([this, &getExperienceFile, &lower_ext, &ensureExperienceReady](const Option&) {
+    options.add("ClearExperience", Option([this,
+                                            &getExperienceFile,
+                                            &getExperienceBuckets,
+                                            &lower_ext,
+                                            &ensureExperienceReady](const Option&) {
                     const std::string target = getExperienceFile();
                     const std::string ext    = lower_ext(target);
                     bool              ok     = false;
                     if (ext == ".exp")
-                        ok = Experience_InitNew(target);
+                        ok = Experience_InitNew(target, getExperienceBuckets());
                     if (!ok)
                     {
                         sync_cout << "info string ClearExperience failed for: " << target << sync_endl;

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -205,25 +205,25 @@ void Experience::load(const std::string& file) {
     if (!buffer.empty())
     {
         bool handledExpHeader = false;
-        if (buffer.size() >= sizeof(ExpHeader))
+        if (buffer.size() >= sizeof(ExperienceHeader))
         {
-            ExpHeader header{};
+            ExperienceHeader header{};
             std::memcpy(&header, buffer.data(), sizeof(header));
             if (Experience_IsCompatible(header))
             {
                 handledExpHeader = true;
-                const std::size_t payload = buffer.size() - sizeof(ExpHeader);
+                const std::size_t payload = buffer.size() - sizeof(ExperienceHeader);
 
                 if (payload == 0)
                 {
                     sync_cout << "info string " << display
                               << " -> Experience header detected (no entries)." << sync_endl;
                 }
-                else if (payload % header.record_size == 0)
+                else if (payload % header.recordSize == 0)
                 {
-                    const std::size_t records = payload / header.record_size;
+                    const std::size_t records = payload / header.recordSize;
                     sync_cout << "info string " << display
-                              << " -> Experience format with record size " << header.record_size
+                              << " -> Experience format with record size " << header.recordSize
                               << " is not supported yet; ignoring " << records
                               << (records == 1 ? " record." : " records.") << sync_endl;
                 }
@@ -231,7 +231,7 @@ void Experience::load(const std::string& file) {
                 {
                     sync_cout << "info string " << display
                               << " -> Experience header detected but payload size " << payload
-                              << " does not align with record size " << header.record_size
+                              << " does not align with record size " << header.recordSize
                               << "; ignoring file." << sync_endl;
                 }
 

--- a/src/experience_io.cpp
+++ b/src/experience_io.cpp
@@ -1,170 +1,472 @@
 #include "experience_io.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <string>
+#include <system_error>
+#include <vector>
+
+#include "misc.h"
 
 #ifdef _WIN32
+#    include <io.h>
 #    include <windows.h>
 #else
+#    include <fcntl.h>
 #    include <sys/stat.h>
+#    include <sys/types.h>
 #    include <unistd.h>
 #endif
 
 namespace {
 
+class ExperienceWriteLock {
+   public:
+    explicit ExperienceWriteLock(const std::filesystem::path& target) {
 #ifdef _WIN32
-bool fileExists(const std::string& path) {
-    DWORD attr = GetFileAttributesA(path.c_str());
-    return (attr != INVALID_FILE_ATTRIBUTES) && !(attr & FILE_ATTRIBUTE_DIRECTORY);
+        std::wstring name = L"Global\\RevolutionExperience.lock";
+        handle        = CreateMutexW(nullptr, FALSE, name.c_str());
+        if (handle)
+            locked = WaitForSingleObject(handle, INFINITE) == WAIT_OBJECT_0;
+#else
+        std::filesystem::path lockPath = target;
+        lockPath += ".lock";
+        fd = ::open(lockPath.c_str(), O_CREAT | O_RDWR, 0666);
+        if (fd >= 0) {
+            struct flock fl {
+            };
+            fl.l_type   = F_WRLCK;
+            fl.l_whence = SEEK_SET;
+            fl.l_start  = 0;
+            fl.l_len    = 0;
+            locked      = fcntl(fd, F_SETLKW, &fl) != -1;
+            if (!locked) {
+                ::close(fd);
+                fd = -1;
+            }
+        }
+#endif
+    }
+
+    ExperienceWriteLock(const ExperienceWriteLock&)            = delete;
+    ExperienceWriteLock& operator=(const ExperienceWriteLock&) = delete;
+
+    ~ExperienceWriteLock() {
+#ifdef _WIN32
+        if (handle) {
+            if (locked)
+                ReleaseMutex(handle);
+            CloseHandle(handle);
+        }
+#else
+        if (fd >= 0) {
+            struct flock fl {
+            };
+            fl.l_type   = F_UNLCK;
+            fl.l_whence = SEEK_SET;
+            fl.l_start  = 0;
+            fl.l_len    = 0;
+            fcntl(fd, F_SETLK, &fl);
+            ::close(fd);
+        }
+#endif
+    }
+
+    bool owns_lock() const { return locked; }
+
+   private:
+#ifdef _WIN32
+    HANDLE handle = nullptr;
+#else
+    int  fd     = -1;
+#endif
+    bool locked = false;
+};
+
+bool is_pow2(std::uint32_t value) {
+    return value && ((value & (value - 1)) == 0);
 }
 
-std::int64_t fileSize(const std::string& path) {
-    WIN32_FILE_ATTRIBUTE_DATA data;
-    if (!GetFileAttributesExA(path.c_str(), GetFileExInfoStandard, &data))
-        return -1;
-    LARGE_INTEGER size{};
-    size.HighPart = static_cast<LONG>(data.nFileSizeHigh);
-    size.LowPart  = data.nFileSizeLow;
-    return static_cast<std::int64_t>(size.QuadPart);
+std::uint32_t crc32(const void* data, std::size_t length) {
+    static std::uint32_t table[256];
+    static bool          tableInit = false;
+
+    if (!tableInit) {
+        for (std::uint32_t i = 0; i < 256; ++i) {
+            std::uint32_t c = i;
+            for (int j = 0; j < 8; ++j)
+                c = (c >> 1) ^ (0xEDB88320U & (-(c & 1u)));
+            table[i] = c;
+        }
+        tableInit = true;
+    }
+
+    const auto* bytes = static_cast<const std::uint8_t*>(data);
+    std::uint32_t crc = 0xFFFFFFFFU;
+    for (std::size_t i = 0; i < length; ++i)
+        crc = table[(crc ^ bytes[i]) & 0xFFu] ^ (crc >> 8);
+    return crc ^ 0xFFFFFFFFU;
+}
+
+std::filesystem::path normalize_path(const std::string& raw) {
+    std::filesystem::path path(raw);
+    try {
+        path = path.lexically_normal();
+        if (path.is_relative())
+            path = std::filesystem::absolute(path);
+    } catch (const std::exception&) {
+        // Fall back to the original path representation.
+    }
+    return path;
+}
+
+std::string to_display_string(const std::filesystem::path& path) {
+#ifdef _WIN32
+    return path.u8string();
+#else
+    return path.string();
+#endif
+}
+
+void log_info(const std::string& message) {
+    sync_cout << "info string " << message << sync_endl;
+}
+
+void log_error(const std::string& message, const std::filesystem::path& path) {
+    const int savedErrno = errno;
+    std::string text     = message + ": '" + to_display_string(path) + "'";
+    if (savedErrno)
+        text += " (errno=" + std::to_string(savedErrno) + ": " + std::strerror(savedErrno) + ")";
+    log_info("experience: " + text);
+}
+
+#ifdef _WIN32
+void clear_readonly_attribute(const std::filesystem::path& path) {
+    std::wstring wide = path.wstring();
+    DWORD        attr = GetFileAttributesW(wide.c_str());
+    if (attr == INVALID_FILE_ATTRIBUTES)
+        return;
+    if (attr & FILE_ATTRIBUTE_READONLY)
+        SetFileAttributesW(wide.c_str(), attr & ~FILE_ATTRIBUTE_READONLY);
 }
 #else
-bool fileExists(const std::string& path) {
-    struct stat st {
-    };
-    return ::stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
-}
-
-std::int64_t fileSize(const std::string& path) {
-    struct stat st {
-    };
-    if (::stat(path.c_str(), &st) != 0)
-        return -1;
-    return st.st_size;
-}
+void clear_readonly_attribute(const std::filesystem::path&) {}
 #endif
 
-void log_err(const char* msg, const std::string& path) {
-    std::fprintf(stderr, "[Experience] %s: %s", msg, path.c_str());
-    if (errno) {
-        std::fprintf(stderr, " (errno=%d: %s)", errno, std::strerror(errno));
-    }
-    std::fprintf(stderr, "\n");
+std::size_t expected_file_size(std::uint32_t buckets) {
+    return sizeof(ExperienceHeader) + std::size_t(buckets) * sizeof(ExperienceRecord);
 }
 
-bool ensureWritable(const std::string& path, const void* data, std::size_t len, bool allowTruncate) {
-    std::FILE* f = std::fopen(path.c_str(), "rb+");
+void ensure_parent_directory(const std::filesystem::path& path) {
+    auto parent = path.parent_path();
+    if (parent.empty() || parent == ".")
+        return;
+    std::error_code ec;
+    std::filesystem::create_directories(parent, ec);
+}
+
+ExperienceHeader make_header(std::uint32_t buckets) {
+    ExperienceHeader header{};
+    header.magic      = kExperienceMagic;
+    header.version    = kExperienceVersion;
+    header.recordSize = static_cast<std::uint32_t>(sizeof(ExperienceRecord));
+    header.bucketCount = buckets;
+    header.headerSize  = static_cast<std::uint32_t>(sizeof(ExperienceHeader));
+    header.headerCrc32 = 0;
+    header.headerCrc32 = crc32(&header, sizeof(header));
+    return header;
+}
+
+bool validate_header(const ExperienceHeader& header, std::string* reason = nullptr) {
+    if (header.magic != kExperienceMagic) {
+        if (reason)
+            *reason = "magic mismatch";
+        return false;
+    }
+    if (header.version != kExperienceVersion) {
+        if (reason)
+            *reason = "version mismatch";
+        return false;
+    }
+    if (header.headerSize != sizeof(ExperienceHeader)) {
+        if (reason)
+            *reason = "header size mismatch";
+        return false;
+    }
+    if (header.recordSize != sizeof(ExperienceRecord)) {
+        if (reason)
+            *reason = "record size mismatch";
+        return false;
+    }
+    if (!is_pow2(header.bucketCount)) {
+        if (reason)
+            *reason = "bucket count not power of two";
+        return false;
+    }
+
+    ExperienceHeader temp = header;
+    temp.headerCrc32      = 0;
+    if (crc32(&temp, sizeof(temp)) != header.headerCrc32) {
+        if (reason)
+            *reason = "header CRC mismatch";
+        return false;
+    }
+
+    return true;
+}
+
+bool read_header_from_stream(std::istream& in, ExperienceHeader& header) {
+    in.read(reinterpret_cast<char*>(&header), sizeof(header));
+    return bool(in);
+}
+
+bool write_zero_filled(const std::filesystem::path& target, std::uint32_t buckets, ExperienceHeader& outHeader) {
+    ExperienceWriteLock guard(target);
+    if (!guard.owns_lock()) {
+        log_info("experience: failed to acquire write lock for '" + to_display_string(target)
+                 + "'");
+        return false;
+    }
+
+    const ExperienceHeader header = make_header(buckets);
+    const auto             total  = expected_file_size(buckets);
+
+    std::filesystem::path tmp = target;
+    tmp += ".tmp";
+
+    ensure_parent_directory(target);
+
+    clear_readonly_attribute(target);
+
+    errno = 0;
+    std::FILE* f = std::fopen(tmp.c_str(), "wb");
     if (!f) {
-        errno = 0;
-        f     = std::fopen(path.c_str(), allowTruncate ? "wb+" : "rb+");
-        if (!f) {
-            log_err("open failed", path);
+        log_error("failed to open temp file for writing", tmp);
+        return false;
+    }
+
+    auto cleanup = [&]() {
+        std::fclose(f);
+        std::error_code removeEc;
+        std::filesystem::remove(tmp, removeEc);
+    };
+
+    if (std::fwrite(&header, sizeof(header), 1, f) != 1) {
+        log_error("failed to write header", tmp);
+        cleanup();
+        return false;
+    }
+
+    const std::size_t payload = total - sizeof(header);
+    std::vector<std::uint8_t> zeros(std::min<std::size_t>(payload, 1u << 16), 0);
+    std::size_t               remaining = payload;
+    while (remaining) {
+        const std::size_t chunk = std::min<std::size_t>(zeros.size(), remaining);
+        if (chunk && std::fwrite(zeros.data(), 1, chunk, f) != chunk) {
+            log_error("failed while zero-filling", tmp);
+            cleanup();
             return false;
         }
-        if (allowTruncate && data && len) {
-            if (std::fwrite(data, len, 1, f) != 1) {
-                log_err("write header failed", path);
-                std::fclose(f);
-                return false;
-            }
-            std::fflush(f);
-        }
+        remaining -= chunk;
     }
+
+    std::fflush(f);
+#ifdef _WIN32
+    _commit(_fileno(f));
+#else
+    ::fsync(fileno(f));
+#endif
     std::fclose(f);
+
+    std::error_code ec;
+    std::filesystem::rename(tmp, target, ec);
+    if (ec) {
+        std::filesystem::remove(target, ec);
+        std::filesystem::rename(tmp, target, ec);
+    }
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        log_error("atomic rename failed", target);
+        return false;
+    }
+
+    outHeader = header;
+    return true;
+}
+
+bool ensure_readonly_status(const std::filesystem::path& path, bool& readOnly) {
+    errno = 0;
+    std::FILE* f = std::fopen(path.c_str(), "rb+");
+    if (f) {
+        std::fclose(f);
+        readOnly = false;
+        return true;
+    }
+
+    errno = 0;
+    f = std::fopen(path.c_str(), "rb");
+    if (!f)
+        return false;
+    std::fclose(f);
+    readOnly = true;
+    log_info("experience: path not writable, continuing read-only");
     return true;
 }
 
 }  // namespace
 
-bool Experience_FileLooksLikeSugar(const ExpHeader& h) {
-    const char* raw = reinterpret_cast<const char*>(&h);
-    const char* sugarSig = "SugaR";
-    return std::memcmp(raw, sugarSig, std::strlen(sugarSig)) == 0;
+std::uint32_t Experience_NormalizeBucketCount(std::uint32_t requested) {
+    if (requested < kMinExperienceBuckets)
+        requested = kMinExperienceBuckets;
+    if (requested > kMaxExperienceBuckets)
+        requested = kMaxExperienceBuckets;
+
+    if (!is_pow2(requested)) {
+        std::uint32_t pow2 = kMinExperienceBuckets;
+        while (pow2 < requested && pow2 < kMaxExperienceBuckets)
+            pow2 <<= 1;
+        if (!is_pow2(pow2))
+            pow2 = kDefaultExperienceBuckets;
+        requested = pow2;
+    }
+    return requested;
 }
 
-bool Experience_ReadHeader(const std::string& path, ExpHeader& out) {
-    std::FILE* f = std::fopen(path.c_str(), "rb");
-    if (!f) {
-        log_err("open rb failed", path);
+bool Experience_FileLooksLikeSugar(const ExperienceHeader& header) {
+    const char* raw     = reinterpret_cast<const char*>(&header);
+    const char* sugar   = "SugaR";
+    const size_t length = std::strlen(sugar);
+    return std::memcmp(raw, sugar, length) == 0;
+}
+
+bool Experience_IsCompatible(const ExperienceHeader& header) {
+    return validate_header(header);
+}
+
+bool Experience_ReadHeader(const std::string& path, ExperienceHeader& out) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        log_error("failed to open for reading", std::filesystem::path(path));
         return false;
     }
-    if (std::fread(&out, sizeof(out), 1, f) != 1) {
-        std::fclose(f);
-        log_err("short header", path);
+    if (!read_header_from_stream(in, out)) {
+        log_error("short header", std::filesystem::path(path));
         return false;
     }
-    std::fclose(f);
     return true;
 }
 
-bool Experience_WriteHeader(const std::string& path, const ExpHeader& h) {
-    std::FILE* f = std::fopen(path.c_str(), "wb");
-    if (!f) {
-        log_err("open wb failed", path);
-        return false;
-    }
-    if (std::fwrite(&h, sizeof(h), 1, f) != 1) {
-        std::fclose(f);
-        log_err("write header failed", path);
-        return false;
-    }
-    std::fclose(f);
-    return true;
-}
-
-bool Experience_IsCompatible(const ExpHeader& h) {
-    if (h.magic != kMagic_Accepted1)
-        return false;
-    if (h.record_size != kEngineRecordSize)
-        return false;
-    return true;
-}
-
-bool Experience_InitNew(const std::string& path) {
-    ExpHeader h{};
-    h.magic       = kMagic_Accepted1;
-    h.ver_flags   = kDefaultVerFlags;
-    h.field3      = kDefaultField3;
-    h.field4      = kDefaultField4;
-    h.record_size = kEngineRecordSize;
-    h.marker      = kDefaultMarker;
-    return Experience_WriteHeader(path, h);
-}
-
-bool Experience_OpenForReadWrite(const std::string& path) {
-    const bool exists = fileExists(path);
-    if (exists) {
-        ExpHeader header{};
-        if (!Experience_ReadHeader(path, header)) {
-            std::int64_t size = fileSize(path);
-            if (size > 0 && size <= static_cast<std::int64_t>(sizeof(ExpHeader)))
-                return Experience_InitNew(path);
+bool Experience_WriteHeader(const std::string& path, const ExperienceHeader& header) {
+    std::ofstream out(path, std::ios::binary | std::ios::in | std::ios::out);
+    if (!out) {
+        out.open(path, std::ios::binary | std::ios::trunc);
+        if (!out) {
+            log_error("failed to open for header write", std::filesystem::path(path));
             return false;
         }
-
-        const bool sugarLegacy = Experience_FileLooksLikeSugar(header);
-        if (!Experience_IsCompatible(header)) {
-            if (sugarLegacy) {
-                // Legacy SugaR file: don't truncate, just ensure we can write
-                return ensureWritable(path, nullptr, 0, false);
-            }
-#ifdef _WIN32
-            std::int64_t size = -1;
-#else
-            std::int64_t size = fileSize(path);
-#endif
-            if (size > static_cast<std::int64_t>(sizeof(ExpHeader))) {
-                log_err("incompatible header detected; refusing to truncate non-header file", path);
-                return false;
-            }
-            log_err("incompatible header; re-initializing", path);
-            return Experience_InitNew(path);
-        }
-
-        return ensureWritable(path, &header, sizeof(header), true);
     }
 
-    return Experience_InitNew(path);
+    out.seekp(0, std::ios::beg);
+    out.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    if (!out) {
+        log_error("failed to write header", std::filesystem::path(path));
+        return false;
+    }
+    out.flush();
+    return true;
+}
+
+bool Experience_InitNew(const std::string& path, std::uint32_t bucketCount) {
+    const std::filesystem::path normalized = normalize_path(path);
+
+    const std::uint32_t normalizedBuckets = Experience_NormalizeBucketCount(bucketCount);
+    if (normalizedBuckets != bucketCount)
+        log_info("experience: bucket count " + std::to_string(bucketCount)
+                 + " normalized to " + std::to_string(normalizedBuckets));
+
+    ExperienceHeader header{};
+    if (!write_zero_filled(normalized, normalizedBuckets, header))
+        return false;
+
+    log_info("experience: created '" + to_display_string(normalized) + "' with "
+             + std::to_string(normalizedBuckets) + " buckets (record="
+             + std::to_string(sizeof(ExperienceRecord)) + ", version="
+             + std::to_string(kExperienceVersion) + ")");
+    return true;
+}
+
+ExperienceOpenResult Experience_OpenForReadWrite(const std::string& path, std::uint32_t requestedBuckets) {
+    ExperienceOpenResult result{};
+    result.normalizedPath = path;
+
+    if (path.empty())
+        return result;
+
+    const std::filesystem::path normalized = normalize_path(path);
+    result.normalizedPath                  = to_display_string(normalized);
+
+    ensure_parent_directory(normalized);
+    std::error_code ec;
+
+    const std::uint32_t normalizedBuckets = Experience_NormalizeBucketCount(requestedBuckets);
+    if (normalizedBuckets != requestedBuckets)
+        log_info("experience: bucket count " + std::to_string(requestedBuckets)
+                 + " normalized to " + std::to_string(normalizedBuckets));
+
+    ExperienceHeader header{};
+    bool             exists = std::filesystem::exists(normalized);
+
+    if (!exists) {
+        if (!Experience_InitNew(normalized.string(), normalizedBuckets))
+            return result;
+        if (!Experience_ReadHeader(normalized.string(), header))
+            return result;
+        result.recreated = true;
+    } else {
+        if (!Experience_ReadHeader(normalized.string(), header))
+            header.headerSize = 0;  // force recreation below
+
+        std::string reason;
+        bool        valid = false;
+        if (header.headerSize == sizeof(ExperienceHeader))
+            valid = validate_header(header, &reason);
+        else
+            reason = "header size mismatch";
+
+        if (valid) {
+            std::uintmax_t size = std::filesystem::file_size(normalized, ec);
+            const auto     need = expected_file_size(header.bucketCount);
+            if (ec || size != need) {
+                valid  = false;
+                reason = "unexpected file size";
+            }
+        }
+
+        if (!valid) {
+            const std::string details = reason.empty() ? std::string{}
+                                                       : " (" + reason + ")";
+            log_info("experience: invalid or truncated file '" + to_display_string(normalized)
+                     + details + "' -> recreated with "
+                     + std::to_string(normalizedBuckets) + " buckets (record="
+                     + std::to_string(sizeof(ExperienceRecord)) + ", version="
+                     + std::to_string(kExperienceVersion) + ")");
+            if (!write_zero_filled(normalized, normalizedBuckets, header))
+                return result;
+            result.recreated = true;
+        }
+    }
+
+    if (!ensure_readonly_status(normalized, result.readOnly))
+        return result;
+
+    result.ok          = true;
+    result.bucketCount = header.bucketCount;
+    result.recordSize  = header.recordSize;
+    result.version     = header.version;
+    return result;
 }
 

--- a/src/experience_io.h
+++ b/src/experience_io.h
@@ -3,27 +3,57 @@
 #include <cstdint>
 #include <string>
 
-struct ExpHeader {
-    std::uint32_t magic;
-    std::uint32_t ver_flags;
-    std::uint32_t field3;
-    std::uint32_t field4;
-    std::uint32_t record_size;
-    std::uint32_t marker;
+#pragma pack(push, 1)
+struct ExperienceHeader {
+    std::uint64_t magic;
+    std::uint32_t version;
+    std::uint32_t recordSize;
+    std::uint32_t bucketCount;
+    std::uint32_t headerSize;
+    std::uint32_t headerCrc32;
+    std::uint8_t  reserved[32];
+};
+#pragma pack(pop)
+
+#pragma pack(push, 1)
+struct ExperienceRecord {
+    std::uint64_t key;
+    std::uint16_t move;
+    std::int16_t  score;
+    std::int16_t  depth;
+    std::int16_t  count;
+    std::uint32_t flags;
+    std::uint64_t lastWritten;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(ExperienceHeader) == 64, "ExperienceHeader must remain stable");
+static_assert(sizeof(ExperienceRecord) == 28, "ExperienceRecord layout changed unexpectedly");
+
+constexpr std::uint64_t kExperienceMagic   = 0xAABBEEDD66778899ULL;
+constexpr std::uint32_t kExperienceVersion = 1;
+constexpr std::uint32_t kMinExperienceBuckets = 1u << 10;
+constexpr std::uint32_t kMaxExperienceBuckets = 1u << 24;
+constexpr std::uint32_t kDefaultExperienceBuckets = 1u << 15;
+
+struct ExperienceOpenResult {
+    bool         ok           = false;
+    bool         readOnly     = false;
+    bool         recreated    = false;
+    std::uint32_t bucketCount = 0;
+    std::uint32_t recordSize  = 0;
+    std::uint32_t version     = 0;
+    std::string   normalizedPath;
 };
 
-constexpr std::uint32_t kMagic_Accepted1 = 0x915DF0F9;
-constexpr std::uint32_t kEngineRecordSize = 1383;
-constexpr std::uint32_t kDefaultVerFlags  = 0x80E34492;
-constexpr std::uint32_t kDefaultField3    = 245;
-constexpr std::uint32_t kDefaultField4    = 31999;
-constexpr std::uint32_t kDefaultMarker    = 1;
+std::uint32_t Experience_NormalizeBucketCount(std::uint32_t requested);
 
-bool Experience_OpenForReadWrite(const std::string& path);
-bool Experience_InitNew(const std::string& path);
-bool Experience_IsCompatible(const ExpHeader& h);
-bool Experience_ReadHeader(const std::string& path, ExpHeader& out);
-bool Experience_WriteHeader(const std::string& path, const ExpHeader& h);
+ExperienceOpenResult Experience_OpenForReadWrite(const std::string& path,
+                                                 std::uint32_t        requestedBuckets = kDefaultExperienceBuckets);
+bool Experience_InitNew(const std::string& path, std::uint32_t bucketCount = kDefaultExperienceBuckets);
+bool Experience_IsCompatible(const ExperienceHeader& h);
+bool Experience_ReadHeader(const std::string& path, ExperienceHeader& out);
+bool Experience_WriteHeader(const std::string& path, const ExperienceHeader& h);
 
-bool Experience_FileLooksLikeSugar(const ExpHeader& h);
+bool Experience_FileLooksLikeSugar(const ExperienceHeader& h);
 

--- a/tools/exp_probe.cpp
+++ b/tools/exp_probe.cpp
@@ -1,25 +1,14 @@
+#include "experience_io.h"
+
 #include <cstdio>
-#include <cstdint>
 #include <stdexcept>
 #include <string>
 
-#pragma pack(push, 1)
-struct ExpHeader {
-    std::uint32_t magic;
-    std::uint32_t ver_flags;
-    std::uint32_t field3;
-    std::uint32_t field4;
-    std::uint32_t record_size;
-    std::uint32_t marker;
-};
-#pragma pack(pop)
-static_assert(sizeof(ExpHeader) == 24, "header must be 24 bytes");
-
-static ExpHeader readHeader(const char* path) {
+static ExperienceHeader readHeader(const char* path) {
     std::FILE* f = std::fopen(path, "rb");
     if (!f)
         throw std::runtime_error(std::string("open fail: ") + path);
-    ExpHeader h{};
+    ExperienceHeader h{};
     if (std::fread(&h, sizeof(h), 1, f) != 1) {
         std::fclose(f);
         throw std::runtime_error("short read");
@@ -37,12 +26,13 @@ int main(int argc, char** argv) {
         try {
             auto h = readHeader(argv[i]);
             std::printf("File: %s\n", argv[i]);
-            std::printf("  magic       = 0x%08X\n", h.magic);
-            std::printf("  ver_flags   = 0x%08X\n", h.ver_flags);
-            std::printf("  field3      = %u (0x%08X)\n", h.field3, h.field3);
-            std::printf("  field4      = %u (0x%08X)\n", h.field4, h.field4);
-            std::printf("  record_size = %u (0x%08X)\n", h.record_size, h.record_size);
-            std::printf("  marker      = %u (0x%08X)\n", h.marker, h.marker);
+            std::printf("  magic       = 0x%016llX\n",
+                        static_cast<unsigned long long>(h.magic));
+            std::printf("  version     = %u\n", h.version);
+            std::printf("  recordSize  = %u\n", h.recordSize);
+            std::printf("  bucketCount = %u\n", h.bucketCount);
+            std::printf("  headerSize  = %u\n", h.headerSize);
+            std::printf("  headerCrc32 = 0x%08X\n", h.headerCrc32);
         } catch (const std::exception& e) {
             std::fprintf(stderr, "[ERR] %s: %s\n", argv[i], e.what());
         }

--- a/tools/exp_smoketest.cpp
+++ b/tools/exp_smoketest.cpp
@@ -10,8 +10,8 @@ int main(int argc, char** argv) {
     }
 
     const std::string path = argv[1];
-    bool ok                 = Experience_OpenForReadWrite(path);
-    std::printf("%s\n", ok ? "OK" : "FAIL");
-    return ok ? 0 : 2;
+    auto result = Experience_OpenForReadWrite(path);
+    std::printf("%s\n", result.ok ? "OK" : "FAIL");
+    return result.ok ? 0 : 2;
 }
 

--- a/tools/sanitize_exp.cpp
+++ b/tools/sanitize_exp.cpp
@@ -1,0 +1,48 @@
+#include "experience_io.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 2 || argc > 3) {
+        std::fprintf(stderr, "usage: %s <file.exp> [buckets]\n", argv[0]);
+        return 2;
+    }
+
+    const std::string path = argv[1];
+
+    std::uint32_t buckets = kDefaultExperienceBuckets;
+    if (argc == 3) {
+        try {
+            buckets = static_cast<std::uint32_t>(std::stoul(argv[2]));
+        } catch (const std::exception&) {
+            std::fprintf(stderr, "invalid bucket count: %s\n", argv[2]);
+            return 2;
+        }
+    }
+
+    buckets = Experience_NormalizeBucketCount(buckets);
+
+    try {
+        auto result = Experience_OpenForReadWrite(path, buckets);
+        if (!result.ok) {
+            std::fprintf(stderr, "ERROR: failed to repair %s\n", path.c_str());
+            return 1;
+        }
+
+        std::printf("OK: %s (buckets=%u, record=%u, version=%u, readonly=%s)\n",
+                    result.normalizedPath.c_str(),
+                    result.bucketCount,
+                    result.recordSize,
+                    result.version,
+                    result.readOnly ? "yes" : "no");
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "ERROR: %s\n", e.what());
+        return 1;
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- enforce a stable on-disk ABI for .exp files with validated headers, power-of-two bucket counts, and automatic repair/creation
- add a configurable Experience Buckets UCI option and propagate read-only status while keeping experience loading asynchronous
- update tooling to inspect/smoke-test the new header layout and introduce a sanitize_exp utility for repairing databases

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ec321f488327a4060a17c63ba085