### PR TITLE
Add DEV vs BASE UHO Lichess evaluation summary

### DIFF
--- a/docs/sprt-results/2025-02-27-dev-vs-base-uho-lichess-4852.md
+++ b/docs/sprt-results/2025-02-27-dev-vs-base-uho-lichess-4852.md
@@ -1,0 +1,35 @@
+# DEV vs BASE — UHO_Lichess_4852_v1 (10+0.1, 2 threads, 128 MB)
+
+## Resumen del match
+
+| Métrica | Valor |
+| --- | --- |
+| Partidas | 3 080 |
+| Ritmo | 10+0.1 |
+| Hilos | 2 |
+| Hash | 128 MB |
+| Libro | `UHO_Lichess_4852_v1.epd` |
+| Elo (sprt) | −13.20 ± 6.10 |
+| nElo | −26.60 ± 12.27 |
+| Ratio de victorias | 23.64 % |
+| Ratio de tablas | 52.34 % |
+| Ratio de derrotas | 27.42 % |
+| Puntuación total | 1 481.5 / 3 080 (48.10 %) |
+| Ptnml (0–2) | [8, 415, 806, 308, 3] |
+| LOS | 0.00 % |
+| LLR | −1.77 (umbral de aceptación 2.50) |
+
+## Interpretación
+
+- El intervalo de confianza del Elo se mantiene completamente por debajo de cero, lo que indica que la versión DEV es **inferior** al baseline en este ritmo de juego.
+- El `LOS` en 0 % y el `LLR` negativo descartan la posibilidad de que la prueba alcance el umbral de aceptación sin una reversión drástica de la tendencia.
+- La puntuación final (48.10 %) también se sitúa por debajo del 50 %, reforzando la ausencia de ganancia.
+
+## Conclusión y pasos sugeridos
+
+1. **No promover el cambio actual.** Con la evidencia disponible, el parche debe considerarse perdedor.
+2. **Realizar un diff funcional.** Revisar los commits de la rama DEV para aislar qué heurística o ajuste produjo la pérdida. Priorizar funciones relacionadas con el nodo de búsqueda principal.
+3. **Repetir pruebas tras ajustes.** Una vez identificadas las causas, preparar un nuevo binario y lanzar un nuevo match SPRT partiendo de `h = 0`.
+4. **Registrar futuros intentos.** Añadir nuevos resultados en este directorio (`docs/sprt-results/`) para dar seguimiento histórico a las iteraciones.
+
+> Nota: Este informe resume los datos publicados tras 3 080 partidas, antes de que la prueba alcanzara el límite `h = 0`. Ninguna métrica sugiere una reversión favorable en las rondas restantes, por lo que detener el test y revisar el código es la opción más eficiente.


### PR DESCRIPTION
## Summary
- document the 10+0.1 DEV vs BASE match played with the UHO_Lichess_4852_v1 opening book
- capture the Elo, LOS, LLR, and score breakdown to record the unsuccessful test
- outline recommended follow-up steps before preparing a new SPRT run

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69015ec1e400832798aa1d4668e980aa