### PR TITLE
Improve sacrificial follow-up search and add test games

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -727,6 +727,11 @@ Value Search::Worker::search(
     bestValue          = -VALUE_INFINITE;
     maxValue           = VALUE_INFINITE;
 
+    if (ss->sacrificeUrgency <= 0)
+        ss->sacrificeMargin = VALUE_ZERO;
+
+    bool underSacrificePressure = ss->sacrificeUrgency > 0;
+
     // Check for the available remaining time
     if (is_mainthread())
         main_manager()->check_time(*thisThread);
@@ -896,6 +901,38 @@ Value Search::Worker::search(
                        unadjustedStaticEval, tt.generation());
     }
 
+    if (priorCapture)
+    {
+        Square   kingSq           = pos.square<KING>(us);
+        Bitboard enemyAttackers   = pos.attackers_to(kingSq) & pos.pieces(~us);
+        int      attackCount      = popcount(enemyAttackers);
+        Value    capturedMaterial = PieceValue[pos.captured_piece()];
+        Value    sacrificePenalty = Value(attackCount * PawnValue / 2);
+
+        if (capturedMaterial >= RookValue)
+            sacrificePenalty += PawnValue / 2;
+        else if (capturedMaterial >= BishopValue)
+            sacrificePenalty += PawnValue / 4;
+
+        sacrificePenalty += std::max<Value>(VALUE_ZERO, ss->sacrificeMargin / 4);
+        sacrificePenalty = std::clamp(sacrificePenalty, VALUE_ZERO, Value(3 * PawnValue));
+
+        if (sacrificePenalty > VALUE_ZERO)
+        {
+            ss->staticEval = std::clamp(ss->staticEval - sacrificePenalty,
+                                        VALUE_TB_LOSS_IN_MAX_PLY + 1,
+                                        VALUE_TB_WIN_IN_MAX_PLY - 1);
+            eval = std::clamp(eval - sacrificePenalty, VALUE_TB_LOSS_IN_MAX_PLY + 1,
+                               VALUE_TB_WIN_IN_MAX_PLY - 1);
+
+            if (attackCount >= 2)
+                ss->sacrificeUrgency = std::max(ss->sacrificeUrgency, 1 + attackCount / 2);
+
+            ss->sacrificeMargin = std::max(ss->sacrificeMargin, capturedMaterial);
+            underSacrificePressure = ss->sacrificeUrgency > 0;
+        }
+    }
+
     // Use static evaluation difference to improve quiet move ordering
     if (((ss - 1)->currentMove).is_ok() && !(ss - 1)->inCheck && !priorCapture)
     {
@@ -988,6 +1025,7 @@ Value Search::Worker::search(
     probCutBeta = beta + 185 - 58 * improving;
     if (depth >= 3
         && !is_decisive(beta)
+        && !underSacrificePressure
         // If value from transposition table is lower than probCutBeta, don't attempt
         // probCut there and in further interactions with transposition table cutoff
         // depth is set to depth - 3 because probCut search has depth set to depth - 4
@@ -1050,7 +1088,8 @@ moves_loop:  // When in check, search starts here
     // Step 12. A small Probcut idea
     probCutBeta = beta + 415;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta
-        && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value))
+        && !is_decisive(beta) && is_valid(ttData.value) && !is_decisive(ttData.value)
+        && !ss->sacrificeUrgency)
         return probCutBeta;
 
     const PieceToHistory* contHist[] = {
@@ -1101,6 +1140,11 @@ moves_loop:  // When in check, search starts here
         movedPiece = pos.moved_piece(move);
         givesCheck = pos.gives_check(move);
 
+        Piece capturedPiece = NO_PIECE;
+        if (capture)
+            capturedPiece = move.type_of() == EN_PASSANT ? make_piece(~us, PAWN)
+                                                         : pos.piece_on(move.to_sq());
+
         // Calculate new depth for this move
         newDepth = depth - 1;
 
@@ -1116,36 +1160,49 @@ moves_loop:  // When in check, search starts here
         if (ss->ttPv)
             r += 979;
 
+        if (ss->sacrificeUrgency > 0)
+        {
+            r -= r / 4;
+            r = std::max(0, r - 128 * ss->sacrificeUrgency);
+        }
+
         // Step 14. Pruning at shallow depth.
         // Depth conditions are important for mate finding.
         if (!rootNode && pos.non_pawn_material(us) && !is_loss(bestValue))
         {
-            // Skip quiet moves if movecount exceeds our FutilityMoveCount threshold
-            if (moveCount >= futility_move_count(improving, depth))
+            if (!underSacrificePressure && moveCount >= futility_move_count(improving, depth))
                 mp.skip_quiet_moves();
 
-            // Reduced depth of the next LMR search
             int lmrDepth = newDepth - r / 1024;
 
             if (capture || givesCheck)
             {
-                Piece capturedPiece = pos.piece_on(move.to_sq());
-                int   captHist =
+                int captHist =
                   thisThread->captureHistory[movedPiece][move.to_sq()][type_of(capturedPiece)];
 
-                // Futility pruning for captures
-                if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
+                if (!underSacrificePressure)
                 {
-                    Value futilityValue = ss->staticEval + 242 + 230 * lmrDepth
-                                        + PieceValue[capturedPiece] + 133 * captHist / 1024;
-                    if (futilityValue <= alpha)
+                    if (!givesCheck && lmrDepth < 7 && !ss->inCheck)
+                    {
+                        Value futilityValue = ss->staticEval + 242 + 230 * lmrDepth
+                                            + PieceValue[capturedPiece] + 133 * captHist / 1024;
+                        if (futilityValue <= alpha)
+                            continue;
+                    }
+
+                    int seeHist = std::clamp(captHist / 32, -138 * depth, 135 * depth);
+                    if (!pos.see_ge(move, -154 * depth - seeHist))
                         continue;
                 }
-
-                // SEE based pruning for captures and checks
-                int seeHist = std::clamp(captHist / 32, -138 * depth, 135 * depth);
-                if (!pos.see_ge(move, -154 * depth - seeHist))
-                    continue;
+                else
+                {
+                    lmrDepth = std::max(lmrDepth, newDepth - 1);
+                    int seeHist = std::clamp(captHist / 32, -138 * depth, 135 * depth);
+                    int seeMargin = (-154 * depth - seeHist) / 2
+                                  - std::max<int>(0, ss->sacrificeUrgency - 1) * 32;
+                    if (!pos.see_ge(move, seeMargin))
+                        continue;
+                }
             }
             else
             {
@@ -1154,40 +1211,78 @@ moves_loop:  // When in check, search starts here
                   + (*contHist[1])[movedPiece][move.to_sq()]
                   + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
 
-                // Continuation history based pruning
-                if (history < -4348 * depth)
-                    continue;
-
-                history += 68 * thisThread->mainHistory[us][move.from_to()] / 32;
-
-                lmrDepth += history / 3593;
-
-                Value futilityValue = ss->staticEval + (bestMove ? 48 : 146) + 116 * lmrDepth
-                                    + 103 * (bestValue < ss->staticEval - 128);
-
-                // Futility pruning: parent node
-                // (*Scaler): Generally, more frequent futility pruning
-                // scales well with respect to time and threads
-                if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
+                if (!underSacrificePressure)
                 {
-                    if (bestValue <= futilityValue && !is_decisive(bestValue)
-                        && !is_win(futilityValue))
-                        bestValue = futilityValue;
-                    continue;
+                    if (history < -4348 * depth)
+                        continue;
+
+                    history += 68 * thisThread->mainHistory[us][move.from_to()] / 32;
+
+                    lmrDepth += history / 3593;
+
+                    Value futilityValue = ss->staticEval + (bestMove ? 48 : 146) + 116 * lmrDepth
+                                        + 103 * (bestValue < ss->staticEval - 128);
+
+                    if (!ss->inCheck && lmrDepth < 12 && futilityValue <= alpha)
+                    {
+                        if (bestValue <= futilityValue && !is_decisive(bestValue)
+                            && !is_win(futilityValue))
+                            bestValue = futilityValue;
+                        continue;
+                    }
+
+                    lmrDepth = std::max(lmrDepth, 0);
+
+                    if (!pos.see_ge(move, -27 * lmrDepth * lmrDepth))
+                        continue;
                 }
+                else
+                {
+                    history += 68 * thisThread->mainHistory[us][move.from_to()] / 32;
+                    lmrDepth += history / 3593;
+                    lmrDepth = std::max(lmrDepth, 0);
 
-                lmrDepth = std::max(lmrDepth, 0);
+                    if (history < -4348 * depth - 512)
+                        continue;
 
-                // Prune moves with negative SEE
-                if (!pos.see_ge(move, -27 * lmrDepth * lmrDepth))
-                    continue;
+                    int seeMargin = -27 * lmrDepth * lmrDepth / 2;
+                    if (!pos.see_ge(move, seeMargin))
+                        continue;
+                }
             }
         }
+
+        int   nextSacUrgency = ss->sacrificeUrgency > 0 ? ss->sacrificeUrgency - 1 : 0;
+        Value nextSacMargin  = nextSacUrgency ? ss->sacrificeMargin : VALUE_ZERO;
+
+        if (capture)
+        {
+            Value capturedVal = PieceValue[capturedPiece];
+            Value moverVal    = PieceValue[movedPiece];
+            Value swing       = capturedVal - moverVal;
+
+            if (swing > PawnValue / 2)
+            {
+                nextSacUrgency = std::max(nextSacUrgency, 2 + (capturedVal >= RookValue));
+                nextSacMargin  = std::max(nextSacMargin, swing);
+            }
+            else if (ss->sacrificeUrgency > 0)
+                nextSacMargin = std::max(nextSacMargin, ss->sacrificeMargin);
+        }
+        else if (ss->sacrificeUrgency > 1)
+            nextSacMargin = ss->sacrificeMargin;
+
+        nextSacMargin = std::max(nextSacMargin, VALUE_ZERO);
+        (ss + 1)->sacrificeUrgency = nextSacUrgency;
+        (ss + 1)->sacrificeMargin  = nextSacMargin;
 
         // Step 15. Extensions
         // We take care to not overdo to avoid search getting stuck.
         if (ss->ply < thisThread->rootDepth * 2)
         {
+            if ((ss + 1)->sacrificeUrgency > 0 && (capture || givesCheck))
+                extension = std::max(extension, Depth(1));
+
             // Singular extension search. If all moves but one
             // fail low on a search of (alpha-s, beta-s), and just one fails high on
             // (alpha, beta), then that move is singular and should be extended. To
@@ -1620,6 +1715,11 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
     ss->inCheck        = pos.checkers();
     moveCount          = 0;
 
+    Color us = pos.side_to_move();
+    if (ss->sacrificeUrgency <= 0)
+        ss->sacrificeMargin = VALUE_ZERO;
+    bool underSacrifice = ss->sacrificeUrgency > 0;
+
     // Used to send selDepth info to GUI (selDepth counts from 1, ply from 0)
     if (PvNode && thisThread->selDepth < ss->ply + 1)
         thisThread->selDepth = ss->ply + 1;
@@ -1718,50 +1818,97 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
 
         moveCount++;
 
+        Piece movedPiece   = pos.moved_piece(move);
+        Piece capturedPiece = NO_PIECE;
+        if (capture)
+            capturedPiece = move.type_of() == EN_PASSANT ? make_piece(~us, PAWN)
+                                                         : pos.piece_on(move.to_sq());
+
         // Step 6. Pruning
         if (!is_loss(bestValue))
         {
-            // Futility pruning and moveCount pruning
-            if (!givesCheck && move.to_sq() != prevSq && !is_loss(futilityBase)
-                && move.type_of() != PROMOTION)
+            if (!underSacrifice)
             {
-                if (moveCount > 2)
-                    continue;
-
-                Value futilityValue = futilityBase + PieceValue[pos.piece_on(move.to_sq())];
-
-                // If static eval + value of piece we are going to capture is
-                // much lower than alpha, we can prune this move.
-                if (futilityValue <= alpha)
+                // Futility pruning and moveCount pruning
+                if (!givesCheck && move.to_sq() != prevSq && !is_loss(futilityBase)
+                    && move.type_of() != PROMOTION)
                 {
-                    bestValue = std::max(bestValue, futilityValue);
-                    continue;
+                    if (moveCount > 2)
+                        continue;
+
+                    Value futilityValue = futilityBase + PieceValue[capturedPiece];
+
+                    // If static eval + value of piece we are going to capture is
+                    // much lower than alpha, we can prune this move.
+                    if (futilityValue <= alpha)
+                    {
+                        bestValue = std::max(bestValue, futilityValue);
+                        continue;
+                    }
+
+                    // If static exchange evaluation is low enough
+                    // we can prune this move.
+                    if (!pos.see_ge(move, alpha - futilityBase))
+                    {
+                        bestValue = std::min(alpha, futilityBase);
+                        continue;
+                    }
                 }
 
-                // If static exchange evaluation is low enough
-                // we can prune this move.
-                if (!pos.see_ge(move, alpha - futilityBase))
-                {
-                    bestValue = std::min(alpha, futilityBase);
-                    continue;
-                }
-            }
-
-            // Continuation history based pruning
-            if (!capture
-                && (*contHist[0])[pos.moved_piece(move)][move.to_sq()]
-                       + thisThread->pawnHistory[pawn_structure_index(pos)][pos.moved_piece(move)]
+                // Continuation history based pruning
+                if (!capture
+                    && (*contHist[0])[movedPiece][move.to_sq()]
+                           + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece]
                                                 [move.to_sq()]
-                     <= 6290)
-                continue;
+                         <= 6290)
+                    continue;
 
-            // Do not search moves with bad enough SEE values
-            if (!pos.see_ge(move, -75))
-                continue;
+                // Do not search moves with bad enough SEE values
+                if (!pos.see_ge(move, -75))
+                    continue;
+            }
+            else
+            {
+                if (!capture)
+                {
+                    int continuationScore =
+                      (*contHist[0])[movedPiece][move.to_sq()]
+                      + thisThread->pawnHistory[pawn_structure_index(pos)][movedPiece][move.to_sq()];
+                    if (continuationScore <= 5500)
+                        continue;
+                }
+
+                if (!pos.see_ge(move, -30))
+                    continue;
+            }
         }
 
