### PR TITLE
Fix little-endian serializer shift overflow

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -51,7 +51,8 @@ void append_little_endian_value(std::string& out, T value)
     for (std::size_t i = 0; i < sizeof(T); ++i)
     {
         out.push_back(static_cast<char>(v & 0xFF));
-        v >>= 8;
+        if constexpr (sizeof(T) > 1)
+            v >>= 8;
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid shifting by the bit width in `append_little_endian_value` so 1-byte types no longer trigger a shift-count overflow warning during builds

## Testing
- make -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"

------
https://chatgpt.com/codex/tasks/task_e_68e51c119f00832793dfc988071d1a7a