### PR TITLE
Document review task failure status

### DIFF
--- a/docs/review_status.md
+++ b/docs/review_status.md
@@ -1,0 +1,7 @@
+# Review Status
+
+The requested code review for potential errors could not be completed.
+
+Reason: automatic extraction of the necessary context failed, so the task is marked as **failed**.
+
+No code changes were made as part of this status update.


### PR DESCRIPTION
## Summary
- add documentation noting that the requested code review could not be performed
- record that the task failed because the required code extraction was not possible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e10d927bdc8327823cd2716f769538