### PR TITLE
Update engine release identifiers to revolution-2.81-071025

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ The distribution includes:
 | v1.0.0-dev | 2025-08-27 | Streamlined late move reductions and refreshed the default engine branding. |
 | v1.0 | 2025-08-27 | Initial public release with iterative deepening improvements and updated author metadata. |
 
+### Revolution 2.81 Release Results
+
+Revolution 2.81 vs 2.80 (10+0.1, 1 thread, 64 MB, UHO_Lichess_4852_v1.epd).
+
+Over 4,000 games, Revolution 2.81 scores 50.65%, corresponding to +4.5 Elo (±5.4) with LOS 95%. Pairing quality is high (PairsRatio 1.10). This indicates a small, reproducible strength increase on this test matrix, suitable for CI/gauntlet use. As usual, improvements are book- and TC-dependent; results may vary on other suites or time controls.
+
 ## Contributing
 
 ### Development Guidelines

--- a/scripts/fastchess_sprt_relaunch.bat
+++ b/scripts/fastchess_sprt_relaunch.bat
@@ -8,7 +8,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "FASTCHESS=C:\fastchess\fastchess.exe"
-set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution 2.81 021025.exe"
+set "ENGINE_NEW=C:\fastchess\revolution-ad\revolution-2.81-071025.exe"
 set "ENGINE_BASE=C:\fastchess\revolution-base\revolution-dev_v2.40_130925.exe"
 set "DIR_NEW=C:\fastchess\revolution-ad"
 set "DIR_BASE=C:\fastchess\revolution-base"
@@ -97,7 +97,7 @@ if errorlevel 2 goto :sprt
 set "GATING_DONE=1"
 echo Running gating match (%GATING_GAMES% games) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution-2.81-071025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^
