### PR TITLE
Add missing cstddef include for std::size_t usage

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -37,6 +37,7 @@
 //               | only in 64-bit mode and requires hardware with pext support.
 
     #include <cassert>
+    #include <cstddef>
     #include <cstdint>
 
     #if defined(_MSC_VER)


### PR DESCRIPTION
## Summary
- include `<cstddef>` in `types.h` so that `std::size_t` is available when building without implicit includes

## Testing
- `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa493ba0d08327a15e239302daf490