### PR TITLE
Enhance evaluation and search heuristics with tuning tooling

### DIFF
--- a/scripts/run_texel.py
+++ b/scripts/run_texel.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Utility script to run a lightweight Texel-style tuning session.
+
+The script parses a PGN (or simple FEN list) and extracts positions together with
+game results. For each position it recomputes the handcrafted evaluation terms
+implemented in the engine and performs a logistic regression to obtain scaling
+weights that best fit the observed results. The final weights are written to
+stdout and can optionally be exported to JSON for further processing.
+
+The implementation intentionally mirrors the heuristics used in the C++
+evaluation so that the suggested weights can be plugged into
+`Eval::ManualEvalWeights` without additional transformations.
+
+Examples
+--------
+
+```
+python3 scripts/run_texel.py --input recent_games.pgn --max-games 2000 \
+    --output weights.json
+```
+
+Requirements
+------------
+
+The script relies on the `python-chess` package for PGN parsing and board
+manipulation. Install it with `pip install python-chess` if it is not already
+available in your environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+try:
+    import chess
+    import chess.pgn
+except ImportError as exc:  # pragma: no cover - handled at runtime
+    raise SystemExit(
+        "python-chess is required to run Texel tuning. Install it with"
+        " 'pip install python-chess' and retry."
+    ) from exc
+
+
+ResultValue = float
+
+
+def relative_rank(color: chess.Color, square: chess.Square) -> int:
+    rank = chess.square_rank(square)
+    return rank if color == chess.WHITE else 7 - rank
+
+
+def forward_span(color: chess.Color, square: chess.Square) -> List[chess.Square]:
+    span: List[chess.Square] = []
+    direction = 1 if color == chess.WHITE else -1
+    rank = chess.square_rank(square) + direction
+
+    while 0 <= rank <= 7:
+        for file_offset in (-1, 0, 1):
+            file = chess.square_file(square) + file_offset
+            if 0 <= file <= 7:
+                span.append(chess.square(file, rank))
+        rank += direction
+
+    return span
+
+
+def is_passed_pawn(board: chess.Board, color: chess.Color, square: chess.Square) -> bool:
+    enemy_pawns = board.pieces(chess.PAWN, not color)
+    return all(target not in enemy_pawns for target in forward_span(color, square))
+
+
+def king_shield_squares(color: chess.Color, square: chess.Square) -> List[chess.Square]:
+    shield: List[chess.Square] = []
+    direction = 1 if color == chess.WHITE else -1
+
+    for step in (1, 2):
+        rank = chess.square_rank(square) + direction * step
+        if 0 <= rank <= 7:
+            for df in (-1, 0, 1):
+                file = chess.square_file(square) + df
+                if 0 <= file <= 7:
+                    shield.append(chess.square(file, rank))
+
+    return shield
+
+
+def king_safety_for(board: chess.Board, color: chess.Color) -> int:
+    king_square = board.king(color)
+    if king_square is None:
+        return 0
+
+    pawns = board.pieces(chess.PAWN, color)
+    penalty = 0
+
+    shield_count = sum(1 for sq in king_shield_squares(color, king_square) if sq in pawns)
+    if shield_count < 2:
+        penalty += (2 - shield_count) * 10
+
+    adjacent_files = {
+        chess.square_file(king_square) + offset
+        for offset in (-1, 0, 1)
+        if 0 <= chess.square_file(king_square) + offset <= 7
+    }
+    for pawn_sq in pawns:
+        if chess.square_file(pawn_sq) not in adjacent_files:
+            continue
+        rel = relative_rank(color, pawn_sq)
+        if rel > 3:
+            penalty += 6 * (rel - 3)
+
+    forward_file = [sq for sq in forward_span(color, king_square) if chess.square_file(sq) == chess.square_file(king_square)]
+    if not any(sq in pawns for sq in forward_file):
+        penalty += 18
+
+    enemy_sliders = board.pieces(chess.ROOK, not color) | board.pieces(chess.QUEEN, not color)
+    for slider in enemy_sliders:
+        if chess.square_file(slider) != chess.square_file(king_square):
+            continue
+        between = chess.BB_BETWEEN[slider][king_square]
+        if between and chess.popcount(between & board.occupied_co[color]) == 0:
+            penalty += 12
+            break
+
+    flank_patterns = [
+        (chess.parse_square("g4"), chess.parse_square("h4")),
+        (chess.parse_square("g5"), chess.parse_square("h6")),
+    ]
+    for base_a, base_b in flank_patterns:
+        sq_a = chess.square_mirror(base_a) if color == chess.BLACK else base_a
+        sq_b = chess.square_mirror(base_b) if color == chess.BLACK else base_b
+        if sq_a in pawns and sq_b in pawns:
+            penalty += 14
+            break
+
+    king_ring = chess.SquareSet(chess.BB_KING_ATTACKS[king_square])
+    attackers = sum(1 for sq in king_ring if board.piece_at(sq) and board.color_at(sq) != color)
+    if attackers == 0 and penalty > 0:
+        penalty = max(0, penalty - 6)
+
+    return penalty
+
+
+def passed_pawn_score(board: chess.Board, color: chess.Color) -> int:
+    rank_bonus = [0, 0, 12, 28, 44, 68, 110, 0]
+    score = 0
+
+    for sq in board.pieces(chess.PAWN, color):
+        if not is_passed_pawn(board, color, sq):
+            continue
+
+        rel_rank = relative_rank(color, sq)
+        bonus = rank_bonus[rel_rank]
+        block_sq = sq + (8 if color == chess.WHITE else -8)
+        if chess.SQUARES_A1 <= block_sq <= chess.SQUARES_H8:
+            attackers_us = len(board.attackers(color, block_sq))
+            attackers_them = len(board.attackers(not color, block_sq))
+            piece = board.piece_at(block_sq)
+            if piece is None:
+                bonus += 6 + 2 * rel_rank + max(attackers_us - attackers_them, 0) * 4
+            elif piece.color == color:
+                bonus += 4
+            else:
+                bonus -= 6
+                diff = attackers_us - attackers_them
+                bonus += diff * 5
+
+            if attackers_us - attackers_them > 1:
+                bonus += (attackers_us - attackers_them) * 3
+
+        enemy_king = board.king(not color)
+        if enemy_king is not None and rel_rank >= 5:
+            if chess.square_distance(enemy_king, sq) > 3:
+                bonus += 18
+
+        score += bonus
+
+    return score
+
+
+def knight_mobility(board: chess.Board, color: chess.Color) -> int:
+    central = {chess.parse_square(sq) for sq in ("d4", "e4", "d5", "e5")}
+    score = 0
+    for sq in board.pieces(chess.KNIGHT, color):
+        moves = list(board.attacks(sq))
+        mobility = sum(1 for dst in moves if not board.color_at(dst) == color)
+        penalty = max(0, 3 - mobility) * 6
+        if mobility <= 1:
+            penalty += 10
+
+        file_edge = chess.square_file(sq) in (0, 7)
+        rank_edge = relative_rank(color, sq) in (0, 7)
+        if file_edge or rank_edge:
+            penalty += 6
+
+        if sq in central:
+            bonus = 14
+            pawn_support = any(board.piece_at(dst) and board.piece_at(dst).piece_type == chess.PAWN and board.piece_at(dst).color == color for dst in board.attackers(color, sq))
+            if pawn_support:
+                bonus += 6
+            if not board.attackers(not color, sq):
+                bonus += 4
+            penalty -= bonus
+
+        score -= penalty
+
+    return score
+
+
+def pawn_endgame_feature(board: chess.Board) -> int:
+    non_pawn = board.pieces(chess.BISHOP, chess.WHITE) | board.pieces(chess.BISHOP, chess.BLACK)
+    non_pawn |= board.pieces(chess.KNIGHT, chess.WHITE) | board.pieces(chess.KNIGHT, chess.BLACK)
+    non_pawn |= board.pieces(chess.ROOK, chess.WHITE) | board.pieces(chess.ROOK, chess.BLACK)
+    non_pawn |= board.pieces(chess.QUEEN, chess.WHITE) | board.pieces(chess.QUEEN, chess.BLACK)
+    if non_pawn:
+        return 0
+
+    king_w = board.king(chess.WHITE)
+    king_b = board.king(chess.BLACK)
+    if king_w is None or king_b is None:
+        return 0
+
+    def center_bonus(king: chess.Square) -> int:
+        df = min(abs(chess.square_file(king) - 3), abs(chess.square_file(king) - 4))
+        dr = min(abs(chess.square_rank(king) - 3), abs(chess.square_rank(king) - 4))
+        return 18 - 6 * (df + dr)
+
+    score = center_bonus(king_w) - center_bonus(king_b)
+
+    for sq in board.pieces(chess.PAWN, chess.WHITE):
+        if is_passed_pawn(board, chess.WHITE, sq):
+            dist = chess.square_distance(king_w, sq)
+            score += max(0, 6 - dist) * 4
+            score -= chess.square_distance(king_b, sq) * 6
+
+    for sq in board.pieces(chess.PAWN, chess.BLACK):
+        if is_passed_pawn(board, chess.BLACK, sq):
+            dist = chess.square_distance(king_b, sq)
+            score -= max(0, 6 - dist) * 4
+            score += chess.square_distance(king_w, sq) * 6
+
+    same_file = chess.square_file(king_w) == chess.square_file(king_b)
+    same_rank = chess.square_rank(king_w) == chess.square_rank(king_b)
+    if (same_file or same_rank) and chess.square_distance(king_w, king_b) == 2:
+        score += -12 if board.turn == chess.WHITE else 12
+
+    return score
+
+
+def feature_vector(board: chess.Board) -> Tuple[int, int, int, int]:
+    king = king_safety_for(board, chess.WHITE) - king_safety_for(board, chess.BLACK)
+    passed = passed_pawn_score(board, chess.WHITE) - passed_pawn_score(board, chess.BLACK)
+    mobility = knight_mobility(board, chess.WHITE) - knight_mobility(board, chess.BLACK)
+    endings = pawn_endgame_feature(board)
+    return king, passed, mobility, endings
+
+
+def orientation(board: chess.Board, features: Sequence[int]) -> Tuple[int, int, int, int]:
+    if board.turn == chess.WHITE:
+        return features
+    return tuple(-value for value in features)
+
+
+def result_for_side_to_move(board: chess.Board, game_result: str) -> ResultValue | None:
+    if game_result not in ("1-0", "0-1", "1/2-1/2"):
+        return None
+
+    if game_result == "1/2-1/2":
+        return 0.5
+
+    white_won = game_result == "1-0"
+    return 1.0 if (white_won and board.turn == chess.WHITE) or (not white_won and board.turn == chess.BLACK) else 0.0
+
+
+def extract_positions(stream: Iterable[str], max_games: int | None) -> List[Tuple[Tuple[int, int, int, int], ResultValue]]:
+    dataset: List[Tuple[Tuple[int, int, int, int], ResultValue]] = []
+    games_parsed = 0
+
+    while True:
+        game = chess.pgn.read_game(stream)
+        if game is None:
+            break
+
+        result = game.headers.get("Result", "*")
+        board = game.board()
+        for move in game.mainline_moves():
+            value = result_for_side_to_move(board, result)
+            if value is not None:
+                feats = orientation(board, feature_vector(board))
+                dataset.append((feats, value))
+            board.push(move)
+
+        games_parsed += 1
+        if max_games is not None and games_parsed >= max_games:
+            break
+
+    return dataset
+
+
+@dataclass
+class TrainingConfig:
+    temperature: float = 400.0
+    learning_rate: float = 1e-4
+    epochs: int = 200
+    l2: float = 1e-6
+
+
+def train_weights(dataset: Sequence[Tuple[Tuple[int, int, int, int], ResultValue]], config: TrainingConfig) -> List[float]:
+    if not dataset:
+        raise ValueError("Dataset is empty; cannot tune weights.")
+
+    weights = [1.0, 1.0, 1.0, 1.0]
+    eps = 1e-9
+
+    for _ in range(config.epochs):
+        grad = [0.0, 0.0, 0.0, 0.0]
+        for features, result in dataset:
+            evaluation = sum(w * f for w, f in zip(weights, features))
+            scaled = max(-2000.0, min(2000.0, evaluation / config.temperature))
+            probability = 1.0 / (1.0 + math.exp(-scaled))
+            diff = probability - result
+            for i, feature in enumerate(features):
+                grad[i] += diff * feature / config.temperature
+
+        for i in range(len(weights)):
+            grad[i] = grad[i] / len(dataset) + config.l2 * weights[i]
+            weights[i] -= config.learning_rate * grad[i]
+
+    return weights
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a Texel-style tuning session for manual eval terms.")
+    parser.add_argument("--input", required=True, help="Path to a PGN file or a text file with FEN; the script currently expects PGN.")
+    parser.add_argument("--max-games", type=int, default=None, help="Maximum number of games to process (useful for quick experiments).")
+    parser.add_argument("--output", type=str, default=None, help="Optional path to write the resulting weights as JSON.")
+    parser.add_argument("--temperature", type=float, default=400.0, help="Logistic scaling factor (Texel temperature in centipawns).")
+    parser.add_argument("--learning-rate", type=float, default=1e-4, help="Gradient descent learning rate.")
+    parser.add_argument("--epochs", type=int, default=200, help="Number of gradient descent iterations.")
+
+    args = parser.parse_args()
+
+    config = TrainingConfig(temperature=args.temperature, learning_rate=args.learning_rate, epochs=args.epochs)
+
+    with open(args.input, "r", encoding="utf-8", errors="ignore") as handle:
+        dataset = extract_positions(handle, args.max_games)
+
+    if not dataset:
+        raise SystemExit("No valid positions were extracted from the provided input.")
+
+    weights = train_weights(dataset, config)
+    scaled_weights = [int(round(w * 100)) for w in weights]
+
+    summary = {
+        "king_safety": scaled_weights[0],
+        "passed_pawns": scaled_weights[1],
+        "minor_mobility": scaled_weights[2],
+        "pawn_endgames": scaled_weights[3],
+        "samples": len(dataset),
+        "temperature": config.temperature,
+        "learning_rate": config.learning_rate,
+        "epochs": config.epochs,
+    }
+
+    print("Suggested manual evaluation weights (percent scaling):")
+    for key in ("king_safety", "passed_pawns", "minor_mobility", "pawn_endgames"):
+        print(f"  {key.replace('_', ' ').title():<18}: {summary[key]:>4}")
+    print(f"Processed positions: {summary['samples']}")
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as out:
+            json.dump(summary, out, indent=2)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    try:
+        main()
+    except KeyboardInterrupt:
+        sys.exit(1)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -19,6 +19,7 @@
 #include "evaluate.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
