### PR TITLE
Initialize thread pool atomics to avoid premature stops

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -151,7 +151,9 @@ class ThreadPool {
 
     void ensure_network_replicated();
 
-    std::atomic_bool stop, abortedSearch, increaseDepth;
+    std::atomic_bool stop{false};
+    std::atomic_bool abortedSearch{false};
+    std::atomic_bool increaseDepth{false};
 
     auto cbegin() const noexcept { return threads.cbegin(); }
     auto begin() noexcept { return threads.begin(); }


### PR DESCRIPTION
## Summary
- initialize the ThreadPool stop, abortedSearch, and increaseDepth flags so they start from a known false state, preventing undefined behaviour on compilers like clang++/mingw

## Testing
- `make -C src build ARCH=x86-64 -j4`
- `./src/revolution-dv1-011125 bench 128 1 1`


------
https://chatgpt.com/codex/tasks/task_e_6905d89746dc8327b6f0437f35a32bbe