### PR TITLE
Fix SSE fallback crashes on AVX2-incompatible CPUs

### DIFF
--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -74,8 +74,8 @@ static void affine_transform_non_ssse3(std::int32_t*       output,
         const auto row   = reinterpret_cast<const __m128i*>(&weights[offset]);
         for (IndexType j = 0; j < NumChunks; ++j)
         {
-            __m128i row_j           = _mm_load_si128(&row[j]);
-            __m128i input_j         = _mm_load_si128(&inputVector[j]);
+            __m128i row_j           = _mm_loadu_si128(&row[j]);
+            __m128i input_j         = _mm_loadu_si128(&inputVector[j]);
             __m128i extendedRowLo   = _mm_srai_epi16(_mm_unpacklo_epi8(row_j, row_j), 8);
             __m128i extendedRowHi   = _mm_srai_epi16(_mm_unpackhi_epi8(row_j, row_j), 8);
             __m128i extendedInputLo = _mm_unpacklo_epi8(input_j, Zeros);

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -101,7 +101,7 @@ void find_nnz(const std::int32_t* input, std::uint16_t* out, IndexType& count_ou
         #if (USE_SSE41)
             #define vec128_load(a) _mm_cvtepu8_epi16(_mm_loadl_epi64(a))
         #else
-            #define vec128_load(a) _mm_load_si128(a)
+            #define vec128_load(a) _mm_loadu_si128(a)
         #endif
         #define vec128_storeu(a, b) _mm_storeu_si128(a, b)
         #define vec128_add(a, b) _mm_add_epi16(a, b)

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -90,12 +90,12 @@ class ClippedReLU {
             for (IndexType i = 0; i < NumChunks; ++i)
             {
                 const __m128i words0 = _mm_srli_epi16(
-                  _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
+                  _mm_packus_epi32(_mm_loadu_si128(&in[i * 4 + 0]), _mm_loadu_si128(&in[i * 4 + 1])),
                   WeightScaleBits);
                 const __m128i words1 = _mm_srli_epi16(
-                  _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
+                  _mm_packus_epi32(_mm_loadu_si128(&in[i * 4 + 2]), _mm_loadu_si128(&in[i * 4 + 3])),
                   WeightScaleBits);
-                _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
+                _mm_storeu_si128(&out[i], _mm_packs_epi16(words0, words1));
             }
         }
         constexpr IndexType Start = InputDimensions % SimdWidth == 0
@@ -115,21 +115,21 @@ class ClippedReLU {
         {
     #if defined(USE_SSE41)
             const __m128i words0 = _mm_srli_epi16(
-              _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
+              _mm_packus_epi32(_mm_loadu_si128(&in[i * 4 + 0]), _mm_loadu_si128(&in[i * 4 + 1])),
               WeightScaleBits);
             const __m128i words1 = _mm_srli_epi16(
-              _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
+              _mm_packus_epi32(_mm_loadu_si128(&in[i * 4 + 2]), _mm_loadu_si128(&in[i * 4 + 3])),
               WeightScaleBits);
-            _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
+            _mm_storeu_si128(&out[i], _mm_packs_epi16(words0, words1));
     #else
             const __m128i words0 = _mm_srai_epi16(
-              _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
+              _mm_packs_epi32(_mm_loadu_si128(&in[i * 4 + 0]), _mm_loadu_si128(&in[i * 4 + 1])),
               WeightScaleBits);
             const __m128i words1 = _mm_srai_epi16(
-              _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
+              _mm_packs_epi32(_mm_loadu_si128(&in[i * 4 + 2]), _mm_loadu_si128(&in[i * 4 + 3])),
               WeightScaleBits);
             const __m128i packedbytes = _mm_packs_epi16(words0, words1);
-            _mm_store_si128(&out[i], _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s));
+            _mm_storeu_si128(&out[i], _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s));
     #endif
         }
         constexpr IndexType Start = NumChunks * SimdWidth;

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -70,9 +70,9 @@ class SqrClippedReLU {
         for (IndexType i = 0; i < NumChunks; ++i)
         {
             __m128i words0 =
-              _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1]));
+              _mm_packs_epi32(_mm_loadu_si128(&in[i * 4 + 0]), _mm_loadu_si128(&in[i * 4 + 1]));
             __m128i words1 =
-              _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3]));
+              _mm_packs_epi32(_mm_loadu_si128(&in[i * 4 + 2]), _mm_loadu_si128(&in[i * 4 + 3]));
 
             // We shift by WeightScaleBits * 2 = 12 and divide by 128
             // which is an additional shift-right of 7, meaning 19 in total.