@@ -26,9 +27,11 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <utility>
 
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
@@ -193,6 +196,280 @@ Value tempo_bonus(const Position& pos) {
     return pos.side_to_move() == Color::WHITE ? Tempo : -Tempo;
 }
 
+constexpr std::array<Square, 4> CentralSquares = {SQ_D4, SQ_E4, SQ_D5, SQ_E5};
+
+Eval::ManualEvalWeights manualWeights;
+
+Bitboard forward_rays(Color c, Square sq) {
+    Bitboard   mask = 0;
+    Direction  dir  = pawn_push(c);
+    Square     s    = sq;
+    const auto step = [&]() {
+        s += dir;
+        return is_ok(s);
+    };
+
+    while (step())
+        mask |= square_bb(s);
+
+    return mask;
+}
+
+Bitboard passed_span(Color c, Square sq) {
+    Bitboard front = forward_rays(c, sq);
+    Bitboard span  = front;
+
+    if (file_of(sq) > FILE_A)
+        span |= shift<WEST>(front);
+    if (file_of(sq) < FILE_H)
+        span |= shift<EAST>(front);
+
+    return span;
+}
+
+bool is_passed_pawn(const Position& pos, Color c, Square sq) {
+    return !(passed_span(c, sq) & pos.pieces(~c, PAWN));
+}
+
+Bitboard king_shield_mask(Color c, Square king) {
+    Bitboard firstRing = shift<pawn_push(c)>(square_bb(king));
+    Bitboard mask      = firstRing;
+    mask |= shift<EAST>(firstRing);
+    mask |= shift<WEST>(firstRing);
+    Bitboard secondRing = shift<pawn_push(c)>(firstRing);
+    mask |= secondRing;
+    return mask;
+}
+
+int king_safety_contrib(const Position& pos, Color c) {
+    const Square    king         = pos.square<KING>(c);
+    const Bitboard  pawns        = pos.pieces(c, PAWN);
+    const Bitboard  enemyPieces  = pos.pieces(~c);
+    const Bitboard  enemySliders = pos.pieces(~c, ROOK) | pos.pieces(~c, QUEEN);
+    int             penalty      = 0;
+
+    Bitboard shieldMask = king_shield_mask(c, king);
+    int      shieldCnt  = popcount(pawns & shieldMask);
+    if (shieldCnt < 2)
+        penalty += (2 - shieldCnt) * 10;
+
+    Bitboard fileMask = file_bb(king);
+    File     kFile    = file_of(king);
+    if (kFile > FILE_A)
+        fileMask |= file_bb(File(int(kFile) - 1));
+    if (kFile < FILE_H)
+        fileMask |= file_bb(File(int(kFile) + 1));
+
+    Bitboard pawnsAround = pawns & fileMask;
+    Bitboard advanced    = pawnsAround;
+    while (advanced)
+    {
+        Square sq     = pop_lsb(advanced);
+        int    rel    = static_cast<int>(relative_rank(c, sq));
+        int    excess = std::max(0, rel - static_cast<int>(RANK_3));
+        if (excess)
+            penalty += 6 * excess;
+    }
+
+    Bitboard forward = forward_rays(c, king) & file_bb(king);
+    if (!(forward & pawns))
+        penalty += 18;
+
+    Bitboard slidersOnFile = enemySliders & file_bb(king);
+    while (slidersOnFile)
+    {
+        Square slider = pop_lsb(slidersOnFile);
+        Bitboard between = between_bb(slider, king);
+        if (!(between & pos.pieces()) || !(between & pos.pieces(c)))
+        {
+            penalty += 12;
+            break;
+        }
+    }
+
+    const std::array<std::pair<Square, Square>, 2> flankPatterns = {
+      std::make_pair(SQ_G4, SQ_H4), std::make_pair(SQ_G5, SQ_H6)};
+    for (const auto& [s1, s2] : flankPatterns)
+    {
+        Square rel1 = relative_square(c, s1);
+        Square rel2 = relative_square(c, s2);
+        if ((pawns & rel1) && (pawns & rel2))
+        {
+            penalty += 14;
+            break;
+        }
+    }
+
+    // Slight bonus if enemy pieces are far from the king area
+    Bitboard kingRing = attacks_bb<KING>(king);
+    if (!(kingRing & enemyPieces))
+        penalty = std::max(0, penalty - 6);
+
+    return c == Color::WHITE ? -penalty : penalty;
+}
+
+int passed_pawn_contrib(const Position& pos, Color c) {
+    static constexpr std::array<int, 8> RankBonus = {0, 0, 12, 28, 44, 68, 110, 0};
+
+    Bitboard pawns = pos.pieces(c, PAWN);
+    int      score = 0;
+
+    while (pawns)
+    {
+        Square sq = pop_lsb(pawns);
+        if (!is_passed_pawn(pos, c, sq))
+            continue;
+
+        int relRank = static_cast<int>(relative_rank(c, sq));
+        int bonus   = RankBonus[relRank];
+
+        Square blockSq = sq + pawn_push(c);
+        if (is_ok(blockSq))
+        {
+            Bitboard ourCtrl   = pos.attackers_to(blockSq) & pos.pieces(c);
+            Bitboard enemyCtrl = pos.attackers_to(blockSq) & pos.pieces(~c);
+            int      diff      = popcount(ourCtrl) - popcount(enemyCtrl);
+
+            if (pos.empty(blockSq))
+                bonus += 6 + 2 * relRank + std::max(diff, 0) * 4;
+            else if (color_of(pos.piece_on(blockSq)) == c)
+                bonus += 4;
+            else
+            {
+                bonus -= 6;
+                if (diff > 0)
+                    bonus += diff * 5;
+                else if (diff < 0)
+                    bonus += diff * 6;
+            }
+
+            // Penalize the opponent additionally when the block square is under our control
+            if (diff > 1)
+                bonus += diff * 3;
+        }
+
+        // Encourage unstoppable passer when king is far
+        Square enemyKing = pos.square<KING>(~c);
+        int    kingDist  = distance(enemyKing, sq);
+        if (relRank >= static_cast<int>(RANK_6) && kingDist > 3)
+            bonus += 18;
+
+        score += (c == Color::WHITE ? bonus : -bonus);
+    }
+
+    return score;
+}
+
+int minor_mobility_contrib(const Position& pos, Color c) {
+    Bitboard knights = pos.pieces(c, KNIGHT);
+    int      score   = 0;
+
+    while (knights)
+    {
+        Square sq       = pop_lsb(knights);
+        Bitboard moves  = attacks_bb<KNIGHT>(sq) & ~pos.pieces(c);
+        int      mobile = popcount(moves);
+
+        int trappedPenalty = std::max(0, 3 - mobile) * 6;
+        if (mobile <= 1)
+            trappedPenalty += 10;
+
+        if (!edge_distance(file_of(sq)) || relative_rank(c, sq) <= RANK_2
+            || relative_rank(c, sq) >= RANK_7)
+            trappedPenalty += 6;
+
+        Bitboard sqBB = square_bb(sq);
+        if (sqBB & (CentralSquares[0] | CentralSquares[1] | CentralSquares[2] | CentralSquares[3]))
+        {
+            int bonus = 14;
+            if (pos.attackers_to(sq) & pos.pieces(c, PAWN))
+                bonus += 6;
+            if (!(pos.attackers_to(sq) & pos.pieces(~c)))
+                bonus += 4;
+            trappedPenalty -= bonus;
+        }
+
+        score += (c == Color::WHITE ? -trappedPenalty : trappedPenalty);
+    }
+
+    return score;
+}
+
+int passed_pawn_distance_penalty(const Position& pos, Color c, Square king) {
+    Bitboard pawns = pos.pieces(c, PAWN);
+    int      score = 0;
+
+    while (pawns)
+    {
+        Square sq = pop_lsb(pawns);
+        if (!is_passed_pawn(pos, c, sq))
+            continue;
+
+        int dist = distance(king, sq);
+        score -= dist * 6;
+    }
+
+    return score;
+}
+
+int pawn_endgame_contrib(const Position& pos) {
+    if (pos.non_pawn_material())
+        return 0;
+
+    const Square kingW = pos.square<KING>(Color::WHITE);
+    const Square kingB = pos.square<KING>(Color::BLACK);
+
+    auto center_bonus = [](Square king) {
+        int df = std::min(std::abs(int(file_of(king)) - int(FILE_D)),
+                          std::abs(int(file_of(king)) - int(FILE_E)));
+        int dr = std::min(std::abs(int(rank_of(king)) - int(RANK_4)),
+                          std::abs(int(rank_of(king)) - int(RANK_5)));
+        return 18 - 6 * (df + dr);
+    };
+
+    int score = center_bonus(kingW) - center_bonus(kingB);
+
+    score += passed_pawn_distance_penalty(pos, Color::BLACK, kingW);
+    score -= passed_pawn_distance_penalty(pos, Color::WHITE, kingB);
+
+    // Reward supporting distance to own passers
+    Bitboard whitePassers = pos.pieces(Color::WHITE, PAWN);
+    while (whitePassers)
+    {
+        Square sq = pop_lsb(whitePassers);
+        if (!is_passed_pawn(pos, Color::WHITE, sq))
+            continue;
+        int dist = distance(kingW, sq);
+        score += std::max(0, 6 - dist) * 4;
+    }
+
+    Bitboard blackPassers = pos.pieces(Color::BLACK, PAWN);
+    while (blackPassers)
+    {
+        Square sq = pop_lsb(blackPassers);
+        if (!is_passed_pawn(pos, Color::BLACK, sq))
+            continue;
+        int dist = distance(kingB, sq);
+        score -= std::max(0, 6 - dist) * 4;
+    }
+
+    if ((file_of(kingW) == file_of(kingB) || rank_of(kingW) == rank_of(kingB))
+        && distance(kingW, kingB) == 2)
+        score += pos.side_to_move() == Color::WHITE ? -12 : 12;
+
+    return score;
+}
+
+Eval::ManualEvalTerms compute_manual_terms_impl(const Position& pos) {
+    Eval::ManualEvalTerms terms;
+    terms.kingSafety = king_safety_contrib(pos, Color::WHITE) + king_safety_contrib(pos, Color::BLACK);
+    terms.passedPawns = passed_pawn_contrib(pos, Color::WHITE) + passed_pawn_contrib(pos, Color::BLACK);
+    terms.minorMobility =
+      minor_mobility_contrib(pos, Color::WHITE) + minor_mobility_contrib(pos, Color::BLACK);
+    terms.pawnEndgames = pawn_endgame_contrib(pos);
+    return terms;
+}
+
 }  // namespace
 
 namespace Eval {
@@ -315,6 +592,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     // Damp down the evaluation linearly when shuffling
     v -= v * pos.rule50_count() / 212;
 
+    Eval::ManualEvalTerms manualTerms = compute_manual_terms_impl(pos);
+    int                   manualScore = manualTerms.kingSafety * manualWeights.kingSafety
+                      + manualTerms.passedPawns * manualWeights.passedPawns
+                      + manualTerms.minorMobility * manualWeights.minorMobility
+                      + manualTerms.pawnEndgames * manualWeights.pawnEndgames;
+    int roundedManual = manualScore >= 0 ? manualScore + 50 : manualScore - 50;
+    v += Value(roundedManual / 100);
+
     v += tempo_bonus(pos);
 
     // Guarantee evaluation does not hit the tablebase range
@@ -335,6 +620,14 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     return v;
 }
