### PR TITLE
Fix Makefile recipe indentation

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1126,7 +1126,7 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-        $(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
@@ -1154,7 +1154,7 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-        $(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output="$(RELEASE_BIN).profdata" *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=$(RELEASE_BIN).profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \


### PR DESCRIPTION
## Summary
- replace the space-indented commands in the clang-profile-use and icx-profile-use targets with tabs so GNU make treats them as recipes

## Testing
- make build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e17b26a2883279a5a90647f8993c8)