### PR TITLE
Limit killer cache reuse by depth

### DIFF
--- a/src/movepick.h
+++ b/src/movepick.h
@@ -83,8 +83,8 @@ class MovePicker {
     ExtMove                      moves[MAX_MOVES];
 };
 
-std::array<Move, 2> load_killers_from_cache(int ply);
-void                save_killer_to_cache(int ply, Move move);
+std::array<Move, 2> load_killers_from_cache(int ply, Depth depth);
+void                save_killer_to_cache(int ply, Move move, Depth depth);
 void                clear_killer_cache();
 void                clear_killer_cache_from_ply(int ply);
 


### PR DESCRIPTION
## Summary
- track per-ply killer cache entries along with the deepest search depth that produced them
- return cached killer moves only when they meet the current node depth requirement and clear depth metadata on cache resets
- pass the current node depth to killer updates so the cache stays synchronized with main iterations

## Testing
- ninja -C build *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_690161196834832792bb40c8e067227c