### PR TITLE
Fix NNUE accumulator backward loop underflow

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <initializer_list>
 #include <memory>
+#include <cstdint>
 
 #include "../bitboard.h"
 #include "../position.h"
@@ -214,9 +215,13 @@ void AccumulatorStack::backward_update_incremental(
 
     const Square ksq = pos.square<KING>(Perspective);
 
-    for (std::size_t next = m_current_idx - 2; next >= end; next--)
-        update_accumulator_incremental<Perspective, BACKWARDS>(
-          featureTransformer, ksq, m_accumulators[next], m_accumulators[next + 1]);
+    for (std::int64_t next = static_cast<std::int64_t>(m_current_idx) - 2;
+         next >= static_cast<std::int64_t>(end);
+         --next)
+        update_accumulator_incremental<Perspective, BACKWARDS>(featureTransformer,
+                                                               ksq,
+                                                               m_accumulators[static_cast<std::size_t>(next)],
+                                                               m_accumulators[static_cast<std::size_t>(next + 1)]);
 
     assert((m_accumulators[end].*accPtr).computed[Perspective]);
 }


### PR DESCRIPTION
## Summary
- prevent the backward incremental NNUE accumulator loop from underflowing by iterating with a signed index
- include the appropriate header for std::int64_t

## Testing
- make build -j4
- ./revolution-dev-01125 bench

------
https://chatgpt.com/codex/tasks/task_e_69060c9695a883278173258da8729777