### PR TITLE
Rebrand engine to revolution-dv1-011125

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,8 +1,8 @@
-# Revolution maintainers
+# revolution-dv1-011125 maintainers
 Jorge Ruiz
 ChatGPT
 
-# Revolution 2.90 241025 is a derivative of Stockfish 17.1. The original Stockfish
+# revolution-dv1-011125 is a derivative of Stockfish 17.1. The original Stockfish
 # contributors remain credited below.
 
 # Founders of the Stockfish project and Fishtest infrastructure

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: Revolution 2.90 241025
+title: revolution-dv1-011125
 message: >-
-  Please cite Revolution 2.90 241025 as a derivative of Stockfish 17.1 using the
+  Please cite revolution-dv1-011125 as a derivative of Stockfish 17.1 using the
   metadata from this file.
 type: software
 authors:
@@ -16,7 +16,7 @@ repository-code: 'https://github.com/jorgeruiz/revolution'
 url: 'https://github.com/jorgeruiz/revolution'
 repository-artifact: 'https://github.com/jorgeruiz/revolution/releases'
 abstract: >-
-  Revolution 2.90 241025 is a free and strong UCI chess engine derived from
+  revolution-dv1-011125 is a free and strong UCI chess engine derived from
   Stockfish 17.1, co-authored by Jorge Ruiz and ChatGPT with full credit to the
   Stockfish developers.
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,13 @@
-# Contributing to Revolution
+# Contributing to revolution-dv1-011125
 
-Welcome to the Revolution project! We are excited that you are interested in
-contributing. This document outlines the guidelines and steps to follow when
-making contributions to Revolution 2.90 241025, a derivative of Stockfish 17.1.
+Welcome to the revolution-dv1-011125 project! We are excited that you are
+interested in contributing. This document outlines the guidelines and steps to
+follow when making contributions to revolution-dv1-011125, a derivative of
+Stockfish 17.1.
 
 ## Table of Contents
 
