### PR TITLE
Update engine identifiers to v2.74-dev-250925-tsd1

### DIFF
--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -8,7 +8,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "FASTCHESS=C:\fastchess\fastchess.exe"
-set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution-v.2.74-dev240925-EXP.exe"
+set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution v2.74-dev-250925-tsd1.exe"
 set "ENGINE_BASE=C:\fastchess\revolution-base\revolution-dev_v2.40_130925.exe"
 set "DIR_NEW=C:\fastchess\revolution-ad"
 set "DIR_BASE=C:\fastchess\revolution-base"
@@ -97,7 +97,7 @@ if errorlevel 2 goto :sprt
 set "GATING_DONE=1"
 echo Running gating match (%GATING_GAMES% games) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution v.2.74-dev240925-EXP" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution v2.74-dev-250925-tsd1" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^
@@ -142,7 +142,7 @@ if defined GATING_PERCENT (
 :sprt
 echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution v.2.74-dev240925-EXP" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution v2.74-dev-250925-tsd1" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,8 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution v2.74-dev-250925-tsd1"
+ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/gauntlet.cmd
+++ b/scripts/gauntlet.cmd
@@ -7,7 +7,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "CUTECHESS=C:\\cutechess\\cutechess-cli.exe"
-set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution-dev.exe"
+set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution v2.74-dev-250925-tsd1.exe"
 set "ENGINE_BASE=C:\\engines\\revolution-stable\\revolution-stable.exe"
 set "DIR_NEW=C:\\engines\\revolution-dev"
 set "DIR_BASE=C:\\engines\\revolution-stable"
@@ -76,7 +76,7 @@ if not "%NNUE_BASE%"=="" for %%F in ("%NNUE_BASE%") do set "ENGINE_BASE_EVAL= op
 echo Starting gauntlet (%GAMES% games, %ROUNDS% rounds) ...
 "%CUTECHESS%" ^
  -tournament gauntlet ^
- -engine cmd="%ENGINE_NEW%" name="revolution-dev" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution v2.74-dev-250925-tsd1" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution-stable" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,8 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="${ENGINE:-$ROOT_DIR/src/revolution}"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution v2.74-dev-250925-tsd1"
+ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
 TC="${3:-40/0.4+0.4}"
@@ -15,7 +16,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name=Revolution \
+  -engine cmd="$ENGINE" name="revolution v2.74-dev-250925-tsd1" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,8 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE="$ROOT_DIR/src/revolution"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution v2.74-dev-250925-tsd1"
+ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 TEST_DIR="$ROOT_DIR/tests"
 
 if [ ! -x "$ENGINE" ]; then

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution-v.2.74-dev240925-EXP"
+DEFAULT_ENGINE = ROOT / "src" / "revolution v2.74-dev-250925-tsd1"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Revolution")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution")
+    p.add_argument("--engine", default="src/revolution v2.74-dev-250925-tsd1")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,12 +37,16 @@ else ifeq ($(COMP),mingw)
 	endif
 endif
 
+empty :=
+space := $(empty) $(empty)
+
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution-dev_v2.40_130925.exe
+        EXE_UNESCAPED = $(ENGINE_NAME).exe
 else
-        EXE = revolution-dev_v2.40_130925
+        EXE_UNESCAPED = $(ENGINE_NAME)
 endif
+EXE = $(subst $(space),\ ,$(EXE_UNESCAPED))
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -862,11 +866,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution-dev v.2.40 130925"
+#- ENGINE_NAME : "revolution v2.74-dev-250925-tsd1"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution-dev v.2.40 130925" ENGINE_BUILD_DATE = 20250913
-ENGINE_NAME        ?= revolution-dev v.2.40 130925
+#make ENGINE_NAME = "revolution v2.74-dev-250925-tsd1" ENGINE_BUILD_DATE = 20250925
+ENGINE_NAME        ?= revolution v2.74-dev-250925-tsd1
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 
@@ -1025,12 +1029,12 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
 
 strip:
-	$(STRIP) $(EXE)
+	$(STRIP) "$(EXE_UNESCAPED)"
 
 install:
 	-mkdir -p -m 755 $(BINDIR)
-	-cp $(EXE) $(BINDIR)
-	$(STRIP) $(BINDIR)/$(EXE)
+	-cp "$(EXE_UNESCAPED)" "$(BINDIR)/$(EXE_UNESCAPED)"
+	$(STRIP) "$(BINDIR)/$(EXE_UNESCAPED)"
 
 #clean all
 clean: objclean profileclean
@@ -1136,7 +1140,7 @@ config-sanity: net
 	 test "$(comp)" = "aarch64-linux-android21-clang")
 
 $(EXE): $(OBJS)
-	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+	+$(CXX) -o "$@" $(OBJS) $(LDFLAGS)
 
 # Force recompilation to ensure version info is up-to-date
 misc.o: FORCE

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution-dev v.2.40 130925"
+            // Force a stable, explicit UCI name so GUIs show "revolution v2.74-dev-250925-tsd1"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution-dev v.2.40 130925"
+    #define ENGINE_NAME "revolution v2.74-dev-250925-tsd1"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- set the default UCI id string to "revolution v2.74-dev-250925-tsd1" in the engine sources and build configuration, and teach the Makefile to emit an executable with the same name across platforms
- refresh helper scripts and Windows harnesses so they point to the renamed binary and display the new identifier in GUIs
- ensure install/strip steps quote the renamed executable and adjust ancillary tooling defaults accordingly

## Testing
- make -j2 build ARCH=x86-64
- make -j2 build ARCH=x86-64 COMP=clang *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d462d02d5083279bd0f28e9195be9b