### PR TITLE
Make tempo bonus symmetric between colors

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -125,9 +125,10 @@ Value adaptive_style_bonus(const Position& pos, Value current) {
     return Value(bonus);
 }
 
-// Simple tempo bonus favoring the side to move
+// Simple tempo bonus applied symmetrically to either side
 Value tempo_bonus(const Position& pos) {
-    return pos.side_to_move() == Color::WHITE ? Value(10) : Value(-10);
+    (void)pos.side_to_move();  // Document intent without affecting symmetry
+    return Value(10);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- return a fixed bonus from tempo regardless of the side to move and clarify the intent in code comments

## Testing
- make build
- bash scripts/match.sh ./src/revolution\ v.2.80-dev-270925 4 10/0.1+0.1 *(fails: cutechess-cli not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d91b61fa888327aa2f0ba74cab36b2