+        int   nextSacUrgency = ss->sacrificeUrgency > 0 ? ss->sacrificeUrgency - 1 : 0;
+        Value nextSacMargin  = nextSacUrgency ? ss->sacrificeMargin : VALUE_ZERO;
+
+        if (capture)
+        {
+            Value capturedVal = PieceValue[capturedPiece];
+            Value moverVal    = PieceValue[movedPiece];
+            Value swing       = capturedVal - moverVal;
+
+            if (swing > PawnValue / 2)
+            {
+                nextSacUrgency = std::max(nextSacUrgency, 2 + (capturedVal >= RookValue));
+                nextSacMargin  = std::max(nextSacMargin, swing);
+            }
+            else if (ss->sacrificeUrgency > 0)
+                nextSacMargin = std::max(nextSacMargin, ss->sacrificeMargin);
+        }
+        else if (ss->sacrificeUrgency > 1)
+            nextSacMargin = ss->sacrificeMargin;
+
+        nextSacMargin = std::max(nextSacMargin, VALUE_ZERO);
+
+        (ss + 1)->sacrificeUrgency = nextSacUrgency;
+        (ss + 1)->sacrificeMargin  = nextSacMargin;
+
         // Step 7. Make and search the move
-        Piece movedPiece = pos.moved_piece(move);
 
         do_move(pos, move, st, givesCheck);
         thisThread->nodes.fetch_add(1, std::memory_order_relaxed);