@@ -80,7 +80,7 @@ class SqrClippedReLU {
             words0 = _mm_srli_epi16(_mm_mulhi_epi16(words0, words0), 3);
             words1 = _mm_srli_epi16(_mm_mulhi_epi16(words1, words1), 3);
 
-            _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
+            _mm_storeu_si128(&out[i], _mm_packs_epi16(words0, words1));
         }
         constexpr IndexType Start = NumChunks * 16;
 

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -135,21 +135,21 @@ inline void apply_accumulator_deltas_sse2(std::int16_t*                      des
 
     for (std::size_t i = 0; i < vecCount; ++i)
     {
-        __m128i acc = _mm_load_si128(baseVec + i);
+        __m128i acc = _mm_loadu_si128(baseVec + i);
 
         for (std::size_t r = 0; r < removedCount; ++r)
         {
             const auto* colVec = reinterpret_cast<const __m128i*>(removedCols[r]) + i;
-            acc                = _mm_sub_epi16(acc, _mm_load_si128(colVec));
+            acc                = _mm_sub_epi16(acc, _mm_loadu_si128(colVec));
         }
 
         for (std::size_t a = 0; a < addedCount; ++a)
         {
             const auto* colVec = reinterpret_cast<const __m128i*>(addedCols[a]) + i;
-            acc                = _mm_add_epi16(acc, _mm_load_si128(colVec));
+            acc                = _mm_add_epi16(acc, _mm_loadu_si128(colVec));
         }
 
-        _mm_store_si128(destVec + i, acc);
+        _mm_storeu_si128(destVec + i, acc);
     }
 }
 
@@ -166,21 +166,21 @@ inline void apply_psqt_deltas_sse2(std::int32_t*                            dest
 
     for (std::size_t i = 0; i < vecCount; ++i)
     {
-        __m128i acc = _mm_load_si128(baseVec + i);
+        __m128i acc = _mm_loadu_si128(baseVec + i);
 
         for (std::size_t r = 0; r < removedCount; ++r)
         {
             const auto* colVec = reinterpret_cast<const __m128i*>(removedCols[r]) + i;
-            acc                = _mm_sub_epi32(acc, _mm_load_si128(colVec));
+            acc                = _mm_sub_epi32(acc, _mm_loadu_si128(colVec));
         }
 
         for (std::size_t a = 0; a < addedCount; ++a)
         {
             const auto* colVec = reinterpret_cast<const __m128i*>(addedCols[a]) + i;
-            acc                = _mm_add_epi32(acc, _mm_load_si128(colVec));
+            acc                = _mm_add_epi32(acc, _mm_loadu_si128(colVec));
         }
 
-        _mm_store_si128(destVec + i, acc);
+        _mm_storeu_si128(destVec + i, acc);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace aligned SSE load/store intrinsics in NNUE SSE2 code paths with unaligned variants to avoid faults on CPUs without AVX2 support
- update the SSE fallback layers to use unaligned loads and stores so the fallback binary no longer crashes during profiling

## Testing
- `./revolution-SSE2-fallback-2.90-241025 bench 1 1 1 default depth 1`


------
https://chatgpt.com/codex/tasks/task_e_68fc09b185188327b3ead9760c594659