### PR TITLE
Fix tempo bonus color bias

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,7 +127,8 @@ Value adaptive_style_bonus(const Position& pos, Value current) {
 
 // Simple tempo bonus favoring the side to move
 Value tempo_bonus(const Position& pos) {
-    return pos.side_to_move() == Color::WHITE ? Value(10) : Value(-10);
+    (void)pos;  // Tempo bonus is symmetric for both colors
+    return Value(10);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- make the tempo bonus symmetric regardless of the side to move to avoid a persistent color bias

## Testing
- make build ARCH=x86-64-sse41-popcnt

------
https://chatgpt.com/codex/tasks/task_e_68d475ed10188327aabc01d88888155e