### PR TITLE
Fix undefined behavior in whitespace helpers

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -483,11 +483,16 @@ std::optional<std::string> read_file_to_string(const std::string& path) {
 }
 
 void remove_whitespace(std::string& s) {
-    s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());
+    s.erase(std::remove_if(s.begin(), s.end(), [](char c) {
+                return std::isspace(static_cast<unsigned char>(c));
+            }),
+            s.end());
 }
 
 bool is_whitespace(std::string_view s) {
-    return std::all_of(s.begin(), s.end(), [](char c) { return std::isspace(c); });
+    return std::all_of(s.begin(), s.end(), [](char c) {
+        return std::isspace(static_cast<unsigned char>(c));
+    });
 }
 
 std::string CommandLine::get_binary_directory(std::string argv0) {


### PR DESCRIPTION
## Summary
- guard the whitespace helper utilities against signed-char UB when forwarding to `std::isspace`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68faedbcf68883279b0ffb2631219b49