### PR TITLE
Fix POSIX aligned allocation return value

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -78,6 +78,7 @@ void* std_aligned_alloc(size_t alignment, size_t size) {
     int err = posix_memalign(&mem, alignment, size);
     if (err != 0)
         return nullptr;
+    return mem;
 #elif defined(_WIN32) && !defined(_M_ARM) && !defined(_M_ARM64)
     return _mm_malloc(size, alignment);
 #elif defined(_WIN32)


### PR DESCRIPTION
## Summary
- ensure std_aligned_alloc returns the pointer obtained from posix_memalign on POSIX platforms
- prevent falling through without returning allocated memory when aligned allocation succeeds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e10e518428832793000e7ec263171c