### PR TITLE
Rebrand engine to Revolution 3.20-Dev-071125

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@
 Jorge Ruiz
 ChatGPT
 
-# revolution-3.10-051125 is a derivative of Stockfish 17.1. The original Stockfish
+# Revolution 3.20-Dev-071125 is a derivative of Stockfish 17.1. The original Stockfish
 # contributors remain credited below.
 
 # Founders of the Stockfish project and Fishtest infrastructure

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,9 +2,9 @@
 # Visit https://bit.ly/cffinit to generate yours today!
 
 cff-version: 1.2.0
-title: revolution-3.10-051125
+title: Revolution 3.20-Dev-071125
 message: >-
-  Please cite revolution-3.10-051125 as a derivative of Stockfish 17.1 using the
+  Please cite Revolution 3.20-Dev-071125 as a derivative of Stockfish 17.1 using the
   metadata from this file.
 type: software
 authors:
@@ -16,7 +16,7 @@ repository-code: 'https://github.com/jorgeruiz/revolution'
 url: 'https://github.com/jorgeruiz/revolution'
 repository-artifact: 'https://github.com/jorgeruiz/revolution/releases'
 abstract: >-
-  revolution-3.10-051125 is a free and strong UCI chess engine derived from
+  Revolution 3.20-Dev-071125 is a free and strong UCI chess engine derived from
   Stockfish 17.1, co-authored by Jorge Ruiz and ChatGPT with full credit to the
   Stockfish developers.
 keywords:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Welcome to the Revolution project! We are excited that you are interested in
 contributing. This document outlines the guidelines and steps to follow when
-making contributions to revolution-3.10-051125, a derivative of Stockfish 17.1.
+making contributions to Revolution 3.20-Dev-071125, a derivative of Stockfish 17.1.
 
 ## Table of Contents
 

--- a/Copying.txt
+++ b/Copying.txt
@@ -1,4 +1,4 @@
-revolution-3.10-051125 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
+Revolution 3.20-Dev-071125 is a derivative of Stockfish 17.1, maintained by Jorge Ruiz
 with credits to ChatGPT and the Stockfish developers listed in AUTHORS. The GNU
 General Public License reproduced below governs Revolution.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
   <img src="assets/pullsfish-logo.svg" alt="Revolution logo" width="160">
 
-  <h3>revolution-3.10-051125</h3>
+  <h3>Revolution 3.20-Dev-071125</h3>
 
   A free and strong UCI chess engine derived from Stockfish 17.1.
   <br>
@@ -19,32 +19,35 @@
 
 </div>
 
-> **revolution-3.10-051125** is a UCI chess engine derived from **Stockfish 17.1**. The
+> **Revolution 3.20-Dev-071125** is a UCI chess engine derived from **Stockfish 17.1**. The
 > project is jointly authored by **Jorge Ruiz** and the **ChatGPT AI**, with
 > credits to the Stockfish authors and every contributor listed in
 > [AUTHORS](AUTHORS). This repository provides the complete source so the
 > community can collaborate on maintenance and future improvements.
 
-This release and all distributed binaries identify themselves as **revolution-3.10-051125**.
-You should see that exact name (including the build tag `051125`) in the engine
-headers, UCI responses, and compiled executable filenames. If a GUI shows a
-different string, make sure it is loading the binaries built from this version
-of the source tree.
+This release and all distributed binaries identify themselves as **Revolution 3.20-Dev-071125**.
+You should see that exact name (including the build tag `071125`) in the engine
+headers, UCI responses, and packaged executable filenames. The default `make`
+build emits `Revolution-3.20-Dev-071125` (without the embedded space so GNU make
+can treat the target correctly) and the `brand` rule copies it to
+`Revolution 3.20-Dev-071125.exe` for distribution. If a GUI shows a different
+string, make sure it is loading the binaries built from this version of the
+source tree.
 
 ## Overview
 
-revolution-3.10-051125 is a **free and strong UCI chess engine** that analyzes chess positions
+Revolution 3.20-Dev-071125 is a **free and strong UCI chess engine** that analyzes chess positions
 and computes the optimal moves while preserving full compatibility with popular
 front-ends.
 
-revolution-3.10-051125 **does not include a graphical user interface** (GUI) and is normally
+Revolution 3.20-Dev-071125 **does not include a graphical user interface** (GUI) and is normally
 paired with third-party front-ends such as Fritz 20 or Cutechess. It implements
 the Universal Chess Interface (UCI) protocol so those GUIs can discover it as
-**revolution-3.10-051125** in their engine lists.
+**Revolution 3.20-Dev-071125** in their engine lists.
 
 ### BrainLearn experience integration
 
-revolution-3.10-051125 bundles the BrainLearn learning hash so it shares the same
+Revolution 3.20-Dev-071125 bundles the BrainLearn learning hash so it shares the same
 UCI options as BrainFish while persisting the data to `experience.exp`. Each
 entry in the file stores the following information (mirroring the in-memory
 BrainLearn transposition table):
