### PR TITLE
Remove time options to match Stockfish 17.1

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -112,9 +112,6 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Move Overhead", Option(10, 0, 5000));
 
-    options.add("Minimum Thinking Time", Option(100, 0, 2000));
-    options.add("Slow Mover", Option(100, 10, 500));
-
     options.add("nodestime", Option(0, 0, 10000));
 
     options.add("UCI_Chess960", Option(false));

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -59,9 +59,7 @@ void TimeManagement::init(Search::LimitsType& limits,
     if (limits.time[us] == 0)
         return;
 
-    TimePoint moveOverhead       = TimePoint(options["Move Overhead"]);
-    TimePoint minimumThinkingTime = TimePoint(options["Minimum Thinking Time"]);
-    const int  slowMoverPercent   = options["Slow Mover"];
+    TimePoint moveOverhead = TimePoint(options["Move Overhead"]);
 
     // optScale is a percentage of available time to use for the current move.
     // maxScale is a multiplier applied to optimumTime.
@@ -81,7 +79,6 @@ void TimeManagement::init(Search::LimitsType& limits,
         limits.inc[us] *= npmsec;
         limits.npmsec = npmsec;
         moveOverhead *= npmsec;
-        minimumThinkingTime *= npmsec;
     }
 
     // These numbers are used where multiplications, divisions or comparisons
@@ -104,8 +101,6 @@ void TimeManagement::init(Search::LimitsType& limits,
       std::max(TimePoint(1),
                limits.time[us]
                  + (limits.inc[us] * (centiMTG - 100) - moveOverhead * (200 + centiMTG)) / 100);
-
-    timeLeft = std::max(TimePoint(1), TimePoint(timeLeft * slowMoverPercent / 100));
 
     // x basetime (+ z increment)
     // If there is a healthy increment, timeLeft can exceed the actual available
@@ -141,8 +136,6 @@ void TimeManagement::init(Search::LimitsType& limits,
     maximumTime =
       TimePoint(std::min(0.825179 * limits.time[us] - moveOverhead, maxScale * optimumTime)) - 10;
 
-    optimumTime = std::max(optimumTime, minimumThinkingTime);
-    maximumTime = std::max(maximumTime, minimumThinkingTime);
     maximumTime = std::max(maximumTime, optimumTime);
 
     if (options["Ponder"])


### PR DESCRIPTION
## Summary
- remove the custom "Minimum Thinking Time" and "Slow Mover" UCI options from the engine initialization
- align time management calculations with Stockfish 17.1 by removing the dependence on the deleted options

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68facc051c188327a83b0ca54c4fea15