### PR TITLE
Improve clang compiler autodetection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -525,9 +525,19 @@ endif
 
 ifeq ($(COMP),clang)
 	comp=clang
-	CXX=clang++
 	ifeq ($(target_windows),yes)
 		CXX=x86_64-w64-mingw32-clang++
+	else
+		ifneq ($(shell which clang++ 2> /dev/null),)
+			CXX=clang++
+		else
+			CLANGXX := $(firstword $(foreach ver,20 19 18 17 16,$(shell which clang++-$(ver) 2> /dev/null)))
+			ifneq ($(CLANGXX),)
+				CXX=$(CLANGXX)
+			else
+				CXX=clang++
+			endif
+		endif
 	endif
 
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes \


### PR DESCRIPTION
## Summary
- allow the Makefile's clang configuration to fall back to versioned `clang++-XX` binaries when the unversioned `clang++` is unavailable

## Testing
- `make -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`


------
https://chatgpt.com/codex/tasks/task_e_68e4f9ff6d8c83278502bc16eb5421af