@@ -90,17 +93,17 @@ each move, and persists the updated values so they are used in future sessions.
 
 ## Files
 
-This distribution of revolution-3.10-051125 consists of the following files:
+This distribution of Revolution 3.20-Dev-071125 consists of the following files:
 
   * [README.md](README.md), the file you are currently reading.
 
   * [Copying.txt](Copying.txt), a text file containing the GNU General Public
     License version 3.
 
-  * [AUTHORS](AUTHORS), a text file with the list of authors for revolution-3.10-051125.
+  * [AUTHORS](AUTHORS), a text file with the list of authors for Revolution 3.20-Dev-071125.
 
   * [src](src), a subdirectory containing the full source code, including a
-    Makefile that can be used to compile revolution-3.10-051125 on Unix-like systems.
+    Makefile that can be used to compile Revolution 3.20-Dev-071125 on Unix-like systems.
 
   * a file with the .nnue extension, storing the neural network for the NNUE
     evaluation. Binary distributions will have this file embedded.
@@ -111,19 +114,19 @@ __See [Contributing Guide](CONTRIBUTING.md).__
 
 ### Donating hardware
 
-Improving revolution-3.10-051125 requires a massive amount of testing. You can donate your
+Improving Revolution 3.20-Dev-071125 requires a massive amount of testing. You can donate your
 hardware resources by installing the Revolution worker and joining the community
 channels to coordinate testing campaigns.
 
 ### Improving the code
 
 In the [chessprogramming wiki](https://www.chessprogramming.org/Main_Page), many
-techniques used in revolution-3.10-051125 are explained with a lot of background information.
+techniques used in Revolution 3.20-Dev-071125 are explained with a lot of background information.
 The [section on evaluation techniques](https://www.chessprogramming.org/Evaluation)
 describes many features and techniques used by modern engines.
 
 The engine testing is coordinated by the Revolution maintainers. If you want to
-help improve revolution-3.10-051125, please read this
+help improve Revolution 3.20-Dev-071125, please read this
 [guideline](https://github.com/jorgeluisruiz/revolution/wiki/Getting-Started)
 first, where the basics of development are explained.
 
@@ -133,10 +136,10 @@ questions about the codebase and how to improve it.
 
 ## Compiling Revolution
 
-revolution-3.10-051125 has support for 32 or 64-bit CPUs, certain hardware instructions,
+Revolution 3.20-Dev-071125 has support for 32 or 64-bit CPUs, certain hardware instructions,
 big-endian machines such as Power PC, and other platforms.
 
-On Unix-like systems, it should be easy to compile revolution-3.10-051125 directly from the
+On Unix-like systems, it should be easy to compile Revolution 3.20-Dev-071125 directly from the
 source code with the included Makefile in the folder `src`. In general, it is
 recommended to run `make help` to see a list of make targets with corresponding
 descriptions. An example suitable for most Intel and AMD chips:
@@ -154,7 +157,7 @@ supported by Revolution.
 
 ## Terms of use
 
-revolution-3.10-051125 is free and distributed under the
+Revolution 3.20-Dev-071125 is free and distributed under the
 [**GNU General Public License version 3**](Copying.txt) (GPL v3). Essentially,
 this means you are free to do almost exactly what you want with the program,
 including distributing it among your friends, making it available for download
@@ -162,7 +165,7 @@ from your website, selling it (either by itself or as part of some bigger
 software package), or using it as the starting point for a software project of
 your own.
 
-The only real limitation is that whenever you distribute revolution-3.10-051125 in some way,
+The only real limitation is that whenever you distribute Revolution 3.20-Dev-071125 in some way,
 you MUST always include the license and the full source code (or a pointer to
 where the source code can be found) to generate the exact binary you are
 distributing. If you make any changes to the source code, these changes must
@@ -170,7 +173,7 @@ also be made available under GPL v3.
 
 ## Credits
 
-revolution-3.10-051125 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
+Revolution 3.20-Dev-071125 is maintained by Jorge Ruiz in collaboration with the ChatGPT AI.
 The project gives full credit to the Stockfish authors and to every contributor
 listed in [AUTHORS](AUTHORS), and it continues to benefit from the innovations
 shared by the wider open-source chess community.

--- a/docs/fastchess_sprt_plan.md
+++ b/docs/fastchess_sprt_plan.md
@@ -40,7 +40,7 @@ set "FASTCHESS=C:\\fastchess\\fastchess.exe"
 set "DIR_DEV=C:\\fastchess\\revolution-device"
 set "ENGINE_DEV=%DIR_DEV%\\revolution-threat-extensions.exe"
 set "DIR_BASE=C:\\fastchess\\revolution-baseline"
-set "ENGINE_BASE=%DIR_BASE%\\revolution-3.10-051125.exe"
+set "ENGINE_BASE=%DIR_BASE%\\Revolution 3.20-Dev-071125.exe"
 set "BOOK=C:\\fastchess\\Books\\UHO_Lichess_4852_v1.epd"
 set "OUTDIR=C:\\fastchess\\out"
 

--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -148,6 +148,6 @@ if [ -z "$file_arch" ]; then
   file_arch=$true_arch
 fi
 
-file_name="revolution-3.10-051125-$file_os-$file_arch.$file_ext"
+file_name="Revolution 3.20-Dev-071125-$file_os-$file_arch.$file_ext"
 
 printf '%s %s\n' "$true_arch" "$file_name"

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,8 +38,8 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
-RELEASE_BIN   = revolution-3.10-051125
-BRANDED_NAME  = revolution-3.10-051125
+RELEASE_BIN   = Revolution-3.20-Dev-071125
+BRANDED_NAME  = Revolution 3.20-Dev-071125
 
 ifeq ($(target_windows),yes)
         EXE          = $(RELEASE_BIN).exe
@@ -54,7 +54,7 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(WINE_PATH) ./$(EXE) bench
+PGOBENCH = $(WINE_PATH) "./$(EXE)" bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
@@ -878,7 +878,7 @@ ifeq ($(debug), no)
 endif
 endif
 
-### 3.10 Android 5 can only run position independent executables. Note that this
+### 3.20 Android 5 can only run position independent executables. Note that this
 ### breaks Android 4.0 and earlier.
 ifeq ($(OS), Android)
 	CXXFLAGS += -fPIE
@@ -1015,15 +1015,15 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f $(RELEASE_BIN) $(RELEASE_BIN).exe "$(BRANDED_NAME)" "$(BRANDED_NAME).exe" *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f "$(RELEASE_BIN)" "$(RELEASE_BIN).exe" "$(BRANDED_NAME)" "$(BRANDED_NAME).exe" *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f $(RELEASE_BIN).profdata *.profraw
-	@rm -f $(RELEASE_BIN).*args*
-	@rm -f $(RELEASE_BIN).*lt*
+	@rm -f "$(RELEASE_BIN).profdata" *.profraw
+	@rm -f "$(RELEASE_BIN)."*args*
+	@rm -f "$(RELEASE_BIN)."*lt*
 	@rm -f "$(BRANDED_NAME).res" "$(RELEASE_BIN).res"
 	@rm -f ./-lstdc++.res
 
@@ -1126,7 +1126,7 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=$(RELEASE_BIN).profdata *.profraw
+        $(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
@@ -1154,7 +1154,7 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=$(RELEASE_BIN).profdata *.profraw
+        $(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -42,8 +42,8 @@ namespace {
 
 // Version number or dev.
 // Keep this in sync with the README and build scripts so every artifact reports
-// the same revolution-3.10-051125 release branding.
-constexpr std::string_view engine_name = "revolution-3.10-051125";
+// the same Revolution 3.20-Dev-071125 release branding.
+constexpr std::string_view engine_name = "Revolution 3.20-Dev-071125";
 constexpr std::string_view version     = "release";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and

--- a/tests/perft.sh
+++ b/tests/perft.sh
@@ -19,7 +19,7 @@ cat << 'EOF' > $EXPECT_SCRIPT
 set timeout 30
 lassign [lrange $argv 0 4] pos depth result chess960 logfile
 log_file -noappend $logfile
-spawn ./revolution-3.10-051125
+spawn ./Revolution-3.20-Dev-071125
 if {$chess960 == "true"} {
   send "setoption name UCI_Chess960 value true\n"
 }

--- a/tests/reprosearch.sh
+++ b/tests/reprosearch.sh
@@ -15,7 +15,7 @@ echo "reprosearch testing started"
 # the same node count for each iteration.
 cat << EOF > repeat.exp
  set timeout 10
-  spawn ./revolution-3.10-051125
+  spawn ./Revolution-3.20-Dev-071125
  lassign \$argv nodes
 
  send "uci\n"

--- a/tests/signature.sh
+++ b/tests/signature.sh
@@ -11,7 +11,7 @@ trap 'error ${LINENO}' ERR
 
 # obtain
 
-signature=`eval "$WINE_PATH ./revolution-3.10-051125 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
+signature=`eval "$WINE_PATH ./Revolution-3.20-Dev-071125 bench 2>&1" | grep "Nodes searched  : " | awk '{print $4}'`
 
 if [ $# -gt 0 ]; then
    # compare to given reference


### PR DESCRIPTION
## Summary
- update the engine name, documentation, and metadata to Revolution 3.20-Dev-071125
- adjust build scripts and automated tests so binaries and branded artifacts use the new naming

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e151f98748327bb1c893477cd2cfd)