@@ -142,7 +142,7 @@ if defined GATING_PERCENT (
 :sprt
 echo Running SPRT (%ROUNDS% rounds, elo0=%ELO0%, elo1=%ELO1%) ...
 "%FASTCHESS%" ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution-2.81-071025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution_dev_v2.40" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/fishtest_local.sh
+++ b/scripts/fishtest_local.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution-2.81-071025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 FISHTEST_DIR="${FISHTEST_DIR:-$HOME/fishtest}"
 

--- a/scripts/gauntlet.cmd
+++ b/scripts/gauntlet.cmd
@@ -7,7 +7,7 @@ rem =============================================
 
 rem -------- User configurable paths --------
 set "CUTECHESS=C:\\cutechess\\cutechess-cli.exe"
-set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution 2.81 021025.exe"
+set "ENGINE_NEW=C:\\engines\\revolution-dev\\revolution-2.81-071025.exe"
 set "ENGINE_BASE=C:\\engines\\revolution-stable\\revolution-stable.exe"
 set "DIR_NEW=C:\\engines\\revolution-dev"
 set "DIR_BASE=C:\\engines\\revolution-stable"
@@ -76,7 +76,7 @@ if not "%NNUE_BASE%"=="" for %%F in ("%NNUE_BASE%") do set "ENGINE_BASE_EVAL= op
 echo Starting gauntlet (%GAMES% games, %ROUNDS% rounds) ...
 "%CUTECHESS%" ^
  -tournament gauntlet ^
- -engine cmd="%ENGINE_NEW%" name="revolution 2.81 021025" dir="%DIR_NEW%" ^
+ -engine cmd="%ENGINE_NEW%" name="revolution-2.81-071025" dir="%DIR_NEW%" ^
     %ENGINE_NEW_CORE%%ENGINE_NEW_EVAL%%EXP_BLOCK_CHAIN% ^
  -engine cmd="%ENGINE_BASE%" name="revolution-stable" dir="%DIR_BASE%" ^
     %ENGINE_BASE_CORE%%ENGINE_BASE_EVAL%%EXP_BLOCK_CHAIN% ^

--- a/scripts/match.sh
+++ b/scripts/match.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution-2.81-071025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 OPPONENT="${1:?Opponent engine path required}"
 GAMES="${2:-10}"
@@ -16,7 +16,7 @@ if ! command -v cutechess-cli >/dev/null; then
 fi
 
 cutechess-cli \
-  -engine cmd="$ENGINE" name="revolution 2.81 021025" \
+  -engine cmd="$ENGINE" name="revolution-2.81-071025" \
   -engine cmd="$OPPONENT" name=Opponent \
   -each proto=uci tc=$TC \
   -games $GAMES -concurrency 2 \

--- a/scripts/perft.sh
+++ b/scripts/perft.sh
@@ -4,7 +4,7 @@
 
 set -e
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-ENGINE_DEFAULT="$ROOT_DIR/src/revolution 2.81 021025"
+ENGINE_DEFAULT="$ROOT_DIR/src/revolution-2.81-071025"
 ENGINE="${ENGINE:-$ENGINE_DEFAULT}"
 TEST_DIR="$ROOT_DIR/tests"
 

--- a/scripts/run_metrics_pipeline.py
+++ b/scripts/run_metrics_pipeline.py
@@ -15,7 +15,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PLAN = ROOT / "docs" / "pipelines" / "xp_plan.json"
-DEFAULT_ENGINE = ROOT / "src" / "revolution 2.81 021025"
+DEFAULT_ENGINE = ROOT / "src" / "revolution-2.81-071025"
 
 
 class UCIProcess:

--- a/scripts/spsa.py
+++ b/scripts/spsa.py
@@ -21,7 +21,7 @@ def run_bench(engine, name, value):
 def main():
     p = argparse.ArgumentParser(description="SPSA tuning for Revolution")
     p.add_argument("--param", nargs=4, metavar=("NAME", "START", "MIN", "MAX"), action='append', required=True)
-    p.add_argument("--engine", default="src/revolution 2.81 021025")
+    p.add_argument("--engine", default="src/revolution-2.81-071025")
     p.add_argument("--iterations", type=int, default=10)
     args = p.parse_args()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -866,11 +866,11 @@ endif
 ### 3.8.4 Engine identity (UCI id name / build date)
 #UCI "id name" string shown in GUIs.
 #Defaults:
-#- ENGINE_NAME : "revolution 2.81 021025"
+#- ENGINE_NAME : "revolution-2.81-071025"
 #- ENGINE_BUILD_DATE : optional build identifier
 #You can override on the command line:
-#make ENGINE_NAME = "revolution 2.81 021025" ENGINE_BUILD_DATE = 20251025
-ENGINE_NAME        ?= revolution 2.81 021025
+#make ENGINE_NAME = "revolution-2.81-071025" ENGINE_BUILD_DATE = 20251007
+ENGINE_NAME        ?= revolution-2.81-071025
 ENGINE_BUILD_DATE  ?=
 CXXFLAGS += -DENGINE_NAME='"$(ENGINE_NAME)"' -DENGINE_BUILD_DATE='"$(ENGINE_BUILD_DATE)"'
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -118,7 +118,7 @@ void UCIEngine::loop() {
 
         else if (token == "uci")
         {
-            // Force a stable, explicit UCI name so GUIs show "revolution 2.81 021025"
+            // Force a stable, explicit UCI name so GUIs show "revolution-2.81-071025"
             sync_cout_start();
             std::cout
               << "id name " << ENGINE_NAME << "\n"

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef ENGINE_NAME
-    #define ENGINE_NAME "revolution 2.81 021025"
+    #define ENGINE_NAME "revolution-2.81-071025"
 #endif
 
 #ifndef ENGINE_BUILD_DATE


### PR DESCRIPTION
## Summary
- rename the default executable and UCI id to `revolution-2.81-071025`
- update helper scripts to point to the new engine binary name
- document the Revolution 2.81 vs 2.80 release match results in the README

## Testing
- make build ARCH=x86-64-sse41-popcnt -j2

------
https://chatgpt.com/codex/tasks/task_e_68e4f30377cc8327bfdbde542b6c7d60