### PR TITLE
Prevent brand target from deleting executable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -972,8 +972,10 @@ strip: $(EXE) brand
 	$(STRIP) "$(BRANDED_EXE)"
 
 brand: $(EXE)
-	@rm -f "$(BRANDED_EXE)"
-	@cp $(EXE) "$(BRANDED_EXE)"
+	@if [ "$(EXE)" != "$(BRANDED_EXE)" ]; then \
+		rm -f "$(BRANDED_EXE)"; \
+		cp "$(EXE)" "$(BRANDED_EXE)"; \
+	fi
 
 install: all
 	-mkdir -p -m 755 $(BINDIR)


### PR DESCRIPTION
## Summary
- prevent the brand target from deleting the freshly linked binary when the branded name matches the executable name by skipping the copy in that case

## Testing
- not run (requires Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_690610cfa6fc83278f4e0096c560a4ce