### PR TITLE
Fix whitespace helpers to handle non-ASCII characters

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -540,11 +540,16 @@ std::optional<std::string> read_file_to_string(const std::string& path) {
 }
 
 void remove_whitespace(std::string& s) {
-    s.erase(std::remove_if(s.begin(), s.end(), [](char c) { return std::isspace(c); }), s.end());
+    s.erase(std::remove_if(s.begin(), s.end(), [](char c) {
+                return std::isspace(static_cast<unsigned char>(c));
+            }),
+            s.end());
 }
 
 bool is_whitespace(std::string_view s) {
-    return std::all_of(s.begin(), s.end(), [](char c) { return std::isspace(c); });
+    return std::all_of(s.begin(), s.end(), [](char c) {
+        return std::isspace(static_cast<unsigned char>(c));
+    });
 }
 
 std::string CommandLine::get_binary_directory(std::string argv0) {


### PR DESCRIPTION
## Summary
- cast characters to unsigned char before calling std::isspace in the whitespace helpers to avoid undefined behavior with negative char values

## Testing
- make build ARCH=x86-64
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6905f90130f88327b2d6ca30fe03b5a5