### PR TITLE
Rebrand engine as Revolution 2.90-231025

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
-# revolution
-revolutions is strong chess engine derivate of Stockfish 17.1
+# Revolution 2.90-231025
+
+![Revolution minimal logo](assets/revolution-logo.svg)
+
+## Overview
+Revolution is a strong UCI chess engine derived from Stockfish 17.1. The 2.90-231025
+release introduces targeted optimisations and tuning curated with help from codex IA
+while preserving the battle-tested strength of its Stockfish heritage.
+
+## Highlights
+- Modern NNUE-evaluated engine based on the Stockfish 17.1 search framework.
+- codex IA assisted optimisations for evaluation speed and practical play strength.
+- Fully compatible with UCI graphical interfaces such as Fritz, CuteChess, Arena, and more.
+
+## Version identity
+The engine identifies itself in UCI GUIs as:
+
+```
+revolution-2.90-231025 by Jorge Ruiz Centelles and codex IA and the Stockfish developers (see AUTHORS file)
+```
+
+The same name is embedded in the executable so that analysis reports from popular GUIs
+can attribute results to Revolution 2.90-231025.
+
+## Getting started
+Refer to the `stockfish/README.md` file for detailed build and usage instructions. The
+commands and options described there apply equally to Revolution.
+
+## Credits
+- Jorge Ruiz Centelles and codex IA for the Revolution direction and optimisation work.
+- The Stockfish developers (see `AUTHORS`) for the original engine code base and ongoing
+  chess engine research.
+
+## License
+Revolution remains distributed under the GNU General Public License version 3 (or any
+later version). See `stockfish/Copying.txt` for the full license text.

--- a/assets/revolution-logo.svg
+++ b/assets/revolution-logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240" role="img" aria-labelledby="title desc">
+  <title id="title">Revolution minimal logo</title>
+  <desc id="desc">Stylised letter R inside a circular motif</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1d1d1f" />
+      <stop offset="100%" stop-color="#e63946" />
+    </linearGradient>
+  </defs>
+  <circle cx="120" cy="120" r="112" fill="none" stroke="#1d1d1f" stroke-width="12" />
+  <path d="M120 44c-36 0-64 28-64 76 0 47 28 76 68 76 20 0 36-5 48-16l-18-20c-8 8-16 11-28 11-22 0-36-15-36-47 0-33 14-48 36-48 10 0 18 3 24 9l-16 18h28l24-27C174 56 150 44 120 44z" fill="url(#grad)" />
+</svg>

--- a/stockfish/CITATION.cff
+++ b/stockfish/CITATION.cff
@@ -2,17 +2,19 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Stockfish
+title: Revolution 2.90-231025
 message: >-
   Please cite this software using the metadata from this
   file.
 type: software
 authors:
+  - family-names: Ruiz Centelles
+    given-names: Jorge
+  - name: codex IA
   - name: The Stockfish developers (see AUTHORS file)
 repository-code: 'https://github.com/official-stockfish/Stockfish'
-url: 'https://stockfishchess.org/'
 repository-artifact: 'https://stockfishchess.org/download/'
-abstract: Stockfish is a free and strong UCI chess engine.
+abstract: Revolution is a free and strong UCI chess engine derived from Stockfish 17.1 with codex IA optimisations.
 keywords:
   - chess
   - artificial intelligence (AI)

--- a/stockfish/README.md
+++ b/stockfish/README.md
@@ -1,33 +1,17 @@
 <div align="center">
 
-  [![Stockfish][stockfish128-logo]][website-link]
+  <img src="../assets/revolution-logo.svg" alt="Revolution logo" width="128" />
 
-  <h3>Stockfish</h3>
+  <h3>Revolution 2.90-231025</h3>
 
-  A free and strong UCI chess engine.
+  A strong UCI chess engine derived from Stockfish 17.1 with codex IA optimisations.
   <br>
-  <strong>[Explore Stockfish docs »][wiki-link]</strong>
-  <br>
-  <br>
-  [Report bug][issue-link]
-  ·
-  [Open a discussion][discussions-link]
-  ·
-  [Discord][discord-link]
-  ·
-  [Blog][website-blog-link]
-
-  [![Build][build-badge]][build-link]
-  [![License][license-badge]][license-link]
-  <br>
-  [![Release][release-badge]][release-link]
-  [![Commits][commits-badge]][commits-link]
-  <br>
-  [![Website][website-badge]][website-link]
-  [![Fishtest][fishtest-badge]][fishtest-link]
-  [![Discord][discord-badge]][discord-link]
+  Crafted by Jorge Ruiz Centelles and codex IA, building upon the work of the Stockfish developers.
 
 </div>
