### PR TITLE
Handle invalid spin option input gracefully

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -182,9 +182,24 @@ Option& Option::operator=(const std::string& v) {
     assert(!type.empty());
 
     if ((type != "button" && type != "string" && v.empty())
-        || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stof(v) < min || std::stof(v) > max)))
+        || (type == "check" && v != "true" && v != "false"))
         return *this;
+
+    if (type == "spin")
+    {
+        std::istringstream iss(v);
+        double             spinValue = 0.0;
+
+        if (!(iss >> spinValue))
+            return *this;
+
+        iss >> std::ws;
+        if (!iss.eof())
+            return *this;
+
+        if (spinValue < min || spinValue > max)
+            return *this;
+    }
 
     if (type == "combo")
     {


### PR DESCRIPTION
## Summary
- prevent spin-type UCI options from throwing by validating the input string before assignment

## Testing
- python3 tests/instrumented.py --none src/revolution-dv1-011125

------
https://chatgpt.com/codex/tasks/task_e_6905ea3e45588327bbae60cd076bc78f