### PR TITLE
Fix warnings reported during clang profile build

### DIFF
--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -430,10 +430,12 @@ void Manager::load_file(const std::filesystem::path& path) {
 
     std::lock_guard<std::mutex> lk(mutex);
 
-    for (const auto& [key, data] : parsed)
+    for (const auto& entry : parsed)
     {
-        auto& bucket = table[key];
-        auto  it     = std::find_if(bucket.begin(), bucket.end(), [&](const MoveData& existing) {
+        const Key        key  = entry.first;
+        const MoveData&  data = entry.second;
+        auto&            bucket = table[key];
+        auto             it     = std::find_if(bucket.begin(), bucket.end(), [&](const MoveData& existing) {
             return existing.move == data.move;
         });
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -183,11 +183,11 @@ Search::Worker::Worker(SharedState&                    sharedState,
     numaAccessToken(token),
     manager(std::move(sm)),
     bookMan(sharedState.bookMan),
+    experience(sharedState.experience),
     options(sharedState.options),
     threads(sharedState.threads),
     tt(sharedState.tt),
     networks(sharedState.networks),
-    experience(sharedState.experience),
     refreshTable(networks[token]) {
     clear();
 }


### PR DESCRIPTION
## Summary
- align Search::Worker member initialization order with the declaration to satisfy clang's -Wreorder warning
- rewrite experience table merge loop to avoid capturing a structured binding, removing the -Wc++20-extensions warning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa588f42648327aad3d860e7275230