### PR TITLE
Rebrand project to Revolution 2.90 241025

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,8 @@
-# Pullfish maintainers
+# Revolution maintainers
 Jorge Ruiz
 ChatGPT
 
-# Pullfish 1.0 171025 is a derivative of Stockfish 17.1. The original Stockfish
+# Revolution 2.90 241025 is a derivative of Stockfish 17.1. The original Stockfish
 # contributors remain credited below.
 
 # Founders of the Stockfish project and Fishtest infrastructure

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Pullfish 1.0 171025
+title: Revolution 2.90 241025
 message: >-
-  Please cite Pullfish 1.0 171025 as a derivative of Stockfish 17.1 using the
+  Please cite Revolution 2.90 241025 as a derivative of Stockfish 17.1 using the
   metadata from this file.
 type: software
 authors:
@@ -12,11 +12,11 @@ authors:
     given-names: Jorge
   - name: ChatGPT
   - name: The Stockfish developers (see AUTHORS file)
-repository-code: 'https://github.com/jorgeruiz/pullfish'
-url: 'https://github.com/jorgeruiz/pullfish'
-repository-artifact: 'https://github.com/jorgeruiz/pullfish/releases'
+repository-code: 'https://github.com/jorgeruiz/revolution'
+url: 'https://github.com/jorgeruiz/revolution'
+repository-artifact: 'https://github.com/jorgeruiz/revolution/releases'
 abstract: >-
-  Pullfish 1.0 171025 is a free and strong UCI chess engine derived from
+  Revolution 2.90 241025 is a free and strong UCI chess engine derived from
   Stockfish 17.1, co-authored by Jorge Ruiz and ChatGPT with full credit to the
   Stockfish developers.
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Pullfish
+# Contributing to Revolution
 
-Welcome to the Pullfish project! We are excited that you are interested in
+Welcome to the Revolution project! We are excited that you are interested in
 contributing. This document outlines the guidelines and steps to follow when
-making contributions to Pullfish 1.0 171025, a derivative of Stockfish 17.1.
+making contributions to Revolution 2.90 241025, a derivative of Stockfish 17.1.
 
 ## Table of Contents
 
