### PR TITLE
Update engine id name to revolution 2.81 021025

### DIFF
--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -8,7 +8,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "FASTCHESS=C:\fastchess\fastchess.exe"
-set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution 2.80 300925.exe"
+set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution 2.81 021025.exe"
 set "ENGINE_BASE=C:\fastchess\revolution-base\revolution-dev_v2.40_130925.exe"
 set "DIR_NEW=C:\fastchess\revolution-ad"
 set "DIR_BASE=C:\fastchess\revolution-base"
@@ -97,7 +97,7 @@ if errorlevel 2 goto :sprt
 set "GATING_DONE=1"
 echo Running gating match (%GATING_GAMES% games) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.80 300925" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^
@@ -142,7 +142,7 @@ if defined GATING_PERCENT (
 :sprt
 echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.80 300925" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.80 300925"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 

--- a/scripts/gauntlet.cmd
+++ b/scripts/gauntlet.cmd
@@ -7,7 +7,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "CUTECHESS=C:\\cutechess\\cutechess-cli.exe"
-set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution 2.80 300925.exe"
+set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution 2.81 021025.exe"
 set "ENGINE_BASE=C:\\engines\\revolution-stable\\revolution-stable.exe"
 set "DIR_NEW=C:\\engines\\revolution-dev"
 set "DIR_BASE=C:\\engines\\revolution-stable"
@@ -76,7 +76,7 @@ if not "%NNUE_BASE%"=="" for %%F in ("%NNUE_BASE%") do set "ENGINE_BASE_EVAL= op
 echo Starting gauntlet (%GAMES% games, %ROUNDS% rounds) ...
 "%CUTECHESS%" ^
  -tournament gauntlet ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.80 300925" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution-stable" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.80 300925"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
@@ -16,7 +16,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name="revolution 2.80 300925" \
+  -engine cmd="$ENGINE" name="revolution 2.81 021025" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.80 300925"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 TEST_DIR="$ROOT_DIR/tests"
 

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution 2.80 300925"
+DEFAULT_ENGINE = ROOT / "src" / "revolution 2.81 021025"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Revolution")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution 2.80 300925")
+    p.add_argument("--engine", default="src/revolution 2.81 021025")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -866,11 +866,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution 2.80 300925"
+#- ENGINE_NAME : "revolution 2.81 021025"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution 2.80 300925" ENGINE_BUILD_DATE = 20250925
-ENGINE_NAME        ?= revolution 2.80 300925
+#make ENGINE_NAME = "revolution 2.81 021025" ENGINE_BUILD_DATE = 20251025
+ENGINE_NAME        ?= revolution 2.81 021025
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution 2.80 300925"
+            // Force a stable, explicit UCI name so GUIs show "revolution 2.81 021025"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.80 300925"
+    #define ENGINE_NAME "revolution 2.81 021025"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- update the engine name constant so the executable reports "revolution 2.81 021025"
- refresh UCI handling and helper scripts to use the new identifier
- align Makefile defaults with the updated version label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de55ff98308327b7e88a638b686d68