### PR TITLE
Increase pawn history and optimize worker memory

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           repository: vondele/matetrack
           path: matetrack
-          ref: 4f8a80860ed8f3607f05a9195df8b40203bdc360
+          ref: 2d96fa3373f90edb032b7ea7468473fb9e6f0343
           persist-credentials: false
 
       - name: matetrack install deps

--- a/src/history.h
+++ b/src/history.h
@@ -33,7 +33,7 @@
 
 namespace Stockfish {
 
-constexpr int PAWN_HISTORY_SIZE        = 512;    // has to be a power of 2
+constexpr int PAWN_HISTORY_SIZE        = 8192;    // has to be a power of 2
 constexpr int CORRECTION_HISTORY_SIZE  = 32768;  // has to be a power of 2
 constexpr int CORRECTION_HISTORY_LIMIT = 1024;
 constexpr int LOW_PLY_HISTORY_SIZE     = 4;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1871,12 +1871,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 }
             }
 
-            // Continuation history based pruning
-            if (!capture
-                && (*contHist[0])[pos.moved_piece(move)][move.to_sq()]
-                       + thisThread->pawnHistory[pawn_structure_index(pos)][pos.moved_piece(move)]
-                                                [move.to_sq()]
-                     <= 6290)
+            // Skip non-captures (always)
+            if (!capture)
                 continue;
 
             // Do not search moves with bad enough SEE values

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -26,6 +26,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include "memory.h"
 #include "movegen.h"
 #include "search.h"
 #include "syzygy/tbprobe.h"
@@ -53,8 +54,8 @@ Thread::Thread(Search::SharedState&                    sharedState,
         // the Worker allocation. Ideally we would also allocate the SearchManager
         // here, but that's minor.
         this->numaAccessToken = binder();
-        this->worker =
-          std::make_unique<Search::Worker>(sharedState, std::move(sm), n, this->numaAccessToken);
+        this->worker = make_unique_large_page<Search::Worker>(sharedState, std::move(sm), n,
+                                                             this->numaAccessToken);
     });
 
     wait_for_search_finished();

--- a/src/thread.h
+++ b/src/thread.h
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <vector>
 
+#include "memory.h"
 #include "numa.h"
 #include "position.h"
 #include "search.h"
@@ -93,8 +94,8 @@ class Thread {
     void   wait_for_search_finished();
     size_t id() const { return idx; }
 
-    std::unique_ptr<Search::Worker> worker;
-    std::function<void()>           jobFunc;
+    LargePagePtr<Search::Worker> worker = nullptr;
+    std::function<void()>         jobFunc;
 
    private:
     std::mutex                mutex;


### PR DESCRIPTION
## Summary
- increase the pawn history table size to 8192 entries
- prune all non-captures in qsearch
- allocate search workers with large pages and update the matetrack workflow reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fad935f97483279acd78c8678156fa