### PR TITLE
Fix clang profile build with portable NNUE SIMD fallback

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -632,6 +632,19 @@ ifneq ($(comp),mingw)
 	endif
 endif
 
+### Locate llvm-profdata for profile-guided builds
+CLANG_MAJOR_VERSION = $(shell $(CXX) --version 2>/dev/null | head -n 1 | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p')
+ifeq ($(CLANG_MAJOR_VERSION),)
+CLANG_MAJOR_VERSION = $(shell $(CXX) -dumpversion 2>/dev/null | cut -d. -f1)
+endif
+
+LLVM_PROFDATA_CANDIDATES = $(if $(CLANG_MAJOR_VERSION),llvm-profdata-$(CLANG_MAJOR_VERSION)) llvm-profdata llvm-profdata-20 llvm-profdata-19 llvm-profdata-18 llvm-profdata-17 llvm-profdata-16 llvm-profdata-15 llvm-profdata-14
+LLVM_PROFDATA = $(firstword $(foreach cmd,$(LLVM_PROFDATA_CANDIDATES),$(if $(shell command -v $(cmd) 2>/dev/null),$(shell command -v $(cmd)))))
+
+ifeq ($(LLVM_PROFDATA),)
+$(error Could not find llvm-profdata executable; please install llvm-profdata or set LLVM_PROFDATA)
+endif
+
 ### 3.2.1 Debugging
 ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
@@ -1113,7 +1126,7 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) llvm-profdata merge -output=$(RELEASE_BIN).profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=$(RELEASE_BIN).profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
@@ -1141,7 +1154,7 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) llvm-profdata merge -output=$(RELEASE_BIN).profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=$(RELEASE_BIN).profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \

--- a/src/history.h
+++ b/src/history.h
@@ -117,6 +117,9 @@ using CapturePieceToHistory = Stats<std::int16_t, 10692, PIECE_NB, SQUARE_NB, PI
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
 using PieceToHistory = Stats<std::int16_t, 30000, PIECE_NB, SQUARE_NB>;
 
+// TTMoveHistory shares the same layout as PieceToHistory and tracks transposition table moves.
+using TTMoveHistory = PieceToHistory;
+
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
 // PieceToHistory instead of ButterflyBoards.

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -57,6 +57,7 @@
 // versions, so instead of calling them directly (forcing the linker to resolve
 // the calls at compile time), try to load them at runtime. To do this we need
 // first to define the corresponding function pointers.
