### PR TITLE
Refactor Zobrist initialization into dedicated module

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ PGOBENCH = $(WINE_PATH) ./$(EXE) bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
-        misc.cpp movegen.cpp movepick.cpp position.cpp \
+        misc.cpp movegen.cpp movepick.cpp position.cpp zobrist.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/features/half_ka_v2_hm.cpp nnue/network.cpp \
         engine.cpp score.cpp memory.cpp \
@@ -63,10 +63,10 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/layers/affine_transform.h \
 		nnue/layers/affine_transform_sparse_input.h nnue/layers/clipped_relu.h nnue/layers/simd.h \
-		nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h nnue/nnue_architecture.h \
-		nnue/nnue_common.h nnue/nnue_feature_transformer.h position.h \
-		search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
-		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h
+               nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h nnue/nnue_architecture.h \
+               nnue/nnue_common.h nnue/nnue_feature_transformer.h position.h zobrist.h \
+               search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
+               tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -37,18 +37,11 @@
 #include "syzygy/tbprobe.h"
 #include "tt.h"
 #include "uci.h"
+#include "zobrist.h"
 
 using std::string;
 
 namespace Stockfish {
-
-namespace Zobrist {
-
-Key psq[PIECE_NB][SQUARE_NB];
-Key enpassant[FILE_NB];
-Key castling[CASTLING_RIGHT_NB];
-Key side, noPawns;
-}
 
 namespace {
 
@@ -112,23 +105,7 @@ std::array<Move, 8192> cuckooMove;
 // Initializes at startup the various arrays used to compute hash keys
 void Position::init() {
 
-    PRNG rng(1070372);
-
-    for (Piece pc : Pieces)
-        for (Square s = SQ_A1; s <= SQ_H8; ++s)
-            Zobrist::psq[pc][s] = rng.rand<Key>();
-    // pawns on these squares will promote
-    std::fill_n(Zobrist::psq[W_PAWN] + SQ_A8, 8, 0);
-    std::fill_n(Zobrist::psq[B_PAWN], 8, 0);
-
-    for (File f = FILE_A; f <= FILE_H; ++f)
-        Zobrist::enpassant[f] = rng.rand<Key>();
-
-    for (int cr = NO_CASTLING; cr <= ANY_CASTLING; ++cr)
-        Zobrist::castling[cr] = rng.rand<Key>();
-
-    Zobrist::side    = rng.rand<Key>();
-    Zobrist::noPawns = rng.rand<Key>();
+    Zobrist::init();
 
     // Prepare the cuckoo tables
     cuckoo.fill(0);

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -1,0 +1,60 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "zobrist.h"
+
+#include <algorithm>
+
+#include "misc.h"
+
+namespace Stockfish {
+
+Key Zobrist::psq[PIECE_NB][SQUARE_NB];
+Key Zobrist::enpassant[FILE_NB];
+Key Zobrist::castling[CASTLING_RIGHT_NB];
+Key Zobrist::side;
+Key Zobrist::noPawns;
+
+namespace {
+
+constexpr int zobristSeed = 1070372;
+
+}  // namespace
+
+void Zobrist::init() {
+
+    PRNG rng(zobristSeed);
+
+    for (Piece pc = W_PAWN; pc <= B_KING; pc = Piece(pc + 1))
+        for (Square s = SQ_A1; s <= SQ_H8; s = Square(s + 1))
+            psq[pc][s] = rng.rand<Key>();
+
+    std::fill_n(psq[W_PAWN] + SQ_A8, 8, 0);
+    std::fill_n(psq[B_PAWN], 8, 0);
+
+    for (File f = FILE_A; f <= FILE_H; f = File(f + 1))
+        enpassant[f] = rng.rand<Key>();
+
+    for (int cr = NO_CASTLING; cr <= ANY_CASTLING; ++cr)
+        castling[cr] = rng.rand<Key>();
+
+    side    = rng.rand<Key>();
+    noPawns = rng.rand<Key>();
+}
+
+}  // namespace Stockfish

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -1,0 +1,40 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ZOBRIST_H_INCLUDED
+#define ZOBRIST_H_INCLUDED
+
+#include "types.h"
+
+namespace Stockfish {
+
+namespace Zobrist {
+
+extern Key psq[PIECE_NB][SQUARE_NB];
+extern Key enpassant[FILE_NB];
+extern Key castling[CASTLING_RIGHT_NB];
+extern Key side;
+extern Key noPawns;
+
+void init();
+
+}  // namespace Zobrist
+
+}  // namespace Stockfish
+
+#endif  // ZOBRIST_H_INCLUDED


### PR DESCRIPTION
## Summary
- extract Zobrist state into a dedicated zobrist.cpp/zobrist.h module
- have Position::init rely on Zobrist::init while retaining cuckoo setup locally
- register the new module in the Makefile sources and headers lists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa369c960c8327bc7576ac6552d99a