-- [Building Revolution](#building-revolution)
+- [Building revolution-dv1-011125](#building-revolution-dv1-011125)
 - [Making Contributions](#making-contributions)
   - [Reporting Issues](#reporting-issues)
   - [Submitting Pull Requests](#submitting-pull-requests)
@@ -14,7 +15,7 @@ making contributions to Revolution 2.90 241025, a derivative of Stockfish 17.1.
 - [Community and Communication](#community-and-communication)
 - [License](#license)
 
-## Building Revolution
+## Building revolution-dv1-011125
 
 In case you do not have a C++ compiler installed, you can follow the
 instructions from our wiki.
@@ -32,7 +33,7 @@ If you find a bug, please open an issue on the
 like your operating system, build environment, and a detailed description of the
 problem.
 
-_Please note that Revolution development follows the upstream Stockfish policy of
+_Please note that revolution-dv1-011125 development follows the upstream Stockfish policy of
 not focusing on new features. Thus any issue regarding missing features will
 potentially be closed without further discussion._
 
@@ -51,13 +52,13 @@ potentially be closed without further discussion._
 
 _First time contributors should add their name to [AUTHORS](./AUTHORS)._ 
 
-_Revolution's development is not focused on adding new features, mirroring
+_revolution-dv1-011125's development is not focused on adding new features, mirroring
 Stockfish. Thus any pull request introducing new features will potentially be
 closed without further discussion._
 
 ## Code Style
 
-Changes to Revolution C++ code should respect our coding style defined by
+Changes to revolution-dv1-011125 C++ code should respect our coding style defined by
 [.clang-format](.clang-format). You can format your changes by running
 `make format`. This requires clang-format version 18 to be installed on your system.
 
@@ -80,11 +81,11 @@ git config blame.ignoreRevsFile .git-blame-ignore-revs
 
 ## License
 
-By contributing to Revolution, you agree that your contributions will be licensed
+By contributing to revolution-dv1-011125, you agree that your contributions will be licensed
 under the GNU General Public License v3.0. See [Copying.txt][copying-link] for
 more details.
 
-Thank you for contributing to Revolution and helping us make it even better!
+Thank you for contributing to revolution-dv1-011125 and helping us make it even better!
 
 [copying-link]:           https://github.com/official-stockfish/Stockfish/blob/master/Copying.txt
 [discord-link]:           https://discord.gg/GWDRS3kU6R

--- a/Copying.txt
+++ b/Copying.txt
@@ -1,6 +1,6 @@
-Revolution 2.90 241025 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
+revolution-dv1-011125 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
 with credits to ChatGPT and the Stockfish developers listed in AUTHORS. The GNU
-General Public License reproduced below governs Revolution.
+General Public License reproduced below governs revolution-dv1-011125.
 
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
-  <img src="assets/pullsfish-logo.svg" alt="Revolution logo" width="160">
+  <img src="assets/pullsfish-logo.svg" alt="revolution-dv1-011125 logo" width="160">
 
-  <h3>Revolution 2.90 241025</h3>
+  <h3>revolution-dv1-011125</h3>
 
   A free and strong UCI chess engine derived from Stockfish 17.1.
   <br>
@@ -19,32 +19,31 @@
 
 </div>
 
-> **Revolution 2.90 241025** is a UCI chess engine derived from **Stockfish 17.1**. The
+> **revolution-dv1-011125** is a UCI chess engine derived from **Stockfish 17.1**. The
 > project is jointly authored by **Jorge Ruiz** and the **ChatGPT AI**, with
 > credits to the Stockfish authors and every contributor listed in
 > [AUTHORS](AUTHORS). This repository provides the complete source so the
 > community can collaborate on maintenance and future improvements.
 
-This release and all distributed binaries identify themselves as **Revolution 2.90 241025**.
-You should see that exact name (including the build tag `241025`) in the engine
-headers, UCI responses, and compiled executable filenames. If a GUI shows a
-different string, make sure it is loading the binaries built from this version
-of the source tree.
+This release and all distributed binaries identify themselves as **revolution-dv1-011125**.
+You should see that exact name in the engine headers, UCI responses, and
+compiled executable filenames. If a GUI shows a different string, make sure it
+is loading the binaries built from this version of the source tree.
 
 ## Overview
 
-Revolution 2.90 241025 is a **free and strong UCI chess engine** that analyzes chess positions
+revolution-dv1-011125 is a **free and strong UCI chess engine** that analyzes chess positions
 and computes the optimal moves while preserving full compatibility with popular
 front-ends.
 
-Revolution 2.90 241025 **does not include a graphical user interface** (GUI) and is normally
+revolution-dv1-011125 **does not include a graphical user interface** (GUI) and is normally
 paired with third-party front-ends such as Fritz 20 or Cutechess. It implements
 the Universal Chess Interface (UCI) protocol so those GUIs can discover it as
-**Revolution 2.90 241025** in their engine lists.
+**revolution-dv1-011125** in their engine lists.
 
 ### BrainLearn experience integration
 
-Revolution 2.90 241025 bundles the BrainLearn learning hash so it shares the same
+revolution-dv1-011125 bundles the BrainLearn learning hash so it shares the same
 UCI options as BrainFish while persisting the data to `experience.exp`. Each
 entry in the file stores the following information (mirroring the in-memory
 BrainLearn transposition table):
@@ -90,17 +89,17 @@ each move, and persists the updated values so they are used in future sessions.
 
 ## Files
 
-This distribution of Revolution 2.90 241025 consists of the following files:
+This distribution of revolution-dv1-011125 consists of the following files:
 
   * [README.md](README.md), the file you are currently reading.
 
   * [Copying.txt](Copying.txt), a text file containing the GNU General Public
     License version 3.
 
-  * [AUTHORS](AUTHORS), a text file with the list of authors for Revolution 2.90 241025.
+  * [AUTHORS](AUTHORS), a text file with the list of authors for revolution-dv1-011125.
 
   * [src](src), a subdirectory containing the full source code, including a
-    Makefile that can be used to compile Revolution 2.90 241025 on Unix-like systems.
+    Makefile that can be used to compile revolution-dv1-011125 on Unix-like systems.
 
   * a file with the .nnue extension, storing the neural network for the NNUE
     evaluation. Binary distributions will have this file embedded.
@@ -111,32 +110,32 @@ __See [Contributing Guide](CONTRIBUTING.md).__
 
 ### Donating hardware
 
-Improving Revolution 2.90 241025 requires a massive amount of testing. You can donate your
-hardware resources by installing the Revolution worker and joining the community
+Improving revolution-dv1-011125 requires a massive amount of testing. You can donate your
+hardware resources by installing the revolution-dv1-011125 worker and joining the community
 channels to coordinate testing campaigns.
 
 ### Improving the code
 
 In the [chessprogramming wiki](https://www.chessprogramming.org/Main_Page), many
-techniques used in Revolution 2.90 241025 are explained with a lot of background information.
+techniques used in revolution-dv1-011125 are explained with a lot of background information.
 The [section on evaluation techniques](https://www.chessprogramming.org/Evaluation)
 describes many features and techniques used by modern engines.
 
-The engine testing is coordinated by the Revolution maintainers. If you want to
-help improve Revolution 2.90 241025, please read this
+The engine testing is coordinated by the revolution-dv1-011125 maintainers. If you want to
+help improve revolution-dv1-011125, please read this
 [guideline](https://github.com/jorgeluisruiz/revolution/wiki/Getting-Started)
 first, where the basics of development are explained.
 
-Discussions about Revolution take place mainly in the community
+Discussions about revolution-dv1-011125 take place mainly in the community
 [Discord server](https://discord.gg/GWDRS3kU6R). This is the best place to ask
 questions about the codebase and how to improve it.
 
-## Compiling Revolution
+## Compiling revolution-dv1-011125
 
-Revolution 2.90 241025 has support for 32 or 64-bit CPUs, certain hardware instructions,
+revolution-dv1-011125 has support for 32 or 64-bit CPUs, certain hardware instructions,
 big-endian machines such as Power PC, and other platforms.
 
-On Unix-like systems, it should be easy to compile Revolution 2.90 241025 directly from the
+On Unix-like systems, it should be easy to compile revolution-dv1-011125 directly from the
 source code with the included Makefile in the folder `src`. In general, it is
 recommended to run `make help` to see a list of make targets with corresponding
 descriptions. An example suitable for most Intel and AMD chips:
@@ -150,11 +149,11 @@ Detailed compilation instructions for all platforms can be found in the
 [documentation](https://github.com/jorgeluisruiz/revolution/wiki/Compilation). The
 wiki also has information about the
 [UCI commands](https://github.com/jorgeluisruiz/revolution/wiki/UCI-Commands)
-supported by Revolution.
+supported by revolution-dv1-011125.
 
 ## Terms of use
 
-Revolution 2.90 241025 is free and distributed under the
+revolution-dv1-011125 is free and distributed under the
 [**GNU General Public License version 3**](Copying.txt) (GPL v3). Essentially,
 this means you are free to do almost exactly what you want with the program,
 including distributing it among your friends, making it available for download
@@ -162,7 +161,7 @@ from your website, selling it (either by itself or as part of some bigger
 software package), or using it as the starting point for a software project of
 your own.
 
-The only real limitation is that whenever you distribute Revolution 2.90 241025 in some way,
+The only real limitation is that whenever you distribute revolution-dv1-011125 in some way,
 you MUST always include the license and the full source code (or a pointer to
 where the source code can be found) to generate the exact binary you are
 distributing. If you make any changes to the source code, these changes must
@@ -170,14 +169,14 @@ also be made available under GPL v3.
 
 ## Credits
 
-Revolution 2.90 241025 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
+revolution-dv1-011125 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
 The project gives full credit to the Stockfish authors and to every contributor
 listed in [AUTHORS](AUTHORS), and it continues to benefit from the innovations
 shared by the wider open-source chess community.
 
 ## Acknowledgements
 
-Revolution uses neural networks trained on
+revolution-dv1-011125 uses neural networks trained on
 [data provided by the Leela Chess Zero project](https://training.lczero.org/),
 which is made available under the
 [Open Database License](https://opendatacommons.org/licenses/odbl/) (ODbL).

--- a/docs/fastchess_sprt_plan.md
+++ b/docs/fastchess_sprt_plan.md
@@ -1,6 +1,6 @@
 # Propuestas de optimización para pruebas SPRT en Fastchess
 
-Las siguientes propuestas describen optimizaciones realistas para el motor **Revolution**. Cada propuesta incluye el repositorio en el que se almacenará el código fuente y la etiqueta (`tag`) sugerida para conservar una instantánea compilable que pueda usarse en las pruebas **SPRT** de [Fastchess](https://github.com/minhducsun2002/fastchess).
+Las siguientes propuestas describen optimizaciones realistas para el motor **revolution-dv1-011125**. Cada propuesta incluye el repositorio en el que se almacenará el código fuente y la etiqueta (`tag`) sugerida para conservar una instantánea compilable que pueda usarse en las pruebas **SPRT** de [Fastchess](https://github.com/minhducsun2002/fastchess).
 
 | Propuesta | Objetivo | Cambios clave | Repositorio / Tag | Métrica primaria | Riesgos y contramedidas |
 |-----------|----------|---------------|-------------------|------------------|-------------------------|
@@ -29,7 +29,7 @@ set "FASTCHESS=C:\fastchess\fastchess.exe"
 set "DIR_DEV=C:\fastchess\revolution-device"
 set "ENGINE_DEV=%DIR_DEV%\revolution-PVS.exe"
 set "DIR_BASE=C:\fastchess\revolution-baseline"
-set "ENGINE_BASE=%DIR_BASE%\revolution-2.90-241025.exe"
+set "ENGINE_BASE=%DIR_BASE%\revolution-dv1-011125.exe"
 set "BOOK=C:\fastchess\Books\UHO_Lichess_4852_v1.epd"
 set "OUTDIR=C:\fastchess\out"
 

--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -148,6 +148,6 @@ if [ -z "$file_arch" ]; then
   file_arch=$true_arch
 fi
 
-file_name="revolution-2.90-241025-$file_os-$file_arch.$file_ext"
+file_name="revolution-dv1-011125-$file_os-$file_arch.$file_ext"
 
 printf '%s %s\n' "$true_arch" "$file_name"

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,8 +38,8 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_BIN   = revolution-2.90-241025
-BRANDED_NAME  = revolution 2.90 241025
+RELEASE_BIN   = revolution-dv1-011125
+BRANDED_NAME  = revolution-dv1-011125
 
 ifeq ($(target_windows),yes)
         EXE          = $(RELEASE_BIN).exe

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -41,8 +41,8 @@ namespace {
 
 // Version number or dev.
 // Keep this in sync with the README and build scripts so every artifact reports
-// the same Revolution 2.90 241025 release branding.
-constexpr std::string_view engine_name = "Revolution 2.90 241025";
+// the same revolution-dv1-011125 release branding.
+constexpr std::string_view engine_name = "revolution-dv1-011125";
 constexpr std::string_view version     = "release";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -267,10 +267,10 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nRevolution is a powerful chess engine for playing and analyzing games of chess."
+              << "\nrevolution-dv1-011125 is a powerful chess engine for playing and analyzing games of chess."
                  "\nIt is a derivative of Stockfish 17.1 maintained by Jorge Ruiz with credits to ChatGPT"
                  "\nand is released as free software licensed under the GNU GPLv3 License."
-                 "\nRevolution is normally used with a graphical user interface (GUI) and implements"
+                 "\nrevolution-dv1-011125 is normally used with a graphical user interface (GUI) and implements"
                  "\nthe Universal Chess Interface (UCI) protocol to communicate with a GUI, an API, etc."
                  "\nFor further information, visit https://github.com/jorgeruiz/revolution"
                  "\nor read the corresponding README.md and Copying.txt files distributed along with this program.\n"

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -221,7 +221,7 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.revolution.clear_output()
 
     def test_startup_output(self):
-        self.revolution.starts_with("Revolution")
+        self.revolution.starts_with("revolution-dv1-011125")
 
     def test_uci_command(self):
         self.revolution.send_command("uci")
@@ -433,7 +433,7 @@ class TestSyzygy(metaclass=OrderedClassMembers):
         self.revolution.clear_output()
 
     def test_syzygy_setup(self):
-        self.revolution.starts_with("Revolution")
+        self.revolution.starts_with("revolution-dv1-011125")
         self.revolution.send_command("uci")
         self.revolution.send_command(
             f"setoption name SyzygyPath value {os.path.join(PATH, 'syzygy')}"

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,7 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 4] pos depth result chess960 logfile
 log_file -noappend $logfile
-spawn ./revolution-2.90-241025
+spawn ./revolution-dv1-011125
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }
@@ -27,7 +27,7 @@ send "position $pos\ngo perft $depth\n"
 expect {
   "Nodes searched: $result" {}
   timeout {puts "TIMEOUT: Expected $result nodes"; exit 1}
-  eof {puts "EOF: Revolution crashed"; exit 2}
+  eof {puts "EOF: revolution-dv1-011125 crashed"; exit 2}
 }
 send "quit\n"
 expect eof

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -15,7 +15,7 @@ echo "reprosearch testing started"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
-  spawn ./revolution-2.90-241025
+  spawn ./revolution-dv1-011125
  lassign \$argv nodes
 
  send "uci\n"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-signature=`eval "$WINE_PATH ./revolution-2.90-241025 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`eval "$WINE_PATH ./revolution-dv1-011125 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ]; then
    # compare to given reference


### PR DESCRIPTION
## Summary
- rename build artifacts, scripts, and packaging references to revolution-dv1-011125
- update engine metadata, UCI help text, and GUI expectations to report the new name
- refresh documentation to describe the project under the revolution-dv1-011125 brand

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905c2386c1883278404f04cfa201402