### PR TITLE
Add UCI option aliases for experience settings

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -281,10 +281,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience", Option(true, [&ensureExperienceReady](const Option& o) {
                     return ensureExperienceReady(bool(o));
                 }));
-
-    options.add("Experience Enabled", Option(true, [&ensureExperienceReady](const Option& o) {
-                    return ensureExperienceReady(bool(o));
-                }));
+    options.add_alias("Experience Enabled", "Experience");
 
     options.add("Experience Buckets",
                 Option(static_cast<double>(kDefaultExperienceBuckets),
@@ -294,10 +291,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("ExperienceFile", Option("experience.exp", [applyExperienceFile](const Option& o) {
                     return applyExperienceFile(std::string(o));
                 }));
-
-    options.add("Experience File", Option("experience.exp", [applyExperienceFile](const Option& o) {
-                    return applyExperienceFile(std::string(o));
-                }));
+    options.add_alias("Experience File", "ExperienceFile");
 
     options.add("ClearExperience", Option([this,
                                             &getExperienceFile,

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -60,19 +60,25 @@ void OptionsMap::setoption(std::istringstream& is) {
 
     if (options_map.count(name))
         options_map[name] = value;
+    else if (auto aliasIt = alias_map.find(name); aliasIt != alias_map.end())
+        options_map[aliasIt->second] = value;
     else
         sync_cout << "No such option: " << name << sync_endl;
 }
 
 const Option& OptionsMap::operator[](const std::string& name) const {
     auto it = options_map.find(name);
-    assert(it != options_map.end());
-    return it->second;
+    if (it != options_map.end())
+        return it->second;
+
+    auto aliasIt = alias_map.find(name);
+    assert(aliasIt != alias_map.end());
+    return options_map.find(aliasIt->second)->second;
 }
 
 // Inits options and assigns idx in the correct printing order
 void OptionsMap::add(const std::string& name, const Option& option) {
-    if (!options_map.count(name))
+    if (!options_map.count(name) && !alias_map.count(name))
     {
         static size_t insert_order = 0;
 
@@ -89,7 +95,28 @@ void OptionsMap::add(const std::string& name, const Option& option) {
 }
 
 
-std::size_t OptionsMap::count(const std::string& name) const { return options_map.count(name); }
+void OptionsMap::add_alias(const std::string& alias, const std::string& target) {
+    auto canonical = options_map.find(target);
+    if (canonical == options_map.end())
+    {
+        std::cerr << "Alias target \"" << target << "\" does not exist" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
+    if (options_map.count(alias) || alias_map.count(alias))
+    {
+        std::cerr << "Alias \"" << alias << "\" conflicts with an existing option" << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+
+    alias_map[alias] = target;
+}
+
+std::size_t OptionsMap::count(const std::string& name) const {
+    if (options_map.count(name))
+        return 1;
+    return alias_map.count(name);
+}
 
 Option::Option(const OptionsMap* map) :
     parent(map) {}

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -86,6 +86,7 @@ class OptionsMap {
     const Option& operator[](const std::string&) const;
 
     void add(const std::string&, const Option& option);
+    void add_alias(const std::string& alias, const std::string& target);
 
     std::size_t count(const std::string&) const;
 
@@ -97,8 +98,10 @@ class OptionsMap {
 
     // The options container is defined as a std::map
     using OptionsStore = std::map<std::string, Option, CaseInsensitiveLess>;
+    using AliasStore   = std::map<std::string, std::string, CaseInsensitiveLess>;
 
     OptionsStore options_map;
+    AliasStore   alias_map;
     InfoListener info;
 };
 


### PR DESCRIPTION
## Summary
- add UCI option alias support so GUIs can offer alternate names without duplicating entries
- expose BrainLearn-style experience option names as aliases instead of separate options to prevent duplicates in Fritz GUI

## Testing
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release *(fails: missing Qt5 development package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d44e18669483279897c28d37169518