### PR TITLE
Cache FEN data before starting thread jobs

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -278,15 +278,18 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     // be deduced from a fen string, so set() clears them and they are set from
     // setupStates->back() later. The rootState is per thread, earlier states are
     // shared since they are read-only.
+    const std::string fen        = pos.fen();
+    const bool        isChess960 = pos.is_chess960();
+
     for (auto&& th : threads)
     {
-        th->run_custom_job([&]() {
+        th->run_custom_job([&, fen, isChess960]() {
             th->worker->limits = limits;
             th->worker->nodes = th->worker->tbHits = th->worker->nmpMinPly =
               th->worker->bestMoveChanges          = 0;
             th->worker->rootDepth = th->worker->completedDepth = 0;
             th->worker->rootMoves                              = rootMoves;
-            th->worker->rootPos.set(pos.fen(), pos.is_chess960(), &th->worker->rootState);
+            th->worker->rootPos.set(fen, isChess960, &th->worker->rootState);
             th->worker->rootState = setupStates->back();
             th->worker->tbConfig  = tbConfig;
         });


### PR DESCRIPTION
## Summary
- cache the root position FEN string and Chess960 flag before spawning thread jobs
- initialize each worker from the cached data to avoid repeated `Position` queries while preserving per-thread root state copies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc7979df2c8327b75e93dc218316d9