### PR TITLE
Prevent Polyglot book reader from overrunning book data

### DIFF
--- a/src/book/polyglot/polyglot.cpp
+++ b/src/book/polyglot/polyglot.cpp
@@ -427,6 +427,9 @@ namespace Stockfish
             size_t curPos = find_first_pos(key) * sizeof(PolyglotEntry);
             while (true)
             {
+                if (curPos >= bookDataLength)
+                    break;
+
                 //Read a new entry
                 read_poly_entry(e, curPos, bookData, bookDataLength);
 


### PR DESCRIPTION
## Summary
- guard the Polyglot book iteration against running past the mapped book buffer

## Testing
- make build

------
https://chatgpt.com/codex/tasks/task_e_69060806845483279260d673fe3f9b16