### PR TITLE
Fix undeclared bookMove reference in worker startup

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -207,24 +207,6 @@ void Search::Worker::start_searching() {
     {
         iterative_deepening();
         return;
-        if (bookMove == Move::none())
-        {
-            if (auto suggestion = experience.best_book_move(rootPos); suggestion.has_value())
-            {
-                std::string ponder;
-                auto        candidate = std::find(rootMoves.begin(), rootMoves.end(), suggestion->move);
-
-                if (candidate != rootMoves.end() && candidate->pv.size() > 1)
-                    ponder = UCIEngine::move(candidate->pv[1], rootPos.is_chess960());
-
-                if (!suggestion->info.empty())
-                    sync_cout << "info string " << suggestion->info << sync_endl;
-
-                main_manager()->updates.onBestmove(
-                  UCIEngine::move(suggestion->move, rootPos.is_chess960()), ponder);
-                return;
-            }
-        }
     }
 
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,


### PR DESCRIPTION
## Summary
- remove unreachable fallback logic that referenced bookMove before it was defined in `Search::Worker::start_searching`
- keep the existing experience-based suggestion handling after the regular opening book probe

## Testing
- `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` *(fails: clang toolchain not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa56bdefc08327897616eb69fa3064