### PR TITLE
Simplify futility pruning margin

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -929,8 +929,7 @@ Value Search::Worker::search(
     // The depth condition is important for mate finding.
     if (!ss->ttPv && depth < 14
         && eval - futility_margin(depth, cutNode && !ss->ttHit, improving, opponentWorsening)
-               - (ss - 1)->statScore / 301 + 37 - std::abs(correctionValue) / 139878
-             >= beta
+               + 37 - std::abs(correctionValue) / 139878 >= beta
         && eval >= beta && (!ttData.move || ttCapture) && !is_loss(beta) && !is_win(eval))
         return beta + (eval - beta) / 3;
 


### PR DESCRIPTION
## Summary
- remove the statScore term from the futility pruning margin check to match upstream simplification

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690609fac56c83279f75bbe835e49dff