+
+> The upstream Stockfish documentation is retained below for reference. All build
+> instructions and technical notes continue to apply to Revolution.
 
 ## Overview
 

--- a/stockfish/src/main.cpp
+++ b/stockfish/src/main.cpp
@@ -29,7 +29,7 @@ using namespace Stockfish;
 
 int main(int argc, char* argv[]) {
 
-    std::cout << engine_info() << std::endl;
+    std::cout << revolution_ascii_logo() << '\n' << engine_info() << std::endl;
 
     Bitboards::init();
     Position::init();

--- a/stockfish/src/misc.cpp
+++ b/stockfish/src/misc.cpp
@@ -40,7 +40,18 @@ namespace Stockfish {
 namespace {
 
 // Version number or dev.
-constexpr std::string_view version = "17.1";
+constexpr std::string_view engineName    = "revolution-2.90-231025";
+constexpr std::string_view engineCredits =
+  "Jorge Ruiz Centelles and codex IA and the Stockfish developers (see AUTHORS file)";
+constexpr std::string_view version       = engineName;
+
+constexpr std::string_view RevolutionAsciiLogo =
+  " ____            _           _   _             \n"
+  "|  _ \\ ___  ___ | | ___  ___| |_(_) ___  _ __  \n"
+  "| |_) / _ \\/ _ \\| |/ _ \\/ __| __| |/ _ \\| '_ \\ \n"
+  "|  _ <  __/ (_) | |  __/ (__| |_| | (_) | | | |\n"
+  "|_| \\\\___|\\___/|_|\\___|\\___|\\__|_|\\___/|_| |_|\n"
+  "               Revolution Engine               ";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -126,7 +137,7 @@ class Logger {
 //      Stockfish version
 std::string engine_version_info() {
     std::stringstream ss;
-    ss << "Stockfish " << version << std::setfill('0');
+    ss << version << std::setfill('0');
 
     if constexpr (version == "dev")
     {
@@ -157,8 +168,11 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ")
-         + "the Stockfish developers (see AUTHORS file)";
+    return engine_version_info() + (to_uci ? "\nid author " : " by ") + std::string(engineCredits);
+}
+
+std::string_view revolution_ascii_logo() {
+    return RevolutionAsciiLogo;
 }
 
 

--- a/stockfish/src/misc.h
+++ b/stockfish/src/misc.h
@@ -40,6 +40,7 @@ namespace Stockfish {
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();
+std::string_view revolution_ascii_logo();
 
 // Preloads the given address in L1/L2 cache. This is a non-blocking
 // function that doesn't stall the CPU waiting for data to be loaded from memory,

--- a/stockfish/src/uci.cpp
+++ b/stockfish/src/uci.cpp
@@ -117,6 +117,9 @@ void UCIEngine::loop() {
             sync_cout << "id name " << engine_info(true) << "\n"
                       << engine.get_options() << sync_endl;
 
+            print_info_string(revolution_ascii_logo());
+            print_info_string(engine_info());
+
             sync_cout << "uciok" << sync_endl;
         }
 
@@ -164,12 +167,11 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nStockfish is a powerful chess engine for playing and analyzing."
+              << "\nRevolution is a powerful chess engine for playing and analyzing."
                  "\nIt is released as free software licensed under the GNU GPLv3 License."
-                 "\nStockfish is normally used with a graphical user interface (GUI) and implements"
+                 "\nRevolution is normally used with a graphical user interface (GUI) and implements"
                  "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
-                 "\nFor any further information, visit https://github.com/official-stockfish/Stockfish#readme"
-                 "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n"
+                 "\nFor any further information, read the README.md and Copying.txt files distributed along with this program.\n"
               << sync_endl;
         else if (!token.empty() && token[0] != '#')
             sync_cout << "Unknown command: '" << cmd << "'. Type help for more information."


### PR DESCRIPTION
## Summary
- update project documentation to describe Revolution 2.90-231025 and credit codex IA alongside the Stockfish developers
- embed the Revolution branding in the engine output, UCI author strings, and CLI banner
- add a minimal SVG logo for the repository landing page and GUI banner output

## Testing
- make build

------
https://chatgpt.com/codex/tasks/task_e_68fa2b8dedac8327abe0ab1f3c80cb3a