### PR TITLE
Restore color-dependent tempo bonus

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -127,8 +127,7 @@ Value adaptive_style_bonus(const Position& pos, Value current) {
 
 // Simple tempo bonus favoring the side to move
 Value tempo_bonus(const Position& pos) {
-    (void)pos;  // Tempo bonus is symmetric for both colors
-    return Value(10);
+    return pos.side_to_move() == Color::WHITE ? Value(10) : Value(-10);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- reinstate the tempo bonus to depend on the side to move so it remains antisymmetric

## Testing
- ./"revolution v2.74-dev-250925-tsd1" <<'EOF'
uci
isready
ucinewgame
position startpos
eval
position fen rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1
eval
quit
EOF


------
https://chatgpt.com/codex/tasks/task_e_68d754b997e08327873f115c65ed7947