-- [Building Pullfish](#building-pullfish)
+- [Building Revolution](#building-revolution)
 - [Making Contributions](#making-contributions)
   - [Reporting Issues](#reporting-issues)
   - [Submitting Pull Requests](#submitting-pull-requests)
@@ -14,7 +14,7 @@ making contributions to Pullfish 1.0 171025, a derivative of Stockfish 17.1.
 - [Community and Communication](#community-and-communication)
 - [License](#license)
 
-## Building Pullfish
+## Building Revolution
 
 In case you do not have a C++ compiler installed, you can follow the
 instructions from our wiki.
@@ -32,7 +32,7 @@ If you find a bug, please open an issue on the
 like your operating system, build environment, and a detailed description of the
 problem.
 
-_Please note that Pullfish development follows the upstream Stockfish policy of
+_Please note that Revolution development follows the upstream Stockfish policy of
 not focusing on new features. Thus any issue regarding missing features will
 potentially be closed without further discussion._
 
@@ -51,13 +51,13 @@ potentially be closed without further discussion._
 
 _First time contributors should add their name to [AUTHORS](./AUTHORS)._ 
 
-_Pullfish's development is not focused on adding new features, mirroring
+_Revolution's development is not focused on adding new features, mirroring
 Stockfish. Thus any pull request introducing new features will potentially be
 closed without further discussion._
 
 ## Code Style
 
-Changes to Pullfish C++ code should respect our coding style defined by
+Changes to Revolution C++ code should respect our coding style defined by
 [.clang-format](.clang-format). You can format your changes by running
 `make format`. This requires clang-format version 18 to be installed on your system.
 
@@ -80,11 +80,11 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 ## License
 
-By contributing to Pullfish, you agree that your contributions will be licensed
+By contributing to Revolution, you agree that your contributions will be licensed
 under the GNU General Public License v3.0. See [Copying.txt][copying-link] for
 more details.
 
-Thank you for contributing to Pullfish and helping us make it even better!
+Thank you for contributing to Revolution and helping us make it even better!
 
 [copying-link]:           https://github.com/official-stockfish/Stockfish/blob/master/Copying.txt
 [discord-link]:           https://discord.gg/GWDRS3kU6R

--- a/Copying.txt
+++ b/Copying.txt
@@ -1,6 +1,6 @@
-Pullfish 1.0 171025 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
+Revolution 2.90 241025 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
 with credits to ChatGPT and the Stockfish developers listed in AUTHORS. The GNU
-General Public License reproduced below governs Pullfish.
+General Public License reproduced below governs Revolution.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/README.md
+++ b/README.md
@@ -1,50 +1,50 @@
 <div align="center">
 
-  <img src="assets/pullsfish-logo.svg" alt="Pullfish logo" width="160">
+  <img src="assets/pullsfish-logo.svg" alt="Revolution logo" width="160">
 
-  <h3>Pullfish 1.0 171025</h3>
+  <h3>Revolution 2.90 241025</h3>
 
   A free and strong UCI chess engine derived from Stockfish 17.1.
   <br>
   <strong>Developed, maintained, and improved by Jorge Ruiz together with the ChatGPT AI, with full credit to the Stockfish authors and contributors.</strong>
   <br>
   <br>
-  <a href="https://github.com/jorgeluisruiz/pullfish/issues/new">Report bug</a>
+  <a href="https://github.com/jorgeluisruiz/revolution/issues/new">Report bug</a>
   ·
-  <a href="https://github.com/jorgeluisruiz/pullfish/discussions/new">Open a discussion</a>
+  <a href="https://github.com/jorgeluisruiz/revolution/discussions/new">Open a discussion</a>
   ·
   <a href="https://discord.gg/GWDRS3kU6R">Discord</a>
   ·
-  <a href="https://pullfish.org/blog">Blog</a>
+  <a href="https://revolution.org/blog">Blog</a>
 
 </div>
 
-> **Pullfish 1.0 171025** is a UCI chess engine derived from **Stockfish 17.1**. The
+> **Revolution 2.90 241025** is a UCI chess engine derived from **Stockfish 17.1**. The
 > project is jointly authored by **Jorge Ruiz** and the **ChatGPT AI**, with
 > credits to the Stockfish authors and every contributor listed in
 > [AUTHORS](AUTHORS). This repository provides the complete source so the
 > community can collaborate on maintenance and future improvements.
 
-This release and all distributed binaries identify themselves as **Pullfish 1.0 171025**.
-You should see that exact name (including the build tag `171025`) in the engine
+This release and all distributed binaries identify themselves as **Revolution 2.90 241025**.
+You should see that exact name (including the build tag `241025`) in the engine
 headers, UCI responses, and compiled executable filenames. If a GUI shows a
 different string, make sure it is loading the binaries built from this version
 of the source tree.
 
 ## Overview
 
-Pullfish 1.0 171025 is a **free and strong UCI chess engine** that analyzes chess positions
+Revolution 2.90 241025 is a **free and strong UCI chess engine** that analyzes chess positions
 and computes the optimal moves while preserving full compatibility with popular
 front-ends.
 
-Pullfish 1.0 171025 **does not include a graphical user interface** (GUI) and is normally
+Revolution 2.90 241025 **does not include a graphical user interface** (GUI) and is normally
 paired with third-party front-ends such as Fritz 20 or Cutechess. It implements
 the Universal Chess Interface (UCI) protocol so those GUIs can discover it as
-**Pullfish 1.0 171025** in their engine lists.
+**Revolution 2.90 241025** in their engine lists.
 
 ### BrainLearn experience integration
 
-Pullfish 1.0 171025 bundles the BrainLearn learning hash so it shares the same
+Revolution 2.90 241025 bundles the BrainLearn learning hash so it shares the same
 UCI options as BrainFish while persisting the data to `experience.exp`. Each
 entry in the file stores the following information (mirroring the in-memory
 BrainLearn transposition table):
@@ -90,17 +90,17 @@ each move, and persists the updated values so they are used in future sessions.
 
 ## Files
 
-This distribution of Pullfish 1.0 171025 consists of the following files:
+This distribution of Revolution 2.90 241025 consists of the following files:
 
   * [README.md](README.md), the file you are currently reading.
 
   * [Copying.txt](Copying.txt), a text file containing the GNU General Public
     License version 3.
 
-  * [AUTHORS](AUTHORS), a text file with the list of authors for Pullfish 1.0 171025.
+  * [AUTHORS](AUTHORS), a text file with the list of authors for Revolution 2.90 241025.
 
   * [src](src), a subdirectory containing the full source code, including a
-    Makefile that can be used to compile Pullfish 1.0 171025 on Unix-like systems.
+    Makefile that can be used to compile Revolution 2.90 241025 on Unix-like systems.
 
   * a file with the .nnue extension, storing the neural network for the NNUE
     evaluation. Binary distributions will have this file embedded.
@@ -111,32 +111,32 @@ __See [Contributing Guide](CONTRIBUTING.md).__
 
 ### Donating hardware
 
-Improving Pullfish 1.0 171025 requires a massive amount of testing. You can donate your
-hardware resources by installing the Pullfish worker and joining the community
+Improving Revolution 2.90 241025 requires a massive amount of testing. You can donate your
+hardware resources by installing the Revolution worker and joining the community
 channels to coordinate testing campaigns.
 
 ### Improving the code
 
 In the [chessprogramming wiki](https://www.chessprogramming.org/Main_Page), many
-techniques used in Pullfish 1.0 171025 are explained with a lot of background information.
+techniques used in Revolution 2.90 241025 are explained with a lot of background information.
 The [section on evaluation techniques](https://www.chessprogramming.org/Evaluation)
 describes many features and techniques used by modern engines.
 
-The engine testing is coordinated by the Pullfish maintainers. If you want to
-help improve Pullfish 1.0 171025, please read this
-[guideline](https://github.com/jorgeluisruiz/pullfish/wiki/Getting-Started)
+The engine testing is coordinated by the Revolution maintainers. If you want to
+help improve Revolution 2.90 241025, please read this
+[guideline](https://github.com/jorgeluisruiz/revolution/wiki/Getting-Started)
 first, where the basics of development are explained.
 
-Discussions about Pullfish take place mainly in the community
+Discussions about Revolution take place mainly in the community
 [Discord server](https://discord.gg/GWDRS3kU6R). This is the best place to ask
 questions about the codebase and how to improve it.
 
-## Compiling Pullfish
+## Compiling Revolution
 
-Pullfish 1.0 171025 has support for 32 or 64-bit CPUs, certain hardware instructions,
+Revolution 2.90 241025 has support for 32 or 64-bit CPUs, certain hardware instructions,
 big-endian machines such as Power PC, and other platforms.
 
-On Unix-like systems, it should be easy to compile Pullfish 1.0 171025 directly from the
+On Unix-like systems, it should be easy to compile Revolution 2.90 241025 directly from the
 source code with the included Makefile in the folder `src`. In general, it is
 recommended to run `make help` to see a list of make targets with corresponding
 descriptions. An example suitable for most Intel and AMD chips:
@@ -147,14 +147,14 @@ make -j profile-build
 ```
 
 Detailed compilation instructions for all platforms can be found in the
-[documentation](https://github.com/jorgeluisruiz/pullfish/wiki/Compilation). The
+[documentation](https://github.com/jorgeluisruiz/revolution/wiki/Compilation). The
 wiki also has information about the
-[UCI commands](https://github.com/jorgeluisruiz/pullfish/wiki/UCI-Commands)
-supported by Pullfish.
+[UCI commands](https://github.com/jorgeluisruiz/revolution/wiki/UCI-Commands)
+supported by Revolution.
 
 ## Terms of use
 
-Pullfish 1.0 171025 is free and distributed under the
+Revolution 2.90 241025 is free and distributed under the
 [**GNU General Public License version 3**](Copying.txt) (GPL v3). Essentially,
 this means you are free to do almost exactly what you want with the program,
 including distributing it among your friends, making it available for download
@@ -162,7 +162,7 @@ from your website, selling it (either by itself or as part of some bigger
 software package), or using it as the starting point for a software project of
 your own.
 
-The only real limitation is that whenever you distribute Pullfish 1.0 171025 in some way,
+The only real limitation is that whenever you distribute Revolution 2.90 241025 in some way,
 you MUST always include the license and the full source code (or a pointer to
 where the source code can be found) to generate the exact binary you are
 distributing. If you make any changes to the source code, these changes must
@@ -170,14 +170,14 @@ also be made available under GPL v3.
 
 ## Credits
 
-Pullfish 1.0 171025 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
+Revolution 2.90 241025 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
 The project gives full credit to the Stockfish authors and to every contributor
 listed in [AUTHORS](AUTHORS), and it continues to benefit from the innovations
 shared by the wider open-source chess community.
 
 ## Acknowledgements
 
-Pullfish uses neural networks trained on
+Revolution uses neural networks trained on
 [data provided by the Leela Chess Zero project](https://training.lczero.org/),
 which is made available under the
 [Open Database License](https://opendatacommons.org/licenses/odbl/) (ODbL).

--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -148,6 +148,6 @@ if [ -z "$file_arch" ]; then
   file_arch=$true_arch
 fi
 
-file_name="pullfish-$file_os-$file_arch.$file_ext"
+file_name="revolution-2.90-241025-$file_os-$file_arch.$file_ext"
 
 printf '%s %s\n' "$true_arch" "$file_name"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,12 @@
-# Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+# Revolution, a UCI chess playing engine derived from Stockfish 17.1
 # Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 #
-# Pullfish is free software: you can redistribute it and/or modify
+# Revolution is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Pullfish is distributed in the hope that it will be useful,
+# Revolution is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
@@ -38,12 +38,15 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_BIN = pullfish-1.0-171025
+RELEASE_BIN   = revolution-2.90-241025
+BRANDED_NAME  = revolution 2.90 241025
 
 ifeq ($(target_windows),yes)
-        EXE = $(RELEASE_BIN).exe
+        EXE          = $(RELEASE_BIN).exe
+        BRANDED_EXE  = $(BRANDED_NAME).exe
 else
-        EXE = $(RELEASE_BIN)
+        EXE          = $(RELEASE_BIN)
+        BRANDED_EXE  = $(BRANDED_NAME)
 endif
 
 ### Installation dir definitions
@@ -861,7 +864,7 @@ endif
 
 help:
 	@echo "" && \
-	echo "To compile pullfish, type: " && \
+	echo "To compile revolution, type: " && \
 	echo "" && \
 	echo "make -j target [ARCH=arch] [COMP=compiler] [COMPCXX=cxx]" && \
 	echo "" && \
@@ -936,11 +939,11 @@ endif
 
 
 .PHONY: help analyze build profile-build strip install clean net \
-	objclean profileclean config-sanity \
-	icx-profile-use icx-profile-make \
-	gcc-profile-use gcc-profile-make \
-	clang-profile-use clang-profile-make FORCE \
-	format analyze
+        objclean profileclean config-sanity \
+        icx-profile-use icx-profile-make \
+        gcc-profile-use gcc-profile-make \
+        clang-profile-use clang-profile-make FORCE \
+        format analyze brand
 
 analyze: net config-sanity objclean
 	$(MAKE) -k ARCH=$(ARCH) COMP=$(COMP) $(OBJS)
@@ -964,13 +967,18 @@ profile-build: net config-sanity objclean profileclean
 	@echo "Step 4/4. Deleting profile data ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
 
-strip:
+strip: $(EXE) brand
 	$(STRIP) $(EXE)
+	$(STRIP) "$(BRANDED_EXE)"
 
-install:
+brand: $(EXE)
+	@rm -f "$(BRANDED_EXE)"
+	@cp $(EXE) "$(BRANDED_EXE)"
+
+install: all
 	-mkdir -p -m 755 $(BINDIR)
-	-cp $(EXE) $(BINDIR)
-	$(STRIP) $(BINDIR)/$(EXE)
+	-cp "$(BRANDED_EXE)" $(BINDIR)
+	$(STRIP) "$(BINDIR)/$(BRANDED_EXE)"
 
 # clean all
 clean: objclean profileclean
@@ -978,16 +986,16 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f pullfish pullfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f $(RELEASE_BIN) $(RELEASE_BIN).exe "$(BRANDED_NAME)" "$(BRANDED_NAME).exe" *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f pullfish.profdata *.profraw
-	@rm -f pullfish.*args*
-	@rm -f pullfish.*lt*
-	@rm -f pullfish.res
+	@rm -f $(RELEASE_BIN).profdata *.profraw
+	@rm -f $(RELEASE_BIN).*args*
+	@rm -f $(RELEASE_BIN).*lt*
+	@rm -f "$(BRANDED_NAME).res" "$(RELEASE_BIN).res"
 	@rm -f ./-lstdc++.res
 
 # evaluation network (nnue)
@@ -1005,7 +1013,7 @@ default:
 ### Section 5. Private Targets
 ### ==========================================================================
 
-all: $(EXE) .depend
+all: $(EXE) brand .depend
 
 config-sanity: net
 	@echo ""
@@ -1089,9 +1097,9 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) llvm-profdata merge -output=pullfish.profdata *.profraw
+	$(XCRUN) llvm-profdata merge -output=$(RELEASE_BIN).profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=pullfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
@@ -1117,9 +1125,9 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) llvm-profdata merge -output=pullfish.profdata *.profraw
+	$(XCRUN) llvm-profdata merge -output=$(RELEASE_BIN).profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=pullfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-instr-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/engine.h
+++ b/src/engine.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/history.h
+++ b/src/history.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
@@ -41,8 +41,8 @@ namespace {
 
 // Version number or dev.
 // Keep this in sync with the README and build scripts so every artifact reports
-// the same Pullfish 1.0 171025 release branding.
-constexpr std::string_view engine_name = "Pullfish 1.0 171025";
+// the same Revolution 2.90 241025 release branding.
+constexpr std::string_view engine_name = "Revolution 2.90 241025";
 constexpr std::string_view version     = "release";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
@@ -116,14 +116,14 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Pullfish version.
+// Returns the full name of the current Revolution version.
 //
 // For local dev compiles we try to append the commit SHA and
 // commit date from git. If that fails only the local compilation
 // date is set and "nogit" is specified:
-//      Pullfish dev-YYYYMMDD-SHA
+//      Revolution dev-YYYYMMDD-SHA
 //      or
-//      Pullfish dev-YYYYMMDD-nogit
+//      Revolution dev-YYYYMMDD-nogit
 //
 // For releases (non-dev builds) we use the fixed branded name.
 std::string engine_version_info() {
@@ -163,7 +163,7 @@ std::string engine_version_info() {
 
 std::string engine_info(bool to_uci) {
     return engine_version_info() + (to_uci ? "\nid author " : " by ")
-         + "Jorge Ruiz with credits to ChatGPT, the Stockfish authors, and the Pullfish development community (see AUTHORS file)";
+         + "Jorge Ruiz with credits to ChatGPT, the Stockfish authors, and the Revolution development community (see AUTHORS file)";
 }
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/layers/simd.h
+++ b/src/nnue/layers/simd.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/numa.h
+++ b/src/numa.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/perft.h
+++ b/src/perft.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/position.h
+++ b/src/position.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/score.h
+++ b/src/score.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/search.h
+++ b/src/search.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/tt.h
+++ b/src/tt.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/tune.h
+++ b/src/tune.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/types.h
+++ b/src/types.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.
@@ -50,7 +50,7 @@ constexpr auto BenchmarkCommand = "speedtest";
 
 namespace {
 
-constexpr std::string_view PullfishLogoUtf8 =
+constexpr std::string_view RevolutionLogoUtf8 =
   R"(██████╗ ██╗   ██╗██╗     ██╗     ███████╗██╗███████╗██╗  ██╗
 ██╔══██╗██║   ██║██║     ██║     ██╔════╝██║██╔════╝██║ ██╔╝
 ██████╔╝██║   ██║██║     ██║     █████╗  ██║█████╗  █████╔╝
@@ -59,7 +59,7 @@ constexpr std::string_view PullfishLogoUtf8 =
 ╚═════╝  ╚═════╝ ╚══════╝╚══════╝╚══════╝╚═╝╚══════╝╚═╝  ╚═╝
 )";
 
-constexpr std::string_view PullfishLogoAscii =
+constexpr std::string_view RevolutionLogoAscii =
   R"( ____        _ _ _     _     _
 |  _ \ _   _| | (_)___| |__ (_)_ __   ___
 | |_) | | | | | | / __| '_ \| | '_ \ / _ \
@@ -83,7 +83,7 @@ bool has_utf8_hint(std::string_view value) {
 }
 
 std::string_view select_logo_from_environment() {
-    if (const char* style_env = std::getenv("PULLFISH_LOGO_STYLE"))
+    if (const char* style_env = std::getenv("REVOLUTION_LOGO_STYLE"))
     {
         const auto style = to_lower_ascii(style_env);
 
@@ -91,24 +91,24 @@ std::string_view select_logo_from_environment() {
             return std::string_view();
 
         if (style == "ascii" || style == "plain")
-            return PullfishLogoAscii;
+            return RevolutionLogoAscii;
 
         if (style == "utf8" || style == "utf-8" || style == "utf")
-            return PullfishLogoUtf8;
+            return RevolutionLogoUtf8;
     }
 
 #if defined(_WIN32)
     // Windows consoles often default to non-UTF-8 code pages. Unless the user opts in
     // through the environment variable above, prefer the ASCII logo to avoid mojibake.
-    return PullfishLogoAscii;
+    return RevolutionLogoAscii;
 #else
     constexpr const char* kLocaleVars[] = {"LC_ALL", "LC_CTYPE", "LANG"};
 
     for (const char* var : kLocaleVars)
         if (const char* value = std::getenv(var); value && has_utf8_hint(value))
-            return PullfishLogoUtf8;
+            return RevolutionLogoUtf8;
 
-    return PullfishLogoAscii;
+    return RevolutionLogoAscii;
 #endif
 }
 
@@ -282,12 +282,12 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nPullfish is a powerful chess engine for playing and analyzing games of chess."
+              << "\nRevolution is a powerful chess engine for playing and analyzing games of chess."
                  "\nIt is a derivative of Stockfish 17.1 maintained by Jorge Ruiz with credits to ChatGPT"
                  "\nand is released as free software licensed under the GNU GPLv3 License."
-                 "\nPullfish is normally used with a graphical user interface (GUI) and implements"
+                 "\nRevolution is normally used with a graphical user interface (GUI) and implements"
                  "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
-                 "\nFor further information, visit https://github.com/jorgeruiz/pullfish"
+                 "\nFor further information, visit https://github.com/jorgeruiz/revolution"
                  "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n"
               << sync_endl;
         else if (!token.empty() && token[0] != '#')

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -1,13 +1,13 @@
 /*
-  Pullfish, a UCI chess playing engine derived from Stockfish 17.1
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
   Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
 
-  Pullfish is free software: you can redistribute it and/or modify
+  Revolution is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
 
-  Pullfish is distributed in the hope that it will be useful,
+  Revolution is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU General Public License for more details.

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -8,7 +8,7 @@ import os
 from testing import (
     EPD,
     TSAN,
-    Pullfish as Engine,
+    Revolution as Engine,
     MiniTestFramework,
     OrderedClassMembers,
     Valgrind,
@@ -35,7 +35,7 @@ def get_threads():
 
 
 def get_path():
-    return os.path.abspath(os.path.join(CWD, args.pullfish_path))
+    return os.path.abspath(os.path.join(CWD, args.revolution_path))
 
 
 def postfix_check(output):
@@ -62,7 +62,7 @@ def postfix_check(output):
     return True
 
 
-def Pullfish(*args, **kwargs):
+def Revolution(*args, **kwargs):
     return Engine(get_prefix(), get_path(), *args, **kwargs)
 
 
@@ -75,118 +75,118 @@ class TestCLI(metaclass=OrderedClassMembers):
         pass
 
     def beforeEach(self):
-        self.pullfish = None
+        self.revolution = None
 
     def afterEach(self):
-        assert postfix_check(self.pullfish.get_output()) == True
-        self.pullfish.clear_output()
+        assert postfix_check(self.revolution.get_output()) == True
+        self.revolution.clear_output()
 
     def test_eval(self):
-        self.pullfish = Pullfish("eval".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("eval".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_nodes_1000(self):
-        self.pullfish = Pullfish("go nodes 1000".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("go nodes 1000".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_depth_10(self):
-        self.pullfish = Pullfish("go depth 10".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("go depth 10".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_perft_4(self):
-        self.pullfish = Pullfish("go perft 4".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("go perft 4".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_movetime_1000(self):
-        self.pullfish = Pullfish("go movetime 1000".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("go movetime 1000".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_wtime_8000_btime_8000_winc_500_binc_500(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             "go wtime 8000 btime 8000 winc 500 binc 500".split(" "),
             True,
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_go_wtime_1000_btime_1000_winc_0_binc_0(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             "go wtime 1000 btime 1000 winc 0 binc 0".split(" "),
             True,
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_go_wtime_1000_btime_1000_winc_0_binc_0_movestogo_5(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             "go wtime 1000 btime 1000 winc 0 binc 0 movestogo 5".split(" "),
             True,
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_go_movetime_200(self):
-        self.pullfish = Pullfish("go movetime 200".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("go movetime 200".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_go_nodes_20000_searchmoves_e2e4_d2d4(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             "go nodes 20000 searchmoves e2e4 d2d4".split(" "), True
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_bench_128_threads_8_default_depth(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             f"bench 128 {get_threads()} 8 default depth".split(" "),
             True,
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_bench_128_threads_3_bench_tmp_epd_depth(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             f"bench 128 {get_threads()} 3 {os.path.join(PATH,'bench_tmp.epd')} depth".split(
                 " "
             ),
             True,
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     def test_d(self):
-        self.pullfish = Pullfish("d".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("d".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_compiler(self):
-        self.pullfish = Pullfish("compiler".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("compiler".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_license(self):
-        self.pullfish = Pullfish("license".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("license".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_uci(self):
-        self.pullfish = Pullfish("uci".split(" "), True)
-        assert self.pullfish.process.returncode == 0
+        self.revolution = Revolution("uci".split(" "), True)
+        assert self.revolution.process.returncode == 0
 
     def test_uci_includes_multipv_info(self):
-        self.pullfish = Pullfish(["uci"], True)
+        self.revolution = Revolution(["uci"], True)
         assert (
             "info string MultiPV: Sets the number of alternate lines of analysis to display, with a value of 1 showing only the best line."
-            in self.pullfish.process.stdout
+            in self.revolution.process.stdout
         )
 
     def test_export_net_verify_nnue(self):
         current_path = os.path.abspath(os.getcwd())
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             f"export_net {os.path.join(current_path , 'verify.nnue')}".split(" "), True
         )
-        assert self.pullfish.process.returncode == 0
+        assert self.revolution.process.returncode == 0
 
     # verify the generated net equals the base net
 
     def test_network_equals_base(self):
-        self.pullfish = Pullfish(
+        self.revolution = Revolution(
             ["uci"],
             True,
         )
 
-        output = self.pullfish.process.stdout
+        output = self.revolution.process.stdout
 
         # find line
         for line in output.split("\n"):
@@ -210,55 +210,55 @@ class TestCLI(metaclass=OrderedClassMembers):
 
 class TestInteractive(metaclass=OrderedClassMembers):
     def beforeAll(self):
-        self.pullfish = Pullfish()
+        self.revolution = Revolution()
 
     def afterAll(self):
-        self.pullfish.quit()
-        assert self.pullfish.close() == 0
+        self.revolution.quit()
+        assert self.revolution.close() == 0
 
     def afterEach(self):
-        assert postfix_check(self.pullfish.get_output()) == True
-        self.pullfish.clear_output()
+        assert postfix_check(self.revolution.get_output()) == True
+        self.revolution.clear_output()
 
     def test_startup_output(self):
-        self.pullfish.starts_with("Pullfish")
+        self.revolution.starts_with("Revolution")
 
     def test_uci_command(self):
-        self.pullfish.send_command("uci")
-        self.pullfish.equals("uciok")
+        self.revolution.send_command("uci")
+        self.revolution.equals("uciok")
 
     def test_set_threads_option(self):
-        self.pullfish.send_command(f"setoption name Threads value {get_threads()}")
+        self.revolution.send_command(f"setoption name Threads value {get_threads()}")
 
     def test_ucinewgame_and_startpos_nodes_1000(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go nodes 1000")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go nodes 1000")
+        self.revolution.starts_with("bestmove")
 
     def test_ucinewgame_and_startpos_moves(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position startpos moves e2e4 e7e6")
-        self.pullfish.send_command("go nodes 1000")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position startpos moves e2e4 e7e6")
+        self.revolution.send_command("go nodes 1000")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_1(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1")
-        self.pullfish.send_command("go nodes 1000")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1")
+        self.revolution.send_command("go nodes 1000")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_2_flip(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1")
-        self.pullfish.send_command("flip")
-        self.pullfish.send_command("go nodes 1000")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position fen 5rk1/1K4p1/8/8/3B4/8/8/8 b - - 0 1")
+        self.revolution.send_command("flip")
+        self.revolution.send_command("go nodes 1000")
+        self.revolution.starts_with("bestmove")
 
     def test_depth_5_with_callback(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go depth 5")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go depth 5")
 
         def callback(output):
             regex = r"info depth \d+ seldepth \d+ multipv \d+ score cp \d+ nodes \d+ nps \d+ hashfull \d+ tbhits \d+ time \d+ pv"
@@ -268,13 +268,13 @@ class TestInteractive(metaclass=OrderedClassMembers):
                 return True
             return False
 
-        self.pullfish.check_output(callback)
+        self.revolution.check_output(callback)
 
     def test_ucinewgame_and_go_depth_9(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("setoption name UCI_ShowWDL value true")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go depth 9")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("setoption name UCI_ShowWDL value true")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go depth 9")
 
         depth = 1
 
@@ -294,197 +294,197 @@ class TestInteractive(metaclass=OrderedClassMembers):
 
             return False
 
-        self.pullfish.check_output(callback)
+        self.revolution.check_output(callback)
 
     def test_clear_hash(self):
-        self.pullfish.send_command("setoption name Clear Hash")
+        self.revolution.send_command("setoption name Clear Hash")
 
     def test_fen_position_mate_1(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 5K2/8/2qk4/2nPp3/3r4/6B1/B7/3R4 w - e6"
         )
-        self.pullfish.send_command("go depth 18")
+        self.revolution.send_command("go depth 18")
 
-        self.pullfish.expect("* score mate 1 * pv d5e6")
-        self.pullfish.equals("bestmove d5e6")
+        self.revolution.expect("* score mate 1 * pv d5e6")
+        self.revolution.equals("bestmove d5e6")
 
     def test_fen_position_mate_minus_1(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 2brrb2/8/p7/Q7/1p1kpPp1/1P1pN1K1/3P4/8 b - -"
         )
-        self.pullfish.send_command("go depth 18")
-        self.pullfish.expect("* score mate -1 *")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("go depth 18")
+        self.revolution.expect("* score mate -1 *")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_fixed_node(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 5K2/8/2P1P1Pk/6pP/3p2P1/1P6/3P4/8 w - - 0 1"
         )
-        self.pullfish.send_command("go nodes 500000")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("go nodes 500000")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_with_mate_go_depth(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - -"
         )
-        self.pullfish.send_command("go depth 18 searchmoves c6d7")
-        self.pullfish.expect("* score mate 2 * pv c6d7 * f7f5")
+        self.revolution.send_command("go depth 18 searchmoves c6d7")
+        self.revolution.expect("* score mate 2 * pv c6d7 * f7f5")
 
-        self.pullfish.starts_with("bestmove")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_with_mate_go_mate(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - -"
         )
-        self.pullfish.send_command("go mate 2 searchmoves c6d7")
-        self.pullfish.expect("* score mate 2 * pv c6d7 *")
+        self.revolution.send_command("go mate 2 searchmoves c6d7")
+        self.revolution.expect("* score mate 2 * pv c6d7 *")
 
-        self.pullfish.starts_with("bestmove")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_with_mate_go_nodes(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - -"
         )
-        self.pullfish.send_command("go nodes 500000 searchmoves c6d7")
-        self.pullfish.expect("* score mate 2 * pv c6d7 * f7f5")
+        self.revolution.send_command("go nodes 500000 searchmoves c6d7")
+        self.revolution.expect("* score mate 2 * pv c6d7 * f7f5")
 
-        self.pullfish.starts_with("bestmove")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_depth_27(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen r1b2r1k/pp1p2pp/2p5/2B1q3/8/8/P1PN2PP/R4RK1 w - - 0 18"
         )
-        self.pullfish.send_command("go")
-        self.pullfish.contains("score mate 1")
+        self.revolution.send_command("go")
+        self.revolution.contains("score mate 1")
 
-        self.pullfish.starts_with("bestmove")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_with_mate_go_depth_and_promotion(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - - moves c6d7 f2f1q"
         )
-        self.pullfish.send_command("go depth 18")
-        self.pullfish.expect("* score mate 1 * pv f7f5")
-        self.pullfish.starts_with("bestmove f7f5")
+        self.revolution.send_command("go depth 18")
+        self.revolution.expect("* score mate 1 * pv f7f5")
+        self.revolution.starts_with("bestmove f7f5")
 
     def test_fen_position_with_mate_go_depth_and_searchmoves(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - -"
         )
-        self.pullfish.send_command("go depth 18 searchmoves c6d7")
-        self.pullfish.expect("* score mate 2 * pv c6d7 * f7f5")
+        self.revolution.send_command("go depth 18 searchmoves c6d7")
+        self.revolution.expect("* score mate 2 * pv c6d7 * f7f5")
 
-        self.pullfish.starts_with("bestmove c6d7")
+        self.revolution.starts_with("bestmove c6d7")
 
     def test_fen_position_with_moves_with_mate_go_depth_and_searchmoves(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command(
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command(
             "position fen 8/5R2/2K1P3/4k3/8/b1PPpp1B/5p2/8 w - - moves c6d7"
         )
-        self.pullfish.send_command("go depth 18 searchmoves e3e2")
-        self.pullfish.expect("* score mate -1 * pv e3e2 f7f5")
-        self.pullfish.starts_with("bestmove e3e2")
+        self.revolution.send_command("go depth 18 searchmoves e3e2")
+        self.revolution.expect("* score mate -1 * pv e3e2 f7f5")
+        self.revolution.starts_with("bestmove e3e2")
 
     def test_verify_nnue_network(self):
         current_path = os.path.abspath(os.getcwd())
-        Pullfish(
+        Revolution(
             f"export_net {os.path.join(current_path , 'verify.nnue')}".split(" "), True
         )
 
-        self.pullfish.send_command("setoption name EvalFile value verify.nnue")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go depth 5")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("setoption name EvalFile value verify.nnue")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go depth 5")
+        self.revolution.starts_with("bestmove")
 
     def test_multipv_setting(self):
-        self.pullfish.send_command("setoption name MultiPV value 4")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go depth 5")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("setoption name MultiPV value 4")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go depth 5")
+        self.revolution.starts_with("bestmove")
 
     def test_fen_position_with_skill_level(self):
-        self.pullfish.send_command("setoption name Skill Level value 10")
-        self.pullfish.send_command("position startpos")
-        self.pullfish.send_command("go depth 5")
-        self.pullfish.starts_with("bestmove")
+        self.revolution.send_command("setoption name Skill Level value 10")
+        self.revolution.send_command("position startpos")
+        self.revolution.send_command("go depth 5")
+        self.revolution.starts_with("bestmove")
 
-        self.pullfish.send_command("setoption name Skill Level value 20")
+        self.revolution.send_command("setoption name Skill Level value 20")
 
 
 class TestSyzygy(metaclass=OrderedClassMembers):
     def beforeAll(self):
-        self.pullfish = Pullfish()
+        self.revolution = Revolution()
 
     def afterAll(self):
-        self.pullfish.quit()
-        assert self.pullfish.close() == 0
+        self.revolution.quit()
+        assert self.revolution.close() == 0
 
     def afterEach(self):
-        assert postfix_check(self.pullfish.get_output()) == True
-        self.pullfish.clear_output()
+        assert postfix_check(self.revolution.get_output()) == True
+        self.revolution.clear_output()
 
     def test_syzygy_setup(self):
-        self.pullfish.starts_with("Pullfish")
-        self.pullfish.send_command("uci")
-        self.pullfish.send_command(
+        self.revolution.starts_with("Revolution")
+        self.revolution.send_command("uci")
+        self.revolution.send_command(
             f"setoption name SyzygyPath value {os.path.join(PATH, 'syzygy')}"
         )
-        self.pullfish.expect(
+        self.revolution.expect(
             "info string Found 35 WDL and 35 DTZ tablebase files (up to 4-man)."
         )
 
     def test_syzygy_bench(self):
-        self.pullfish.send_command("bench 128 1 8 default depth")
-        self.pullfish.expect("Nodes searched  :*")
+        self.revolution.send_command("bench 128 1 8 default depth")
+        self.revolution.expect("Nodes searched  :*")
 
     def test_syzygy_position(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position fen 4k3/PP6/8/8/8/8/8/4K3 w - - 0 1")
-        self.pullfish.send_command("go depth 5")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position fen 4k3/PP6/8/8/8/8/8/4K3 w - - 0 1")
+        self.revolution.send_command("go depth 5")
 
         def check_output(output):
             if "score cp 20000" in output or "score mate" in output:
                 return True
 
-        self.pullfish.check_output(check_output)
-        self.pullfish.expect("bestmove *")
+        self.revolution.check_output(check_output)
+        self.revolution.expect("bestmove *")
 
     def test_syzygy_position_2(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position fen 8/1P6/2B5/8/4K3/8/6k1/8 w - - 0 1")
-        self.pullfish.send_command("go depth 5")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position fen 8/1P6/2B5/8/4K3/8/6k1/8 w - - 0 1")
+        self.revolution.send_command("go depth 5")
 
         def check_output(output):
             if "score cp 20000" in output or "score mate" in output:
                 return True
 
-        self.pullfish.check_output(check_output)
-        self.pullfish.expect("bestmove *")
+        self.revolution.check_output(check_output)
+        self.revolution.expect("bestmove *")
 
     def test_syzygy_position_3(self):
-        self.pullfish.send_command("ucinewgame")
-        self.pullfish.send_command("position fen 8/1P6/2B5/8/4K3/8/6k1/8 b - - 0 1")
-        self.pullfish.send_command("go depth 5")
+        self.revolution.send_command("ucinewgame")
+        self.revolution.send_command("position fen 8/1P6/2B5/8/4K3/8/6k1/8 b - - 0 1")
+        self.revolution.send_command("go depth 5")
 
         def check_output(output):
             if "score cp -20000" in output or "score mate" in output:
                 return True
 
-        self.pullfish.check_output(check_output)
-        self.pullfish.expect("bestmove *")
+        self.revolution.check_output(check_output)
+        self.revolution.expect("bestmove *")
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Run Pullfish with testing options")
+    parser = argparse.ArgumentParser(description="Run Revolution with testing options")
     parser.add_argument("--valgrind", action="store_true", help="Run valgrind testing")
     parser.add_argument(
         "--valgrind-thread", action="store_true", help="Run valgrind-thread testing"
@@ -501,7 +501,7 @@ def parse_args():
     parser.add_argument(
         "--none", action="store_true", help="Run without any testing options"
     )
-    parser.add_argument("pullfish_path", type=str, help="Path to Pullfish binary")
+    parser.add_argument("revolution_path", type=str, help="Path to Revolution binary")
 
     return parser.parse_args()
 

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,7 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 4] pos depth result chess960 logfile
 log_file -noappend $logfile
-spawn ./pullfish
+spawn ./revolution-2.90-241025
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }
@@ -27,7 +27,7 @@ send "position $pos\ngo perft $depth\n"
 expect {
   "Nodes searched: $result" {}
   timeout {puts "TIMEOUT: Expected $result nodes"; exit 1}
-  eof {puts "EOF: Pullfish crashed"; exit 2}
+  eof {puts "EOF: Revolution crashed"; exit 2}
 }
 send "quit\n"
 expect eof

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -15,7 +15,7 @@ echo "reprosearch testing started"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
- spawn ./pullfish
+  spawn ./revolution-2.90-241025
  lassign \$argv nodes
 
  send "uci\n"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-signature=`eval "$WINE_PATH ./pullfish bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`eval "$WINE_PATH ./revolution-2.90-241025 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ]; then
    # compare to given reference

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -291,7 +291,7 @@ class MiniTestFramework:
         print(f"    {GREEN_COLOR}✓{RESET_COLOR}{add}", flush=True)
 
 
-class Pullfish:
+class Revolution:
     def __init__(
         self,
         prefix: List[str],
@@ -311,7 +311,7 @@ class Pullfish:
     def _check_process_alive(self):
         if not self.process or self.process.poll() is not None:
             print("\n".join(self.output))
-            raise RuntimeError("Pullfish process has terminated")
+            raise RuntimeError("Revolution process has terminated")
 
     def start(self):
         if self.cli:
@@ -342,7 +342,7 @@ class Pullfish:
 
     def send_command(self, command: str):
         if not self.process:
-            raise RuntimeError("Pullfish process is not started")
+            raise RuntimeError("Revolution process is not started")
 
         self._check_process_alive()
 
@@ -384,7 +384,7 @@ class Pullfish:
 
     def readline(self):
         if not self.process:
-            raise RuntimeError("Pullfish process is not started")
+            raise RuntimeError("Revolution process is not started")
 
         while True:
             self._check_process_alive()


### PR DESCRIPTION
## Summary
- rename the engine branding to Revolution 2.90 241025 throughout the source headers, documentation, and metadata
- update the build system to produce revolution-2.90-241025 binaries and copy branded executables alongside them
- refresh auxiliary scripts and regression tests so they reference the new binary names

## Testing
- make help

------
https://chatgpt.com/codex/tasks/task_e_68faf3607eac8327bac0058626909087