### PR TITLE
Improve king danger heuristics and aspiration handling

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -51,6 +51,8 @@ Value evaluate(const NNUE::Networks&          networks,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
+
+int king_danger(const Position& pos, Color defender);
 }  // namespace Eval
 
 }  // namespace Stockfish


### PR DESCRIPTION
## Summary
- add king danger heuristics with amplified open-file and pawn-storm terms plus rook battery support, and expose the helper for search use
- bias repetition scoring against draws when ahead and clamp LMR reductions for volatile nodes and high king danger
- revise aspiration window logic to perform a single auto-expand and fall back to a full PV window on repeated failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa79a856c48327b32f3e24a53c66ea