### PR TITLE
Define double-step directions for shift helpers

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -133,8 +133,8 @@ template<Direction D>
 constexpr Bitboard shift(Bitboard b) {
     return D == NORTH         ? b << 8
          : D == SOUTH         ? b >> 8
-         : D == NORTH + NORTH ? b << 16
-         : D == SOUTH + SOUTH ? b >> 16
+         : D == NORTH_NORTH   ? b << 16
+         : D == SOUTH_SOUTH   ? b >> 16
          : D == EAST          ? (b & ~FileHBB) << 1
          : D == WEST          ? (b & ~FileABB) >> 1
          : D == NORTH_EAST    ? (b & ~FileHBB) << 9
@@ -152,10 +152,10 @@ constexpr Bitboard shift(Direction d, Bitboard b) {
         return shift<NORTH>(b);
     case SOUTH:
         return shift<SOUTH>(b);
-    case NORTH + NORTH:
-        return shift<NORTH + NORTH>(b);
-    case SOUTH + SOUTH:
-        return shift<SOUTH + SOUTH>(b);
+    case NORTH_NORTH:
+        return shift<NORTH_NORTH>(b);
+    case SOUTH_SOUTH:
+        return shift<SOUTH_SOUTH>(b);
     case EAST:
         return shift<EAST>(b);
     case WEST:

--- a/src/types.h
+++ b/src/types.h
@@ -247,6 +247,9 @@ enum Direction : int8_t {
     SOUTH = -NORTH,
     WEST  = -EAST,
 
+    NORTH_NORTH = 2 * NORTH,
+    SOUTH_SOUTH = 2 * SOUTH,
+
     NORTH_EAST = NORTH + EAST,
     SOUTH_EAST = SOUTH + EAST,
     SOUTH_WEST = SOUTH + WEST,


### PR DESCRIPTION
## Summary
- add explicit Direction enum constants for two-step north/south moves
- update bitboard shift helpers to use the named constants and satisfy -Wswitch

## Testing
- make build ARCH=x86-64-sse41-popcnt COMP=gcc

------
https://chatgpt.com/codex/tasks/task_e_68e4f7502e50832791ace43699154d40