### PR TITLE
Improve dependency generation fallback in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1132,7 +1132,12 @@ icx-profile-use:
 	all
 
 .depend: $(SRCS)
-	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null
+	@echo "Generating dependency file"
+	@if $(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null; then \
+		true; \
+	else \
+		echo "# dependency generation failed; continuing without generated deps" > $@; \
+	fi
 
 ifeq (, $(filter $(MAKECMDGOALS), help strip install clean net objclean profileclean config-sanity))
 -include .depend


### PR DESCRIPTION
## Summary
- ensure the `.depend` rule logs generation and falls back to a stub file when dependency extraction fails so Windows clang builds proceed cleanly

## Testing
- make build ARCH=x86-64-sse41-popcnt -j4

------
https://chatgpt.com/codex/tasks/task_e_68fc03d7433883278d1424de9ebccdca