### PR TITLE
Rebrand SSE2 fallback executable

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -148,6 +148,6 @@ if [ -z "$file_arch" ]; then
   file_arch=$true_arch
 fi
 
-file_name="revolution-2.90-241025-$file_os-$file_arch.$file_ext"
+file_name="revolution-SSE2-fallback-2.90-241025-$file_os-$file_arch.$file_ext"
 
 printf '%s %s\n' "$true_arch" "$file_name"

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,8 +38,8 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_BIN   = revolution-2.90-241025
-BRANDED_NAME  = revolution 2.90 241025
+RELEASE_BIN   = revolution-SSE2-fallback-2.90-241025
+BRANDED_NAME  = revolution-SSE2-fallback 2.90 241025
 
 ifeq ($(target_windows),yes)
         EXE          = $(RELEASE_BIN).exe

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,7 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 4] pos depth result chess960 logfile
 log_file -noappend $logfile
-spawn ./revolution-2.90-241025
+spawn ./revolution-SSE2-fallback-2.90-241025
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -15,7 +15,7 @@ echo "reprosearch testing started"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
-  spawn ./revolution-2.90-241025
+  spawn ./revolution-SSE2-fallback-2.90-241025
  lassign \$argv nodes
 
  send "uci\n"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-signature=`eval "$WINE_PATH ./revolution-2.90-241025 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`eval "$WINE_PATH ./revolution-SSE2-fallback-2.90-241025 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ]; then
    # compare to given reference


### PR DESCRIPTION
## Summary
- rename the release binary and branded executable identifiers to revolution-SSE2-fallback
- update test harnesses and native build packaging script to use the new executable name

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fbfd73abec8327aedb928f49cb54c2