### PR TITLE
Fix merge artifacts in search and test scripts

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -208,19 +208,10 @@ int adaptive_lmr_adjustment(const Stack* ss, int priorReduction, bool cutNode, b
     stackWeight += !improving ? 1 : 0;
 
     stackWeight -= std::min(3, parent.moveCount / 2);
- codex/implement-dynamic-pvs-reductions-a7uw5q
 
     if (priorReduction > 0)
         stackWeight -= std::min(2, priorReduction);
-=======
-codex/implement-dynamic-pvs-reductions-d9h7vw
 
-    if (priorReduction > 0)
-        stackWeight -= std::min(2, priorReduction);
-=======
-    stackWeight -= std::min(2, std::abs(priorReduction) / 512);
- eval_cur-−-eval_prev
- eval_cur-−-eval_prev
     stackWeight -= parent.isTTMove ? 1 : 0;
 
     stackWeight = std::clamp(stackWeight, 0, 12);

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,11 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 5] engine pos depth result chess960 logfile
 log_file -noappend $logfile
- codex/implement-dynamic-pvs-reductions-a7uw5q
 spawn $engine
-=======
-spawn ./revolution-PVS
- eval_cur-−-eval_prev
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -17,13 +17,8 @@ ENGINE_PATH="$(cd "$(dirname "$0")/.." && pwd)/src/revolution-PVS"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
- codex/implement-dynamic-pvs-reductions-a7uw5q
  lassign \$argv engine nodes
  spawn \$engine
-=======
-  spawn ./revolution-PVS
- lassign \$argv nodes
- eval_cur-−-eval_prev
 
  send "uci\n"
  expect "uciok"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,13 +11,9 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-codex/implement-dynamic-pvs-reductions-a7uw5q
 ENGINE_PATH="$(cd "$(dirname "$0")/.." && pwd)/src/revolution-PVS"
 
 signature=`eval "$WINE_PATH $ENGINE_PATH bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
-=======
-signature=`eval "$WINE_PATH ./revolution-PVS bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
- eval_cur-−-eval_prev
 
 if [ $# -gt 0 ]; then
    # compare to given reference


### PR DESCRIPTION
## Summary
- clean up merge artifacts in the adaptive LMR adjustment logic
- restore the test helper scripts to invoke the built engine path without stray markers

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: clang++ not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fbf3e1aa6483278aaf8bd4d5b0cf7e