+#endif
 
 namespace Stockfish {
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -176,8 +176,7 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     constexpr uint64_t alignment = CacheLineSize;
 
-    alignas(alignment)
-      TransformedFeatureType transformedFeatures[FeatureTransformer<FTDimensions>::BufferSize];
+    alignas(alignment) TransformedFeatureType transformedFeatures[Transformer::BufferSize];
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
@@ -238,8 +237,7 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
 
     constexpr uint64_t alignment = CacheLineSize;
 
-    alignas(alignment)
-      TransformedFeatureType transformedFeatures[FeatureTransformer<FTDimensions>::BufferSize];
+    alignas(alignment) TransformedFeatureType transformedFeatures[Transformer::BufferSize];
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
@@ -408,9 +406,11 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
 // Explicit template instantiations
 
 template class Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
-                       FeatureTransformer<TransformedFeatureDimensionsBig>>;
+                       FeatureTransformer<TransformedFeatureDimensionsBig,
+                                          &AccumulatorState::accumulatorBig>>;
 
 template class Network<NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>,
-                       FeatureTransformer<TransformedFeatureDimensionsSmall>>;
+                       FeatureTransformer<TransformedFeatureDimensionsSmall,
+                                          &AccumulatorState::accumulatorSmall>>;
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -78,6 +78,9 @@ class Network {
                            AccumulatorStack&                       accumulatorStack,
                            AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
+    const Transformer& transformer() const { return featureTransformer; }
+    Transformer&       transformer() { return featureTransformer; }
+
 
     void verify(std::string evalfilePath, const std::function<void(std::string_view)>&) const;
     NnueEvalTrace trace_evaluate(const Position&                         pos,
@@ -118,11 +121,13 @@ class Network {
 };
 
 // Definitions of the network types
-using SmallFeatureTransformer = FeatureTransformer<TransformedFeatureDimensionsSmall>;
+using SmallFeatureTransformer =
+  FeatureTransformer<TransformedFeatureDimensionsSmall, &AccumulatorState::accumulatorSmall>;
 using SmallNetworkArchitecture =
   NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>;
 
-using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
+using BigFeatureTransformer =
+  FeatureTransformer<TransformedFeatureDimensionsBig, &AccumulatorState::accumulatorBig>;
 using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
 
 using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -86,17 +86,17 @@ void AccumulatorStack::reset(const Position&    rootPos,
 
     update_accumulator_refresh_cache<WHITE, TransformedFeatureDimensionsBig,
                                      &AccumulatorState::accumulatorBig>(
-      *networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
+      networks.big.transformer(), rootPos, m_accumulators[0], caches.big);
     update_accumulator_refresh_cache<BLACK, TransformedFeatureDimensionsBig,
                                      &AccumulatorState::accumulatorBig>(
-      *networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
+      networks.big.transformer(), rootPos, m_accumulators[0], caches.big);
 
     update_accumulator_refresh_cache<WHITE, TransformedFeatureDimensionsSmall,
                                      &AccumulatorState::accumulatorSmall>(
-      *networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
+      networks.small.transformer(), rootPos, m_accumulators[0], caches.small);
     update_accumulator_refresh_cache<BLACK, TransformedFeatureDimensionsSmall,
                                      &AccumulatorState::accumulatorSmall>(
-      *networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
+      networks.small.transformer(), rootPos, m_accumulators[0], caches.small);
 }
 
 void AccumulatorStack::push(const DirtyPiece& dirtyPiece) noexcept {

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -77,7 +77,8 @@ void permute(T (&data)[N], const std::array<std::size_t, OrderSize>& order) {
 }
 
 // Input feature converter
-template<IndexType TransformedFeatureDimensions>
+template<IndexType TransformedFeatureDimensions,
+         Accumulator<TransformedFeatureDimensions> AccumulatorState::*AccPtr>
 class FeatureTransformer {
 
     // Number of output dimensions for one side
@@ -186,7 +187,7 @@ class FeatureTransformer {
                            OutputType*                               output,
                            int                                       bucket) const {
 
-        using namespace SIMD;
+        using namespace ::Stockfish::Eval::NNUE::SIMD;
 
         accumulatorStack.evaluate(pos, *this, *cache);
         const auto& accumulatorState = accumulatorStack.latest();
@@ -318,10 +319,12 @@ class FeatureTransformer {
 }  // namespace Stockfish::Eval::NNUE
 
 
-template<Stockfish::Eval::NNUE::IndexType TransformedFeatureDimensions>
-struct std::hash<Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>> {
+template<Stockfish::Eval::NNUE::IndexType TransformedFeatureDimensions,
+         Stockfish::Eval::NNUE::Accumulator<TransformedFeatureDimensions>
+           Stockfish::Eval::NNUE::AccumulatorState::*AccPtr>
+struct std::hash<Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions, AccPtr>> {
     std::size_t
-    operator()(const Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>& ft)
+    operator()(const Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions, AccPtr>& ft)
       const noexcept {
         return ft.get_content_hash();
     }

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -139,7 +139,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             {
                 pos.remove_piece(sq);
 
-                accumulators->reset();
+                accumulators->reset(pos, networks, caches);
                 std::tie(psqt, positional) = networks.big.evaluate(pos, *accumulators, &caches.big);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
@@ -156,7 +156,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    accumulators->reset();
+    accumulators->reset(pos, networks, caches);
     auto t = networks.big.trace_evaluate(pos, *accumulators, &caches.big);
 
     ss << " NNUE network contributions "

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -1,0 +1,161 @@
+/*
+  Revolution, a UCI chess playing engine derived from Stockfish 17.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Revolution is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Revolution is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NNUE_SIMD_H_INCLUDED
+#define NNUE_SIMD_H_INCLUDED
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+#include "nnue_common.h"
+
+namespace Stockfish::Eval::NNUE::SIMD {
+
+constexpr std::size_t VecBytes = 16;
+constexpr std::size_t VecInt16Count = VecBytes / sizeof(BiasType);
+constexpr std::size_t VecInt32Count = VecBytes / sizeof(PSQTWeightType);
+
+struct alignas(VecBytes) vec_t {
+    std::array<std::uint8_t, VecBytes> bytes{};
+
+    std::int16_t* as_i16() { return reinterpret_cast<std::int16_t*>(bytes.data()); }
+    const std::int16_t* as_i16() const { return reinterpret_cast<const std::int16_t*>(bytes.data()); }
+};
+
+struct alignas(VecBytes) psqt_vec_t {
+    std::array<std::uint8_t, VecBytes> bytes{};
+
+    std::int32_t* as_i32() { return reinterpret_cast<std::int32_t*>(bytes.data()); }
+    const std::int32_t* as_i32() const { return reinterpret_cast<const std::int32_t*>(bytes.data()); }
+};
+
+inline vec_t vec_zero() { return vec_t{}; }
+
+inline vec_t vec_set_16(int value) {
+    vec_t out;
+    auto* data = out.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        data[i] = static_cast<std::int16_t>(value);
+    return out;
+}
+
+inline vec_t vec_min_16(const vec_t& a, const vec_t& b) {
+    vec_t out;
+    auto* dst       = out.as_i16();
+    const auto* lhs = a.as_i16();
+    const auto* rhs = b.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        dst[i] = std::min(lhs[i], rhs[i]);
+    return out;
+}
+
+inline vec_t vec_max_16(const vec_t& a, const vec_t& b) {
+    vec_t out;
+    auto* dst       = out.as_i16();
+    const auto* lhs = a.as_i16();
+    const auto* rhs = b.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        dst[i] = std::max(lhs[i], rhs[i]);
+    return out;
+}
+
+inline vec_t vec_slli_16(const vec_t& v, int shift) {
+    vec_t out;
+    auto* dst = out.as_i16();
+    const auto* src = v.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        dst[i] = static_cast<std::int16_t>(static_cast<std::int32_t>(src[i]) << shift);
+    return out;
+}
+
+inline vec_t vec_mulhi_16(const vec_t& a, const vec_t& b) {
+    vec_t out;
+    auto* dst       = out.as_i16();
+    const auto* lhs = a.as_i16();
+    const auto* rhs = b.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+    {
+        std::int32_t prod = static_cast<std::int32_t>(lhs[i]) * static_cast<std::int32_t>(rhs[i]);
+        dst[i]            = static_cast<std::int16_t>(prod >> 16);
+    }
+    return out;
+}
+
+inline vec_t vec_add_16(const vec_t& a, const vec_t& b) {
+    vec_t out;
+    auto* dst       = out.as_i16();
+    const auto* lhs = a.as_i16();
+    const auto* rhs = b.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        dst[i] = static_cast<std::int16_t>(static_cast<std::int32_t>(lhs[i])
+                                           + static_cast<std::int32_t>(rhs[i]));
+    return out;
+}
+
+inline vec_t vec_sub_16(const vec_t& a, const vec_t& b) {
+    vec_t out;
+    auto* dst       = out.as_i16();
+    const auto* lhs = a.as_i16();
+    const auto* rhs = b.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        dst[i] = static_cast<std::int16_t>(static_cast<std::int32_t>(lhs[i])
+                                           - static_cast<std::int32_t>(rhs[i]));
+    return out;
+}
+
+inline vec_t vec_packus_16(const vec_t& lo, const vec_t& hi) {
+    vec_t out;
+    auto* bytes = out.bytes.data();
+    const auto* l = lo.as_i16();
+    const auto* h = hi.as_i16();
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        bytes[i] = static_cast<std::uint8_t>(std::clamp<int>(l[i], 0, 255));
+    for (std::size_t i = 0; i < VecInt16Count; ++i)
+        bytes[VecInt16Count + i] = static_cast<std::uint8_t>(std::clamp<int>(h[i], 0, 255));
+    return out;
+}
+
+inline void vec_store(vec_t* dst, const vec_t& value) { *dst = value; }
+
+inline psqt_vec_t vec_add_psqt_32(const psqt_vec_t& a, const psqt_vec_t& b) {
+    psqt_vec_t out;
+    auto* dst       = out.as_i32();
+    const auto* lhs = a.as_i32();
+    const auto* rhs = b.as_i32();
+    for (std::size_t i = 0; i < VecInt32Count; ++i)
+        dst[i] = lhs[i] + rhs[i];
+    return out;
+}
+
+inline psqt_vec_t vec_sub_psqt_32(const psqt_vec_t& a, const psqt_vec_t& b) {
+    psqt_vec_t out;
+    auto* dst       = out.as_i32();
+    const auto* lhs = a.as_i32();
+    const auto* rhs = b.as_i32();
+    for (std::size_t i = 0; i < VecInt32Count; ++i)
+        dst[i] = lhs[i] - rhs[i];
+    return out;
+}
+
+inline void vec_store_psqt(psqt_vec_t* dst, const psqt_vec_t& value) { *dst = value; }
+
+}  // namespace Stockfish::Eval::NNUE::SIMD
+
+#endif  // NNUE_SIMD_H_INCLUDED
+

--- a/src/search.h
+++ b/src/search.h
@@ -73,6 +73,7 @@ struct Stack {
     bool                        inCheck;
     bool                        ttPv;
     bool                        ttHit;
+    bool                        isTTMove = false;
     int                         cutoffCnt;
     int                         reduction;
 };
@@ -296,9 +297,8 @@ class Worker {
    private:
     void iterative_deepening();
 
-    void do_move(Position& pos, const Move move, StateInfo& st, Stack* const ss);
-    void
-    do_move(Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss);
+    void do_move(Position& pos, const Move move, StateInfo& st);
+    void do_move(Position& pos, const Move move, StateInfo& st, bool givesCheck);
     void do_null_move(Position& pos, StateInfo& st);
     void undo_move(Position& pos, const Move move);
     void undo_null_move(Position& pos);


### PR DESCRIPTION
## Summary
- add a portable SIMD helper and refactor the NNUE transformer/accumulator plumbing so clang can build the network code without vendor intrinsics
- detect versioned llvm-profdata binaries and use the resolved path from clang/ICX profile targets so `profile-build` works when only llvm-profdata-XX is available

## Testing
- `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`


------
https://chatgpt.com/codex/tasks/task_e_690b149f2f248327ae896cbed4caa102