### PR TITLE
Fix Windows experience lock fallback to restore experience files

### DIFF
--- a/src/experience_io.cpp
+++ b/src/experience_io.cpp
@@ -41,8 +41,23 @@ class ExperienceWriteLock {
         wchar_t hashBuffer[32];
         std::swprintf(hashBuffer, sizeof(hashBuffer) / sizeof(hashBuffer[0]), L"%016llX",
                       static_cast<unsigned long long>(hash));
-        std::wstring name = L"Global\\RevolutionExperience-" + std::wstring(hashBuffer);
-        handle        = CreateMutexW(nullptr, FALSE, name.c_str());
+
+        auto try_mutex = [](const std::wstring& name) -> HANDLE {
+            if (name.empty())
+                return nullptr;
+            return CreateMutexW(nullptr, FALSE, name.c_str());
+        };
+
+        const std::wstring suffix = L"RevolutionExperience-" + std::wstring(hashBuffer);
+
+        std::wstring candidates[] = {L"Global\\" + suffix, L"Local\\" + suffix, suffix};
+
+        for (const auto& candidate : candidates) {
+            handle = try_mutex(candidate);
+            if (handle)
+                break;
+        }
+
         if (handle)
             locked = WaitForSingleObject(handle, INFINITE) == WAIT_OBJECT_0;
 #else


### PR DESCRIPTION
## Summary
- update the Windows experience file lock helper to try Global, Local, and unnamed mutex namespaces in order
- allow the engine to fall back when Global objects are not permitted so experience files can be read and written again

## Testing
- make -C src build ARCH=x86-64

------
https://chatgpt.com/codex/tasks/task_e_68d423485a588327b0e68b4e4a5b4004