### PR TITLE
Ensure tablebase ply counts remain positive

### DIFF
--- a/src/score.cpp
+++ b/src/score.cpp
@@ -36,7 +36,7 @@ Score::Score(Value v, const Position& pos) {
     else if (std::abs(v) <= VALUE_TB)
     {
         auto distance = VALUE_TB - std::abs(v);
-        score         = (v > 0) ? Tablebase{distance, true} : Tablebase{-distance, false};
+        score         = (v > 0) ? Tablebase{distance, true} : Tablebase{distance, false};
     }
     else
     {


### PR DESCRIPTION
## Summary
- keep tablebase scores' ply counts positive when converting engine values

## Testing
- python tests/instrumented.py src/revolution-dv1-011125

------
https://chatgpt.com/codex/tasks/task_e_6905f10f5080832783a3fe4c4121d521