### PR TITLE
Fix build issues uncovered by clang no-exceptions profile build

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -144,6 +144,35 @@ constexpr Bitboard shift(Bitboard b) {
                               : 0;
 }
 
+// Runtime helper that dispatches to the compile-time shift
+constexpr Bitboard shift(Direction d, Bitboard b) {
+    switch (d)
+    {
+    case NORTH:
+        return shift<NORTH>(b);
+    case SOUTH:
+        return shift<SOUTH>(b);
+    case NORTH + NORTH:
+        return shift<NORTH + NORTH>(b);
+    case SOUTH + SOUTH:
+        return shift<SOUTH + SOUTH>(b);
+    case EAST:
+        return shift<EAST>(b);
+    case WEST:
+        return shift<WEST>(b);
+    case NORTH_EAST:
+        return shift<NORTH_EAST>(b);
+    case NORTH_WEST:
+        return shift<NORTH_WEST>(b);
+    case SOUTH_EAST:
+        return shift<SOUTH_EAST>(b);
+    case SOUTH_WEST:
+        return shift<SOUTH_WEST>(b);
+    default:
+        return 0;
+    }
+}
+
 
 // Returns the squares attacked by pawns of the given color
 // from the squares in the given bitboard.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -232,11 +232,11 @@ bool is_passed_pawn(const Position& pos, Color c, Square sq) {
 }
 
 Bitboard king_shield_mask(Color c, Square king) {
-    Bitboard firstRing = shift<pawn_push(c)>(square_bb(king));
+    Bitboard firstRing = shift(pawn_push(c), square_bb(king));
     Bitboard mask      = firstRing;
     mask |= shift<EAST>(firstRing);
     mask |= shift<WEST>(firstRing);
-    Bitboard secondRing = shift<pawn_push(c)>(firstRing);
+    Bitboard secondRing = shift(pawn_push(c), firstRing);
     mask |= secondRing;
     return mask;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,8 +33,7 @@ using namespace Stockfish;
 
 int main(int argc, char* argv[]) {
 
-    try
-    {
+    auto run = [&]() {
         // Clear, consistent banner (many GUIs echo this to their logs).
         // Send banner to stderr so it doesn't interfere with UCI handshake on stdout.
         std::cerr << ENGINE_NAME
@@ -52,6 +51,12 @@ int main(int argc, char* argv[]) {
 
         uci.loop();
         return EXIT_SUCCESS;
+    };
+
+#if defined(__cpp_exceptions)
+    try
+    {
+        return run();
     }
     catch (const std::exception& e)
     {
@@ -63,4 +68,7 @@ int main(int argc, char* argv[]) {
     }
 
     return EXIT_FAILURE;
+#else
+    return run();
+#endif
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -114,7 +114,7 @@ bool has_dangerous_passed_pawn(const Position& pos, Color c, Rank minRank) {
 bool king_structure_vulnerable(const Position& pos, Color c) {
     Square   king   = pos.square<KING>(c);
     Bitboard pawns  = pos.pieces(c, PAWN);
-    Bitboard shield = shift<pawn_push(c)>(square_bb(king));
+    Bitboard shield = shift(pawn_push(c), square_bb(king));
     shield |= shift<EAST>(shield);
     shield |= shift<WEST>(shield);
 
@@ -319,20 +319,6 @@ void Search::Worker::start_searching() {
             threads.start_searching();  // start non-main threads
             iterative_deepening();      // main thread start searching
         }
-    }
-
-    if (mainThread)
-    {
-        bool quietPhase = false;
-        if (!rootMoves.empty())
-        {
-            bool  stableMove      = !lastBestPV.empty() && rootMoves[0].pv[0] == lastBestPV[0];
-            Value referenceScore = lastBestScore == -VALUE_INFINITE ? rootMoves[0].score : lastBestScore;
-            quietPhase = stableMove && std::abs(rootMoves[0].score - referenceScore) < 30
-                         && totBestMoveChanges < 1.5;
-        }
-
-        mainThread->tm.record_time_usage(mainThread->tm.elapsed_time(), quietPhase);
     }
 
     // When we reach the maximum depth, we can arrive here without a raise of
@@ -672,6 +658,22 @@ void Search::Worker::iterative_deepening() {
         iterIdx                        = (iterIdx + 1) & 3;
     }
 
+    if (mainThread)
+    {
+        bool quietPhase = false;
+
+        if (!rootMoves.empty())
+        {
+            bool  stableMove      = !lastBestPV.empty() && rootMoves[0].pv[0] == lastBestPV[0];
+            Value referenceScore = lastBestScore == -VALUE_INFINITE ? rootMoves[0].score : lastBestScore;
+
+            quietPhase = stableMove && std::abs(rootMoves[0].score - referenceScore) < 30
+                         && totBestMoveChanges < 1.5;
+        }
+
+        mainThread->tm.record_time_usage(mainThread->tm.elapsed_time(), quietPhase);
+    }
+
     if (!mainThread)
         return;
 
@@ -948,6 +950,9 @@ Value Search::Worker::search(
     // Step 6. Static evaluation of the position
     Value      unadjustedStaticEval = VALUE_NONE;
     const auto correctionValue      = correction_value(*this, pos, ss);
+    bool       kingFragile          = false;
+    bool       enemyDangerousPass   = false;
+    bool       skipNullMove         = false;
     if (ss->inCheck)
     {
         // Skip early pruning when in check
@@ -1031,9 +1036,9 @@ Value Search::Worker::search(
             return beta + (eval - beta) / 3;
     }
 
-    bool kingFragile         = king_structure_vulnerable(pos, us);
-    bool enemyDangerousPass  = has_dangerous_passed_pawn(pos, ~us, RANK_6);
-    bool skipNullMove        = (enemyDangerousPass && depth <= 6) || (kingFragile && depth <= 4);
+    kingFragile        = king_structure_vulnerable(pos, us);
+    enemyDangerousPass = has_dangerous_passed_pawn(pos, ~us, RANK_6);
+    skipNullMove       = (enemyDangerousPass && depth <= 6) || (kingFragile && depth <= 4);
 
     // Step 9. Null move search with verification search
     if (!skipNullMove && cutNode && ss->staticEval >= beta - 18 * depth + 390 && !excludedMove


### PR DESCRIPTION
## Summary
- add a runtime bitboard shift helper so pawn shield code no longer instantiates templates with runtime directions
- wrap the main entrypoint logic so builds compiled without exception support succeed
- move quiet-phase bookkeeping into iterative_deepening and predeclare flags around the null-move search to satisfy goto rules

## Testing
- `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` *(fails: clang++: No such file or directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e35fd937848327a187fb3722b55ba3