### PR TITLE
Rebrand engine as revolution-limitkiller-2910205

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,8 +38,8 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_BIN   = revolution-2.90-241025
-BRANDED_NAME  = revolution 2.90 241025
+RELEASE_BIN   = revolution-limitkiller-2910205
+BRANDED_NAME  = revolution-limitkiller-2910205
 
 ifeq ($(target_windows),yes)
         EXE          = $(RELEASE_BIN).exe

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -41,8 +41,8 @@ namespace {
 
 // Version number or dev.
 // Keep this in sync with the README and build scripts so every artifact reports
-// the same Revolution 2.90 241025 release branding.
-constexpr std::string_view engine_name = "Revolution 2.90 241025";
+// the same revolution-limitkiller-2910205 release branding.
+constexpr std::string_view engine_name = "revolution-limitkiller-2910205";
 constexpr std::string_view version     = "release";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and


### PR DESCRIPTION
## Summary
- rename the release binary and branded executable name to revolution-limitkiller-2910205 so Windows builds produce revolution-limitkiller-2910205.exe
- update the UCI-reported engine name to revolution-limitkiller-2910205 to match the new branding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69016a08891c8327a7806c0740cfacdf