### PR TITLE
Fix Zobrist pawn hashing for invalid ranks

### DIFF
--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -44,8 +44,8 @@ void Zobrist::init() {
         for (Square s = SQ_A1; s <= SQ_H8; s = Square(s + 1))
             psq[pc][s] = rng.rand<Key>();
 
-    std::fill_n(psq[W_PAWN] + SQ_A8, 8, 0);
-    std::fill_n(psq[B_PAWN], 8, 0);
+    std::fill_n(psq[W_PAWN], 8, 0);
+    std::fill_n(psq[B_PAWN] + SQ_A8, 8, 0);
 
     for (File f = FILE_A; f <= FILE_H; f = File(f + 1))
         enpassant[f] = rng.rand<Key>();


### PR DESCRIPTION
## Summary
- ensure Zobrist hashing zeroes out white pawns on rank 1 and black pawns on rank 8
- keep invalid pawn positions from contributing spurious hash keys by correcting the table initialization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68fae29de67483279e694cfbfd9a6997