### PR TITLE
Persist killer cache across root iterations

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -19,6 +19,8 @@
 #ifndef MOVEPICK_H_INCLUDED
 #define MOVEPICK_H_INCLUDED
 
+#include <array>
+
 #include "history.h"
 #include "movegen.h"
 #include "types.h"
@@ -46,8 +48,13 @@ class MovePicker {
                const CapturePieceToHistory*,
                const PieceToHistory**,
                const PawnHistory*,
-               int);
-    MovePicker(const Position&, Move, int, const CapturePieceToHistory*);
+               int,
+               const std::array<Move, 2>* killers = nullptr);
+    MovePicker(const Position&,
+               Move,
+               int,
+               const CapturePieceToHistory*,
+               const std::array<Move, 2>* killers = nullptr);
     Move next_move();
     void skip_quiet_moves();
 
@@ -72,8 +79,14 @@ class MovePicker {
     Depth                        depth;
     int                          ply;
     bool                         skipQuiets = false;
+    const std::array<Move, 2>*   killers;
     ExtMove                      moves[MAX_MOVES];
 };
+
+std::array<Move, 2> load_killers_from_cache(int ply);
+void                save_killer_to_cache(int ply, Move move);
+void                clear_killer_cache();
+void                clear_killer_cache_from_ply(int ply);
 
 }  // namespace Stockfish
 

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,7 @@ struct Stack {
     int                         cutoffCnt;
     int                         reduction;
     bool                        isTTMove;
+    std::array<Move, 2>         killers;
 };
 
 


### PR DESCRIPTION
## Summary
- add a thread-local killer cache with helpers to load, save, and reset entries by ply
- score cached killers ahead of other quiets and keep Stack::killers synchronized during search beta cutoffs
- clear killer data on new root searches and after failed null moves, guarded by debug assertions

## Testing
- ninja -C src *(fails: no build.ninja in src)*

------
https://chatgpt.com/codex/tasks/task_e_68fc13995f9883279b2a24ddb8307fab