### PR TITLE
Restore small network usage by default

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -160,6 +160,13 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
+    options.add(
+      "UseSmallNetwork",
+      Option(true, [](const Option& o) {
+          Eval::set_small_network_usage(int(o));
+          return std::nullopt;
+      }).with_info("Use the auxiliary NNUE network in high-evaluation positions. Disable to force exclusive use of the big network."));
+
     options.add("Read only learning", Option(false, [](const Option& o) {
                     LD.set_readonly(o);
                     return std::nullopt;
@@ -200,6 +207,8 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Book 2 Width", Option(1, 1, 100));
     options.add("Book 2 Depth", Option(100, 0, 200));
     options.add("(CTG) Book 2 Only Green", Option(false));
+
+    Eval::set_small_network_usage(int(options["UseSmallNetwork"]));
 
     load_networks();
     resize_threads();

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -19,6 +19,7 @@
 #include "evaluate.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
 #include <cmath>
 #include <cstdlib>
@@ -45,7 +46,24 @@ int Eval::simple_eval(const Position& pos, Color c) {
          + (pos.non_pawn_material(c) - pos.non_pawn_material(~c));
 }
 
+namespace {
+
+std::atomic<bool> g_useSmallNetwork{true};
+
+}  // namespace
+
+void Eval::set_small_network_usage(bool enable) {
+    g_useSmallNetwork.store(enable, std::memory_order_relaxed);
+}
+
+bool Eval::small_network_enabled() {
+    return g_useSmallNetwork.load(std::memory_order_relaxed);
+}
+
 bool Eval::use_smallnet(const Position& pos) {
+    if (!small_network_enabled())
+        return false;
+
     int simpleEval = simple_eval(pos, pos.side_to_move());
     return std::abs(simpleEval) > 962;
 }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -45,6 +45,8 @@ class AccumulatorStack;
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 
 int   simple_eval(const Position& pos, Color c);
+void  set_small_network_usage(bool enable);
+bool  small_network_enabled();
 bool  use_smallnet(const Position& pos);
 Value evaluate(const NNUE::Networks&          networks,
                const Position&                pos,


### PR DESCRIPTION
## Summary
- add a `UseSmallNetwork` UCI option so the auxiliary NNUE network can be toggled at runtime while keeping it enabled by default
- guard the small-network selection with an atomic flag that mirrors the option state
- initialize the evaluator with the option's default value during engine construction

## Testing
- ./src/revolution-dev-01125 bench

------
https://chatgpt.com/codex/tasks/task_e_69060297bd788327a14082ce1d5fd6d6