### PR TITLE
Fix missing score margin initialization in qsearch

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1733,6 +1733,8 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
         futilityBase = ss->staticEval + 359;
     }
 
+    const int scoreMargin = std::max(0, int(beta - alpha));
+
     const PieceToHistory* contHist[] = {(ss - 1)->continuationHistory,
                                         (ss - 2)->continuationHistory};
 


### PR DESCRIPTION
## Summary
- define the scoreMargin value inside the quiescence search routine before it is passed to MovePicker
- ensure the build completes without undefined symbol errors

## Testing
- make build

------
https://chatgpt.com/codex/tasks/task_e_69061fe420488327857bb0d148840b51