+
+Eval::ManualEvalTerms Eval::compute_manual_terms(const Position& pos) {
+    return compute_manual_terms_impl(pos);
+}
+
+Eval::ManualEvalWeights Eval::manual_eval_weights() { return manualWeights; }
+
+void Eval::set_manual_eval_weights(const ManualEvalWeights& weights) { manualWeights = weights; }
 
 // Like evaluate(), but instead of returning a value, it returns
 // a string (suitable for outputting to stdout) that contains the detailed

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -29,6 +29,20 @@ class Position;
 
 namespace Eval {
 
+struct ManualEvalTerms {
+    int kingSafety     = 0;
+    int passedPawns    = 0;
+    int minorMobility  = 0;
+    int pawnEndgames   = 0;
+};
+
+struct ManualEvalWeights {
+    int kingSafety    = 100;
+    int passedPawns   = 100;
+    int minorMobility = 100;
+    int pawnEndgames  = 100;
+};
+
 // The default net name MUST follow the format nn-[SHA256 first 12 digits].nnue
 // for the build process (profile-build and fishtest) to work. Do not change the
 // names or the location where these constants are defined, as they are used in
@@ -51,6 +65,10 @@ Value evaluate(const NNUE::Networks&          networks,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
+
+ManualEvalTerms   compute_manual_terms(const Position& pos);
+ManualEvalWeights manual_eval_weights();
+void              set_manual_eval_weights(const ManualEvalWeights& weights);
 
 // Toggle for optional style-based evaluation adjustments.
 void set_adaptive_style(bool enabled);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,6 +69,89 @@ namespace {
 constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
+Bitboard forward_rays(Color c, Square sq) {
+    Bitboard  mask = 0;
+    Direction dir  = pawn_push(c);
+    Square    s    = sq;
+
+    while (true)
+    {
+        s += dir;
+        if (!is_ok(s))
+            break;
+        mask |= square_bb(s);
+    }
+
+    return mask;
+}
+
+Bitboard passed_span(Color c, Square sq) {
+    Bitboard front = forward_rays(c, sq);
+    Bitboard span  = front;
+    if (file_of(sq) > FILE_A)
+        span |= shift<WEST>(front);
+    if (file_of(sq) < FILE_H)
+        span |= shift<EAST>(front);
+    return span;
+}
+
+bool is_passed_pawn(const Position& pos, Color c, Square sq) {
+    return !(passed_span(c, sq) & pos.pieces(~c, PAWN));
+}
+
+bool has_dangerous_passed_pawn(const Position& pos, Color c, Rank minRank) {
+    Bitboard pawns = pos.pieces(c, PAWN);
+    while (pawns)
+    {
+        Square sq = pop_lsb(pawns);
+        if (static_cast<int>(relative_rank(c, sq)) >= static_cast<int>(minRank)
+            && is_passed_pawn(pos, c, sq))
+            return true;
+    }
+    return false;
+}
+
+bool king_structure_vulnerable(const Position& pos, Color c) {
+    Square   king   = pos.square<KING>(c);
+    Bitboard pawns  = pos.pieces(c, PAWN);
+    Bitboard shield = shift<pawn_push(c)>(square_bb(king));
+    shield |= shift<EAST>(shield);
+    shield |= shift<WEST>(shield);
+
+    if (popcount(pawns & shield) <= 1)
+        return true;
+
+    Bitboard forward = forward_rays(c, king) & file_bb(king);
+    if (!(forward & pawns))
+        return true;
+
+    Bitboard sliders = (pos.pieces(~c, ROOK) | pos.pieces(~c, QUEEN)) & file_bb(king);
+    while (sliders)
+    {
+        Square slider = pop_lsb(sliders);
+        if (!(between_bb(slider, king) & pos.pieces(c)))
+            return true;
+    }
+
+    return false;
+}
+
+Depth additional_extensions(const Position& pos, bool givesCheck) {
+    Depth ext = 0;
+
+    if (has_dangerous_passed_pawn(pos, pos.side_to_move(), RANK_6))
+        ext = std::max(ext, Depth(1));
+
+    if (givesCheck)
+    {
+        MoveList<LEGAL> replies(pos);
+        if (replies.size() <= 2)
+            ext = std::max(ext, Depth(1));
+    }
+
+    return ext;
+}
+
 // (*Scalers):
 // The values with Scaler asterisks have proven non-linear scaling.
 // They are optimized to time controls of 180 + 1.8 and longer,
@@ -236,6 +319,20 @@ void Search::Worker::start_searching() {
             threads.start_searching();  // start non-main threads
             iterative_deepening();      // main thread start searching
         }
+    }
+
+    if (mainThread)
+    {
+        bool quietPhase = false;
+        if (!rootMoves.empty())
+        {
+            bool  stableMove      = !lastBestPV.empty() && rootMoves[0].pv[0] == lastBestPV[0];
+            Value referenceScore = lastBestScore == -VALUE_INFINITE ? rootMoves[0].score : lastBestScore;
+            quietPhase = stableMove && std::abs(rootMoves[0].score - referenceScore) < 30
+                         && totBestMoveChanges < 1.5;
+        }
+
+        mainThread->tm.record_time_usage(mainThread->tm.elapsed_time(), quietPhase);
     }
 
     // When we reach the maximum depth, we can arrive here without a raise of
@@ -934,8 +1031,12 @@ Value Search::Worker::search(
             return beta + (eval - beta) / 3;
     }
 
+    bool kingFragile         = king_structure_vulnerable(pos, us);
+    bool enemyDangerousPass  = has_dangerous_passed_pawn(pos, ~us, RANK_6);
+    bool skipNullMove        = (enemyDangerousPass && depth <= 6) || (kingFragile && depth <= 4);
+
     // Step 9. Null move search with verification search
-    if (cutNode && ss->staticEval >= beta - 18 * depth + 390 && !excludedMove
+    if (!skipNullMove && cutNode && ss->staticEval >= beta - 18 * depth + 390 && !excludedMove
         && pos.non_pawn_material(us)
         && ss->ply >= nmpMinPly && !is_loss(beta))
     {
@@ -943,6 +1044,10 @@ Value Search::Worker::search(
 
         // Null move dynamic reduction based on depth
         Depth R = 6 + depth / 3;
+        if (kingFragile)
+            R = std::max<Depth>(3, R - 2);
+        if (enemyDangerousPass)
+            R = std::max<Depth>(2, R - 2);
 
         ss->currentMove                   = Move::null();
         ss->continuationHistory           = &continuationHistory[0][0][NO_PIECE][0];
@@ -1261,6 +1366,12 @@ moves_loop:  // When in check, search starts here
 
         // Add extension to new depth
         newDepth += extension;
+        if (!rootNode)
+        {
+            Depth selective = additional_extensions(pos, givesCheck);
+            if (selective)
+                newDepth += selective;
+        }
         uint64_t nodeCount = rootNode ? uint64_t(nodes) : 0;
 
         // Decrease reduction for PvNodes (*Scaler)

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -22,12 +22,18 @@
 #include <cassert>
 #include <cmath>
 #include <cstdint>
+#include <numeric>
+#include <vector>
 
 #include "search.h"
 #include "ucioption.h"
 #include "misc.h"
 
 namespace Stockfish {
+
+namespace {
+constexpr TimePoint MinTimePerMoveMs = 60;
+}
 
 TimePoint TimeManagement::optimum() const { return optimumTime; }
 TimePoint TimeManagement::maximum() const { return maximumTime; }
@@ -68,6 +74,8 @@ void TimeManagement::init(Search::LimitsType& limits,
     double    slowMover            = options["Slow Mover"] / 100.0;
     const bool conservativeMode    = bool(options["Revolution Conservative Search"]);
 
+    TimePoint effectiveMoveOverhead = moveOverhead;
+
     // Adjust time usage heuristics for common time controls
     double baseSeconds = double(limits.time[static_cast<int>(us)]) / 1000.0;
     double incSeconds  = double(limits.inc[static_cast<int>(us)]) / 1000.0;
@@ -105,6 +113,15 @@ void TimeManagement::init(Search::LimitsType& limits,
     const int64_t   scaleFactor = useNodesTime ? npmsec : 1;
     const TimePoint scaledTime  = limits.time[static_cast<int>(us)] / scaleFactor;
 
+    TimePoint maxOverhead = std::max(TimePoint(5 * scaleFactor), limits.time[static_cast<int>(us)] / 8);
+    effectiveMoveOverhead = std::min(moveOverhead, maxOverhead);
+
+    TimePoint scaledMinimum = useNodesTime
+                                ? TimePoint(std::max<int64_t>(1, static_cast<int64_t>(npmsec))
+                                             * MinTimePerMoveMs)
+                                : MinTimePerMoveMs;
+    TimePoint absoluteFloor = std::max(minThinkingScaled, scaledMinimum);
+
     // Maximum move horizon
     int centiMTG = limits.movestogo ? std::min(limits.movestogo * 100, 5000) : 5051;
 
@@ -116,7 +133,9 @@ void TimeManagement::init(Search::LimitsType& limits,
     TimePoint timeLeft =
       std::max(TimePoint(1),
                limits.time[static_cast<int>(us)]
-                 + (limits.inc[static_cast<int>(us)] * (centiMTG - 100) - moveOverhead * (200 + centiMTG)) / 100);
+                 + (limits.inc[static_cast<int>(us)] * (centiMTG - 100)
+                    - effectiveMoveOverhead * (200 + centiMTG))
+                       / 100);
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed the actual available
@@ -150,11 +169,25 @@ void TimeManagement::init(Search::LimitsType& limits,
 
     optScale *= slowMover;
 
+    double usageAdjust = usage_ratio();
+    double usageFactor = 1.0;
+    if (usageAdjust > 1.05)
+        usageFactor /= std::min(1.35, 1.0 + (usageAdjust - 1.05) * 0.6);
+    else if (usageAdjust < 0.95)
+        usageFactor *= 1.0 + (0.95 - usageAdjust) * 0.5;
+
+    double quietAdjust    = quiet_phase_bias();
+    double combinedFactor = std::clamp(usageFactor * quietAdjust, 0.6, 1.8);
+    optScale *= combinedFactor;
+    maxScale *= std::clamp(quietAdjust + (usageFactor - 1.0) * 0.5, 0.75, 1.25);
+    optScale = std::max(0.02, optScale);
+
     // Limit the maximum possible time for this move
     optimumTime = TimePoint(optScale * timeLeft);
     maximumTime =
-      TimePoint(std::min(0.90 * limits.time[static_cast<int>(us)] - moveOverhead,
-                          maxScale * optimumTime)) - 10;
+      TimePoint(std::min(0.90 * limits.time[static_cast<int>(us)] - effectiveMoveOverhead,
+                          maxScale * optimumTime))
+      - 10;
 
     if (conservativeMode)
     {
@@ -163,7 +196,7 @@ void TimeManagement::init(Search::LimitsType& limits,
         // slightly larger buffer in long time controls while still being
         // conservative for quick controls.
         TimePoint adaptiveOverhead =
-          moveOverhead + bufferScaled + limits.time[static_cast<int>(us)] / 30;
+          effectiveMoveOverhead + bufferScaled + limits.time[static_cast<int>(us)] / 30;
         TimePoint maxBudget =
           std::max(TimePoint(1), limits.time[static_cast<int>(us)] - adaptiveOverhead);
         optimumTime = std::min(optimumTime, maxBudget);
@@ -173,9 +206,14 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (options["Ponder"])
         optimumTime += optimumTime / 4;
 
-    optimumTime = std::max(optimumTime, minThinkingScaled);
-    maximumTime =
-      std::max(conservativeMode ? maximumTime : maximumTime - bufferScaled, minThinkingScaled);
+    optimumTime = std::max(optimumTime, absoluteFloor);
+    TimePoint maxCandidate = conservativeMode ? maximumTime
+                                              : std::max(TimePoint(1), maximumTime - bufferScaled);
+    maximumTime            = std::max(maxCandidate, absoluteFloor);
+    maximumTime            = std::max(maximumTime, optimumTime);
+
+    pendingOptimum = optimumTime;
+    pendingSample  = true;
 
     if (useNodesTime)
     {
@@ -185,6 +223,78 @@ void TimeManagement::init(Search::LimitsType& limits,
                   << " optimum=" << optimumTime
                   << " maximum=" << maximumTime << sync_endl;
     }
+}
+
+void TimeManagement::record_time_usage(TimePoint spent, bool quietPhase) {
+    if (!pendingSample)
+        return;
+
+    spentHistory[historyIndex]   = std::max<TimePoint>(TimePoint(1), spent);
+    optimumHistory[historyIndex] = std::max<TimePoint>(TimePoint(1), pendingOptimum);
+    quietHistory[historyIndex]   = quietPhase;
+
+    historyIndex = (historyIndex + 1) % HistorySize;
+    if (historyCount < HistorySize)
+        ++historyCount;
+
+    pendingSample = false;
+}
+
+std::vector<TimePoint> TimeManagement::recent_time_samples() const {
+    std::vector<TimePoint> result;
+    result.reserve(historyCount);
+
+    for (size_t i = 0; i < historyCount; ++i)
+    {
+        size_t idx = (historyIndex + HistorySize - historyCount + i) % HistorySize;
+        result.push_back(spentHistory[idx]);
+    }
+
+    return result;
+}
+
+std::vector<TimePoint> TimeManagement::recent_optimum_samples() const {
+    std::vector<TimePoint> result;
+    result.reserve(historyCount);
+
+    for (size_t i = 0; i < historyCount; ++i)
+    {
+        size_t idx = (historyIndex + HistorySize - historyCount + i) % HistorySize;
+        result.push_back(optimumHistory[idx]);
+    }
+
+    return result;
+}
+
+double TimeManagement::usage_ratio() const {
+    if (!historyCount)
+        return 1.0;
+
+    long double spentSum = 0;
+    long double optSum   = 0;
+
+    for (size_t i = 0; i < historyCount; ++i)
+    {
+        spentSum += std::max<long double>(1.0L, static_cast<long double>(spentHistory[i]));
+        optSum += std::max<long double>(1.0L, static_cast<long double>(optimumHistory[i]));
+    }
+
+    if (optSum <= 0.0L)
+        return 1.0;
+
+    return static_cast<double>(spentSum / optSum);
+}
+
+double TimeManagement::quiet_phase_bias() const {
+    if (!historyCount)
+        return 1.0;
+
+    int quietCount = 0;
+    for (size_t i = 0; i < historyCount; ++i)
+        quietCount += quietHistory[i] ? 1 : 0;
+
+    double ratio = static_cast<double>(quietCount) / static_cast<double>(historyCount);
+    return 1.0 + ratio * 0.15;
 }
 
 }  // namespace Stockfish

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -18,7 +18,9 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
+#include <vector>
 
 #include "misc.h"
 
@@ -51,15 +53,29 @@ class TimeManagement {
 
     void clear();
     void advance_nodes_time(std::int64_t nodes);
+    void record_time_usage(TimePoint spent, bool quietPhase);
+    std::vector<TimePoint> recent_time_samples() const;
+    std::vector<TimePoint> recent_optimum_samples() const;
 
    private:
+    double    usage_ratio() const;
+    double    quiet_phase_bias() const;
     TimePoint startTime;
     TimePoint optimumTime;
     TimePoint maximumTime;
 
     std::int64_t availableNodes = -1;     // When in 'nodes as time' mode
     bool         useNodesTime   = false;  // True if we are in 'nodes as time' mode
-};
+
+    static constexpr size_t HistorySize = 32;
+    std::array<TimePoint, HistorySize> spentHistory{};
+    std::array<TimePoint, HistorySize> optimumHistory{};
+    std::array<bool, HistorySize>      quietHistory{};
+    size_t                             historyCount    = 0;
+    size_t                             historyIndex    = 0;
+    bool                               pendingSample   = false;
+    TimePoint                          pendingOptimum  = 0;
+}; 
 
 }  // namespace Stockfish
 


### PR DESCRIPTION
## Summary
- add handcrafted evaluation adjustments for king safety, passed pawns, knight mobility, and pawn endings with tunable weights
- refine time management by enforcing a minimum think time, recording usage statistics, and biasing allocations for quiet phases
- extend selective search heuristics for dangerous passed pawns and mate threats and provide a Texel tuning helper script

## Testing
- `make -C src build ARCH=x86-64-sse41-popcnt COMP=clang` *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e35a0c65908327b2590a40af366a2e