### PR TITLE
Replace requests dependency in test harness

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -14,7 +14,8 @@ import pathlib
 import concurrent.futures
 import tempfile
 import shutil
-import requests
+import urllib.error
+import urllib.request
 
 CYAN_COLOR = "\033[36m"
 GRAY_COLOR = "\033[2m"
@@ -99,10 +100,15 @@ class Syzygy:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tarball_path = os.path.join(tmpdirname, f"{file}.tar.gz")
 
-                response = requests.get(url, stream=True)
-                with open(tarball_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
+                try:
+                    with urllib.request.urlopen(url) as response, open(
+                        tarball_path, "wb"
+                    ) as f:
+                        shutil.copyfileobj(response, f)
+                except urllib.error.URLError as exc:
+                    raise RuntimeError(
+                        f"Failed to download Syzygy tablebases from {url}: {exc}"
+                    ) from exc
 
                 with tarfile.open(tarball_path, "r:gz") as tar:
                     tar.extractall(tmpdirname)


### PR DESCRIPTION
## Summary
- remove the optional `requests` dependency from the internal testing harness
- use Python's standard-library `urllib.request` to download the Syzygy tarball and surface clearer errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68faf5cc085483278eb43fff52b6430b