### PR TITLE
Add evaluation summary for Revolution 2.70 vs Dev v2.40

### DIFF
--- a/docs/revolution_2.70_vs_dev_v2.40_results.md
+++ b/docs/revolution_2.70_vs_dev_v2.40_results.md
@@ -1,0 +1,27 @@
+# Revolution 2.70 vs Revolution Dev v2.40 — 2000-Game Evaluation
+
+This document records the Ordo and BayesElo results for a 2000-game head-to-head match between the Revolution 2.70 (build 210925) engine and the Revolution Dev v2.40 (build 130925) baseline.
+
+## Match Summary
+
+- **Total games:** 2000
+- **Match score:** 51% – 49% in favor of Revolution 2.70
+- **Draw rate:** 40%
+- **White advantage:** 0.00
+
+## BayesElo Standings
+
+| Rank | Name                        | Elo | + | - | Games | Score | Opponent | Draws |
+| ---- | --------------------------- | --- | - | - | ----- | ----- | -------- | ----- |
+| 1    | revolution_2.70_210925      | 2   | 7 | 7 | 2000  | 51%   | -2       | 40%   |
+| 2    | revolution-dev_v2.40_130925 | -2  | 7 | 7 | 2000  | 49%   | 2        | 40%   |
+
+## Ordo Ratings
+
+```
+# PLAYER                         :  RATING  POINTS  PLAYED   (%)
+1 revolution_2.70_210925         :  3704.6  1013.0    2000    51
+2 revolution-dev_v2.40_130925    :  3700.0   987.0    2000    49
+```
+
+The Ordo run also reports a draw rate of 50.00% between equal opponents and confirms a neutral white advantage.


### PR DESCRIPTION
## Summary
- add a documentation page capturing the 2000-game Ordo and BayesElo results for Revolution 2.70 versus Revolution Dev v2.40

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe40244d088327bf9c9e1eb6ddc644