### PR TITLE
Fix duplicate accumulator reference in NNUE refresh

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -670,8 +670,6 @@ void update_accumulator_refresh_cache(
           &featureTransformer.psqtWeights[PSQTBuckets * added[static_cast<int>(idx)]];
     }
 
-    auto& accumulator = accumulatorState.*accPtr;
-
     if (removedCount == 0 && addedCount == 0)
     {
         std::memcpy(accumulator.accumulation[Perspective], entry.accumulation,


### PR DESCRIPTION
## Summary
- remove the duplicate accumulator variable declaration inside `update_accumulator_refresh_cache` to avoid clang redefinition errors

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: `clang++` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fc002f191c8327a153ecda0778130b