### PR TITLE
Improve experience persistence and .exp support

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -219,6 +219,7 @@ Engine::Engine(std::optional<std::string> path) :
 
         const std::string file = getExperienceFile();
         const std::string ext  = lower_ext(file);
+        std::string       loadPath = file;
 
         bool        readOnly = options.count("Experience Readonly")
                             && bool(options["Experience Readonly"]);
@@ -229,11 +230,25 @@ Engine::Engine(std::optional<std::string> path) :
             auto openResult = Experience_OpenForReadWrite(file, getExperienceBuckets());
             openOk          = openResult.ok;
             readOnly        = openResult.readOnly;
+            if (!openResult.normalizedPath.empty())
+                loadPath = openResult.normalizedPath;
+
+            if (openOk)
+            {
+                if (options.count("ExperienceFile"))
+                    setOptionSilently("ExperienceFile", loadPath);
+                if (options.count("Experience File"))
+                    setOptionSilently("Experience File", loadPath);
+
+                if (openResult.recreated)
+                    sync_cout << "info string Experience file recreated: " << loadPath << sync_endl;
+            }
         }
 
         if (!openOk)
         {
-            sync_cout << "info string Experience disabled due to file error: " << file << sync_endl;
+            const std::string& failedPath = loadPath.empty() ? file : loadPath;
+            sync_cout << "info string Experience disabled due to file error: " << failedPath << sync_endl;
             experience.clear();
             setOptionSilently("Experience", "false");
             if (options.count("Experience Enabled"))
@@ -244,8 +259,8 @@ Engine::Engine(std::optional<std::string> path) :
         if (options.count("Experience Readonly"))
             setOptionSilently("Experience Readonly", readOnly ? "true" : "false");
 
-        experience.load_async(file);
-        sync_cout << "info string Experience OK: " << file << sync_endl;
+        experience.load_async(loadPath);
+        sync_cout << "info string Experience OK: " << loadPath << sync_endl;
         setOptionSilently("Experience", "true");
         if (options.count("Experience Enabled"))
             setOptionSilently("Experience Enabled", "true");
@@ -373,6 +388,44 @@ void Engine::go(Search::LimitsType& limits) {
 }
 void Engine::stop() { threads.stop = true; }
 
+void Engine::maybe_save_experience() {
+    if (!options.count("Experience") || !(bool) options["Experience"])
+        return;
+
+    if (options.count("Experience Readonly") && bool(options["Experience Readonly"]))
+        return;
+
+    std::string file = options.count("ExperienceFile") ? std::string(options["ExperienceFile"])
+                                                        : std::string(options["Experience File"]);
+
+    if (file.empty())
+        return;
+
+    if ((bool) options["Experience Concurrent"])
+    {
+        if (concurrentExperienceFile.empty())
+        {
+            std::random_device rd;
+            uint64_t           r = (uint64_t(rd()) << 32) ^ rd();
+            std::ostringstream oss;
+            oss << std::hex << std::setfill('0') << std::setw(16) << r;
+            std::string suffix = oss.str();
+            auto        p      = file.find_last_of('.');
+            if (p != std::string::npos)
+                concurrentExperienceFile = file.substr(0, p) + "-" + suffix + file.substr(p);
+            else
+                concurrentExperienceFile = file + "-" + suffix;
+        }
+        file = concurrentExperienceFile;
+    }
+    else
+    {
+        concurrentExperienceFile.clear();
+    }
+
+    experience.save(file);
+}
+
 void Engine::search_clear() {
     wait_for_search_finished();
 
@@ -383,28 +436,7 @@ void Engine::search_clear() {
     // keep their mappings alive until they also release.
     Tablebases::release();
 
-    if ((bool) options["Experience"] && !(bool) options["Experience Readonly"])
-    {
-        std::string file = options.count("ExperienceFile") ? std::string(options["ExperienceFile"]) : std::string(options["Experience File"]);
-        if ((bool) options["Experience Concurrent"])
-        {
-            if (concurrentExperienceFile.empty())
-            {
-                std::random_device rd;
-                uint64_t           r = (uint64_t(rd()) << 32) ^ rd();
-                std::ostringstream oss;
-                oss << std::hex << std::setfill('0') << std::setw(16) << r;
-                std::string suffix = oss.str();
-                auto        p      = file.find_last_of('.');
-                if (p != std::string::npos)
-                    concurrentExperienceFile = file.substr(0, p) + "-" + suffix + file.substr(p);
-                else
-                    concurrentExperienceFile = file + "-" + suffix;
-            }
-            file = concurrentExperienceFile;
-        }
-        experience.save(file);
-    }
+    maybe_save_experience();
 }
 
 void Engine::set_on_update_no_moves(std::function<void(const Engine::InfoShort&)>&& f) {
@@ -420,7 +452,12 @@ void Engine::set_on_iter(std::function<void(const Engine::InfoIter&)>&& f) {
 }
 
 void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_view)>&& f) {
-    updateContext.onBestmove = std::move(f);
+    onBestmoveHandler        = std::move(f);
+    updateContext.onBestmove = [this](std::string_view bestmove, std::string_view ponder) {
+        if (onBestmoveHandler)
+            onBestmoveHandler(bestmove, ponder);
+        maybe_save_experience();
+    };
 }
 
 void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -125,6 +125,9 @@ class Engine {
     std::function<void(std::string_view)> onVerifyNetworks;
 
     std::string concurrentExperienceFile;
+    std::function<void(std::string_view, std::string_view)> onBestmoveHandler;
+
+    void maybe_save_experience();
 };
 
 }  // namespace Stockfish

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -212,7 +212,8 @@ void Experience::load(const std::string& file) {
             if (Experience_IsCompatible(header))
             {
                 handledExpHeader = true;
-                const std::size_t payload = buffer.size() - sizeof(ExperienceHeader);
+                const std::size_t headerBytes = std::min<std::size_t>(static_cast<std::size_t>(header.headerSize), buffer.size());
+                const std::size_t payload     = buffer.size() - headerBytes;
 
                 if (payload == 0)
                 {
@@ -222,10 +223,46 @@ void Experience::load(const std::string& file) {
                 else if (payload % header.recordSize == 0)
                 {
                     const std::size_t records = payload / header.recordSize;
-                    sync_cout << "info string " << display
-                              << " -> Experience format with record size " << header.recordSize
-                              << " is not supported yet; ignoring " << records
-                              << (records == 1 ? " record." : " records.") << sync_endl;
+                    const auto*       begin   = reinterpret_cast<const std::uint8_t*>(buffer.data());
+                    const auto*       ptr     = begin + headerBytes;
+                    const auto*       end     = begin + buffer.size();
+
+                    std::size_t imported = 0;
+                    std::size_t skipped  = 0;
+
+                    auto clamp_depth = [](int value) {
+                        return std::max(value, 0);
+                    };
+
+                    while (ptr + header.recordSize <= end)
+                    {
+                        ExperienceRecord record{};
+                        const std::size_t copy = std::min<std::size_t>(sizeof(record), header.recordSize);
+                        std::memcpy(&record, ptr, copy);
+                        ptr += header.recordSize;
+
+                        const bool emptyMove = record.move == 0;
+                        const bool emptyKey  = record.key == 0ULL;
+                        if (emptyMove || emptyKey)
+                        {
+                            skipped++;
+                            continue;
+                        }
+
+                        const int storedCount = std::max<int>(1, record.count);
+                        const int storedDepth = clamp_depth(static_cast<int>(record.depth));
+
+                        insert_entry(record.key,
+                                     static_cast<unsigned>(record.move),
+                                     static_cast<int>(record.score),
+                                     storedDepth,
+                                     storedCount);
+                        imported++;
+                    }
+
+                    sync_cout << "info string " << display << " -> Experience format (" << records
+                              << (records == 1 ? " record" : " records") << ") loaded " << imported
+                              << ", skipped " << skipped << sync_endl;
                 }
                 else
                 {
@@ -679,12 +716,7 @@ void Experience::save(const std::string& file) const {
     }
     else
     {
-        std::ofstream out(path, std::ios::binary);
-        if (out)
-        {
-            out.write(buffer.data(), buffer.size());
-            ok = bool(out);
-        }
+        ok = Experience_WriteBufferAtomically(path, buffer);
     }
 
     if (!ok)

--- a/src/experience_io.cpp
+++ b/src/experience_io.cpp
@@ -324,6 +324,65 @@ bool write_zero_filled(const std::filesystem::path& target, std::uint32_t bucket
     return true;
 }
 
+bool Experience_WriteBufferAtomically(const std::string& path, const std::string& buffer) {
+    if (path.empty())
+        return false;
+
+    const std::filesystem::path target = normalize_path(path);
+    ExperienceWriteLock         guard(target);
+    if (!guard.owns_lock()) {
+        log_info("experience: failed to acquire write lock for '" + to_display_string(target) + "'");
+        return false;
+    }
+
+    std::filesystem::path tmp = target;
+    tmp += ".tmp";
+
+    ensure_parent_directory(target);
+    clear_readonly_attribute(target);
+
+    errno = 0;
+    std::FILE* f = fopen_compat(tmp, "wb");
+    if (!f) {
+        log_error("failed to open temp file for writing", tmp);
+        return false;
+    }
+
+    auto cleanup = [&]() {
+        std::fclose(f);
+        std::error_code removeEc;
+        std::filesystem::remove(tmp, removeEc);
+    };
+
+    if (!buffer.empty() && std::fwrite(buffer.data(), 1, buffer.size(), f) != buffer.size()) {
+        log_error("failed while writing buffer", tmp);
+        cleanup();
+        return false;
+    }
+
+    std::fflush(f);
+#ifdef _WIN32
+    _commit(_fileno(f));
+#else
+    ::fsync(fileno(f));
+#endif
+    std::fclose(f);
+
+    std::error_code ec;
+    std::filesystem::rename(tmp, target, ec);
+    if (ec) {
+        std::filesystem::remove(target, ec);
+        std::filesystem::rename(tmp, target, ec);
+    }
+    if (ec) {
+        std::filesystem::remove(tmp, ec);
+        log_error("atomic rename failed", target);
+        return false;
+    }
+
+    return true;
+}
+
 bool ensure_readonly_status(const std::filesystem::path& path, bool& readOnly) {
     errno = 0;
     std::FILE* f = fopen_compat(path, "rb+");

--- a/src/experience_io.h
+++ b/src/experience_io.h
@@ -57,3 +57,5 @@ bool Experience_WriteHeader(const std::string& path, const ExperienceHeader& h);
 
 bool Experience_FileLooksLikeSugar(const ExperienceHeader& h);
 
+bool Experience_WriteBufferAtomically(const std::string& path, const std::string& buffer);
+


### PR DESCRIPTION
## Summary
- save experience data immediately after each search and share the persistence logic with search clearing
- normalize experience file paths returned by the .exp opener and log canonicalized locations when enabling the feature
- import binary .exp records and write experience files through an atomic helper to avoid corruption

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: missing Qt5 development package)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fc97c3cc83279b517d14d68d8f14