### PR TITLE
Ensure profile-build fails early without Wine for Windows targets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,18 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(WINE_PATH) ./$(EXE) bench
+ifeq ($(target_windows),yes)
+        ifeq ($(OS),Windows_NT)
+                PGOBENCH = ./$(EXE) bench
+        else
+                ifeq ($(WINE_PATH),)
+                        $(error profile-build for Windows targets requires Wine. Install Wine and set WINE_PATH or run the build on Windows.)
+                endif
+                PGOBENCH = $(WINE_PATH) ./$(EXE) bench
+        endif
+else
+        PGOBENCH = ./$(EXE) bench
+endif
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \


### PR DESCRIPTION
## Summary
- add a guard so Windows profile-builds require Wine when run on non-Windows hosts
- keep existing benchmark invocation for native Windows builds and other platforms

## Testing
- make profile-build ARCH=x86-64-sse41-popcnt COMP=mingw  # fails early with Wine requirement message

------
https://chatgpt.com/codex/tasks/task_e_68fc079fddc88327b7f40d4171dade3e