### PR TITLE
Adjust history scaling for margin-aware updates

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -79,7 +79,7 @@ namespace {
 // Compress history contributions so that the larger values produced by the
 // margin-scaled updates remain in a comparable range for move ordering.
 int history_score(int raw) {
-    constexpr int Normalization = 4096;
+    constexpr int Normalization = 6144;
     return raw * Normalization / (Normalization + std::abs(raw));
 }
 


### PR DESCRIPTION
## Summary
- amplify or dampen history updates based on whether the score margin supports the reward or penalty
- retune history compression for quiet move ordering to match the wider dynamic range from margin scaling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905efdaa89883278520eb773806e81d