### PR TITLE
Add missing iostream include to main

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,8 @@
   Modifications Copyright (C) 2024 Jorge Ruiz Centelles
 */
 
+#include <iostream>
+
 #include "misc.h"
 #include "uci.h"
 #include "tune.h"


### PR DESCRIPTION
## Summary
- include <iostream> directly in main.cpp so the file pulls in its own std::cerr/std::endl declarations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def58bb1a48327ba21ce0570ae920f