### PR TITLE
Fix case-insensitive character handling

### DIFF
--- a/src/book/ctg/ctg.cpp
+++ b/src/book/ctg/ctg.cpp
@@ -1,3 +1,4 @@
+#include <cctype>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
@@ -477,10 +478,12 @@ void CtgBook::invert_board(CtgPositionData& positionData) const {
             if (p == ' ')
                 continue;
 
-            if (p == toupper(p))
-                p = tolower(p);
+            const auto ch = static_cast<unsigned char>(p);
+
+            if (std::isupper(ch))
+                p = static_cast<char>(std::tolower(ch));
             else
-                p = toupper(p);
+                p = static_cast<char>(std::toupper(ch));
         }
     }
 }

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -52,8 +52,13 @@ bool starts_with_ignore_case(const std::string& value, std::string_view prefix) 
         return false;
 
     for (size_t i = 0; i < prefix.size(); ++i)
-        if (std::tolower(value[i]) != std::tolower(prefix[i]))
+    {
+        const auto lhs = static_cast<unsigned char>(value[i]);
+        const auto rhs = static_cast<unsigned char>(prefix[i]);
+
+        if (std::tolower(lhs) != std::tolower(rhs))
             return false;
+    }
 
     return true;
 }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -610,7 +610,9 @@ std::string UCIEngine::move(Move m, bool chess960) {
 
 
 std::string UCIEngine::to_lower(std::string str) {
-    std::transform(str.begin(), str.end(), str.begin(), [](auto c) { return std::tolower(c); });
+    std::transform(str.begin(), str.end(), str.begin(), [](char c) {
+        return char(std::tolower(static_cast<unsigned char>(c)));
+    });
 
     return str;
 }

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -33,8 +33,11 @@ namespace Stockfish {
 bool CaseInsensitiveLess::operator()(const std::string& s1, const std::string& s2) const {
 
     return std::lexicographical_compare(
-      s1.begin(), s1.end(), s2.begin(), s2.end(),
-      [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
+      s1.begin(), s1.end(), s2.begin(), s2.end(), [](char c1, char c2) {
+          const auto lhs = static_cast<unsigned char>(c1);
+          const auto rhs = static_cast<unsigned char>(c2);
+          return std::tolower(lhs) < std::tolower(rhs);
+      });
 }
 
 void OptionsMap::add_info_listener(InfoListener&& message_func) { info = std::move(message_func); }


### PR DESCRIPTION
## Summary
- prevent undefined behaviour in option name ordering by lower-casing using unsigned char values
- harden case-insensitive string handling across experience manager, position parsing, UCI helpers, and CTG book utilities

## Testing
- make -C src build

------
https://chatgpt.com/codex/tasks/task_e_68fad9fc92a483279be5bea678dea91a