--- a/src/search.h
+++ b/src/search.h
@@ -76,6 +76,8 @@ struct Stack {
     bool                        isTTMove = false;
     int                         cutoffCnt;
     int                         reduction;
+    int                         sacrificeUrgency = 0;
+    Value                       sacrificeMargin  = VALUE_ZERO;
 };
 
 

--- a/tests/training/sacrifice_transitions.pgn
+++ b/tests/training/sacrifice_transitions.pgn
@@ -1,0 +1,35 @@
+[Event "Training"]
+[Site "?"]
+[Date "2024.01.01"]
+[Round "-"]
+[White "Flank Exchange Pressure"]
+[Black "Revolution"]
+[Result "*"]
+[Annotator "Sacrifice regression"]
+[Opening "King's Indian Defence"]
+
+1.d4 Nf6 2.c4 g6 3.Nc3 Bg7 4.e4 d6 5.Nf3 O-O 6.Be2 e5 7.O-O Nc6 8.d5 Ne7 9.b4 a5 10.Ba3 axb4 11.Bxb4 Nd7 12.a4 f5 13.Ng5 Nf6 14.f3 Bh6 15.Ne6 Bxe6 16.dxe6 Be3+ 17.Kh1 Nh5 18.g3 f4 19.Nd5 Nc6 20.e7 Nxe7 21.g4 Nc6 22.gxh5 Qh4 23.Nxc7 Ra5 24.Bxd6 Rf6 25.Qe1 Qxh5 26.c5 g5 27.Bc4+ Kh8 28.Rb1 Rh6 29.Rb2 Nd4 30.Qxa5 Nc6 31.Qa8+ Kg7 32.Qf8+ Kg6 33.Qf7# *
+
+[Event "Training"]
+[Site "?"]
+[Date "2024.01.02"]
+[Round "-"]
+[White "Queenside Pawn Storm"]
+[Black "Revolution"]
+[Result "*"]
+[Annotator "Sacrifice regression"]
+[Opening "English Opening"]
+
+1.c4 Nf6 2.Nc3 e6 3.Nf3 d5 4.e3 c5 5.d4 Nc6 6.a3 a5 7.cxd5 exd5 8.dxc5 Bxc5 9.b3 O-O 10.Bb2 d4 11.Na4 Ba7 12.Nxd4 Nxd4 13.Bxd4 Bxd4 14.Qxd4 Qxd4 15.exd4 Re8+ 16.Kd2 Bf5 17.f3 Rad8 18.Bb5 Rxd4+ 19.Kc3 Red8 20.Nb2 Nd5+ 21.Kxd4 Nc7+ 22.Kc5 Ne6+ 23.Kb6 Rd2 24.Nc4 Rxg2 25.Rad1 h5 26.h4 Rg3 27.Nd6 Bc2 28.Rd2 Bxb3 29.Kxa5 Rxf3 30.Kb6 Kf8 31.a4 Ke7 32.Re1 g5 33.hxg5 Rg3 34.Nf5+ Kf8 35.Nxg3 h4 36.Nf5 *
+
+[Event "Training"]
+[Site "?"]
+[Date "2024.01.03"]
+[Round "-"]
+[White "Kingside Initiative"]
+[Black "Revolution"]
+[Result "*"]
+[Annotator "Sacrifice regression"]
+[Opening "Queen's Pawn Game"]
+
+1.d4 Nf6 2.c4 e6 3.Nc3 Bb4 4.a3 Bxc3+ 5.bxc3 b6 6.f3 Bb7 7.e4 d6 8.Bd3 c5 9.Ne2 Nc6 10.O-O e5 11.f4 exd4 12.cxd4 cxd4 13.Ng3 Nd7 14.Nf5 Qf6 15.e5 dxe5 16.fxe5 Ndxe5 17.Nxg7+ Qxg7 18.Be4 O-O-O 19.Bf4 Rhg8 20.Qh5 Kb8 21.Rae1 f6 22.Bd5 Rge8 23.Bg3 Ka8 24.Qf5 d3 25.Qxf6 Qxf6 26.Rxf6 d2 27.Rd1 Nxc4 28.Bxc4 Na5 29.Bf1 Nb3 30.Rf7 Bd5 31.Rxh7 Re3 32.Bf4 Re1 33.Rxd2 Nxd2 34.Bxd2 Rxf1+ 35.Kxf1 Bxg2+ 36.Kxg2 Rxd2+ *


### PR DESCRIPTION
## Summary
- adjust search heuristics after accepting material to reduce pruning and dampen optimism in sacrificial transitions
- propagate sacrifice urgency into quiescence search and extend forcing replies to capture follow-ups
- add targeted training PGNs featuring flank sacrifices to validate defensive priorities

## Testing
- ninja -C build *(fails: build directory missing in repository)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e0d17133c8327981c27ff263b9eb9)