### PR TITLE
Fix missing declaration for experience IO helper

### DIFF
--- a/src/experience_io.cpp
+++ b/src/experience_io.cpp
@@ -38,6 +38,8 @@
 
 namespace {
 
+void ensure_parent_directory(const std::filesystem::path& path);
+
 class ExperienceWriteLock {
    public:
     explicit ExperienceWriteLock(const std::filesystem::path& target) {


### PR DESCRIPTION
## Summary
- declare ensure_parent_directory before its first use in experience_io.cpp

## Testing
- ⚠️ `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4403f86f08327a6b76df5d42c4934