### PR TITLE
Adopt shared memory NNUE weights infrastructure

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -442,7 +442,7 @@ endif
 ifeq ($(COMP),gcc)
 	comp=gcc
 	CXX=g++
-	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations
+	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
 
 	ifeq ($(arch),$(filter $(arch),armv7 armv8 riscv64))
 		ifeq ($(OS),Android)
@@ -614,6 +614,19 @@ ifneq ($(comp),mingw)
 		ifneq ($(KERNEL),Haiku)
 			ifneq ($(COMP),ndk)
 				LDFLAGS += -lpthread
+
+				add_lrt = yes
+				ifeq ($(target_windows),yes)
+					add_lrt = no
+				endif
+
+				ifeq ($(KERNEL),Darwin)
+					add_lrt = no
+				endif
+
+				ifeq ($(add_lrt),yes)
+					LDFLAGS += -lrt
+				endif
 			endif
 		endif
 	endif
@@ -624,6 +637,7 @@ ifeq ($(debug),no)
 	CXXFLAGS += -DNDEBUG
 else
 	CXXFLAGS += -g
+	CXXFLAGS += -D_GLIBCXX_ASSERTIONS -D_GLIBCXX_DEBUG
 endif
 
 ### 3.2.2 Debugging with undefined behavior sanitizers

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -35,10 +35,12 @@
 #include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
+#include "nnue/nnue_misc.h"
 #include "numa.h"
 #include "perft.h"
 #include "position.h"
 #include "search.h"
+#include "shm.h"
 #include "syzygy/tbprobe.h"
 #include "types.h"
 #include "uci.h"
@@ -61,11 +63,14 @@ Engine::Engine(std::optional<std::string> path) :
     threads(),
     networks(
       numaContext,
-      NN::Networks(
-        NN::NetworkBig({EvalFileDefaultNameBig, "None", ""}, NN::EmbeddedNNUEType::BIG),
-        NN::NetworkSmall({EvalFileDefaultNameSmall, "None", ""}, NN::EmbeddedNNUEType::SMALL))) {
-    pos.set(StartFEN, false, &states->back());
+      // Heap-allocate because sizeof(NN::Networks) is large
+      std::make_unique<NN::Networks>(
+        std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                         NN::EmbeddedNNUEType::BIG),
+        std::make_unique<NN::NetworkSmall>(NN::EvalFile{EvalFileDefaultNameSmall, "None", ""},
+                                           NN::EmbeddedNNUEType::SMALL))) {
 
+    pos.set(StartFEN, false, &states->back());
 
     options.add(  //
       "Debug Log File", Option("", [](const Option& o) {
@@ -401,6 +406,36 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
     networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+
+    auto statuses = networks.get_status_and_errors();
+    for (size_t i = 0; i < statuses.size(); ++i)
+    {
+        const auto [status, error] = statuses[i];
+        std::string message        = "Network replica " + std::to_string(i + 1) + ": ";
+        if (status == SystemWideSharedConstantAllocationStatus::NoAllocation)
+        {
+            message += "No allocation.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::LocalMemory)
+        {
+            message += "Local memory.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::SharedMemory)
+        {
+            message += "Shared memory.";
+        }
+        else
+        {
+            message += "Unknown status.";
+        }
+
+        if (error.has_value())
+        {
+            message += " " + *error;
+        }
+
+        onVerifyNetworks(message);
+    }
 }
 
 void Engine::load_networks() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -116,11 +116,11 @@ class Engine {
     Position     pos;
     StateListPtr states;
 
-    OptionsMap                               options;
-    ThreadPool                               threads;
-    TranspositionTable                       tt;
-    LazyNumaReplicated<Eval::NNUE::Networks> networks;
-    BookManager                              bookManager;
+    OptionsMap                                         options;
+    ThreadPool                                         threads;
+    TranspositionTable                                 tt;
+    LazyNumaReplicatedSystemWide<Eval::NNUE::Networks> networks;
+    BookManager                                        bookManager;
 
     Search::SearchManager::UpdateContext  updateContext;
     std::function<void(std::string_view)> onVerifyNetworks;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -100,10 +100,10 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
     if (pos.checkers())
         return "Final evaluation: none (in check)";
 
-    Eval::NNUE::AccumulatorStack accumulators;
-    auto                         caches = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
+    auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
+    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
 
-    accumulators.reset(pos, networks, *caches);
+    accumulators->reset(pos, networks, *caches);
 
     std::stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
@@ -111,12 +111,12 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
 
-    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &caches->big);
+    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, &caches->big);
     Value v                 = psqt + positional;
     v                       = pos.side_to_move() == WHITE ? v : -v;
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
-    v = evaluate(networks, pos, accumulators, *caches, VALUE_ZERO);
+    v = evaluate(networks, pos, *accumulators, *caches, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,20 +17,20 @@
 */
 
 #include <iostream>
+#include <memory>
 
 #include "bitboard.h"
+#include "learn/learn.h"
 #include "misc.h"
 #include "position.h"
 #include "tune.h"
 #include "types.h"
 #include "uci.h"
 #include "wdl/win_probability.h"
-#include "learn/learn.h"
 
 using namespace Stockfish;
 
 int main(int argc, char* argv[]) {
-
     std::cout << engine_info() << std::endl;
 
     WDLModel::init();
@@ -38,12 +38,12 @@ int main(int argc, char* argv[]) {
     Bitboards::init();
     Position::init();
 
-    UCIEngine uci(argc, argv);
+    auto uci = std::make_unique<UCIEngine>(argc, argv);
 
-    LD.init(uci.engine_options());
-    Tune::init(uci.engine_options());
+    LD.init(uci->engine_options());
+    Tune::init(uci->engine_options());
 
-    uci.loop();
+    uci->loop();
 
     return 0;
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -56,12 +56,6 @@
 // the calls at compile time), try to load them at runtime. To do this we need
 // first to define the corresponding function pointers.
 
-extern "C" {
-using OpenProcessToken_t      = bool (*)(HANDLE, DWORD, PHANDLE);
-using LookupPrivilegeValueA_t = bool (*)(LPCSTR, LPCSTR, PLUID);
-using AdjustTokenPrivileges_t =
-  bool (*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES, PDWORD);
-}
 #endif
 
 
@@ -136,77 +130,14 @@ void std_aligned_free(void* ptr) {
 
 static void* aligned_large_pages_alloc_windows([[maybe_unused]] size_t allocSize) {
 
-    #if !defined(_WIN64)
-    return nullptr;
-    #else
-
-    HANDLE hProcessToken{};
-    LUID   luid{};
-    void*  mem = nullptr;
-
-    const size_t largePageSize = GetLargePageMinimum();
-    if (!largePageSize)
-        return nullptr;
-
-    // Dynamically link OpenProcessToken, LookupPrivilegeValue and AdjustTokenPrivileges
-
-    HMODULE hAdvapi32 = GetModuleHandle(TEXT("advapi32.dll"));
-
-    if (!hAdvapi32)
-        hAdvapi32 = LoadLibrary(TEXT("advapi32.dll"));
-
-    auto OpenProcessToken_f =
-      OpenProcessToken_t((void (*)()) GetProcAddress(hAdvapi32, "OpenProcessToken"));
-    if (!OpenProcessToken_f)
-        return nullptr;
-    auto LookupPrivilegeValueA_f =
-      LookupPrivilegeValueA_t((void (*)()) GetProcAddress(hAdvapi32, "LookupPrivilegeValueA"));
-    if (!LookupPrivilegeValueA_f)
-        return nullptr;
-    auto AdjustTokenPrivileges_f =
-      AdjustTokenPrivileges_t((void (*)()) GetProcAddress(hAdvapi32, "AdjustTokenPrivileges"));
-    if (!AdjustTokenPrivileges_f)
-        return nullptr;
-
-    // We need SeLockMemoryPrivilege, so try to enable it for the process
-
-    if (!OpenProcessToken_f(  // OpenProcessToken()
-          GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken))
-        return nullptr;
-
-    if (LookupPrivilegeValueA_f(nullptr, "SeLockMemoryPrivilege", &luid))
-    {
-        TOKEN_PRIVILEGES tp{};
-        TOKEN_PRIVILEGES prevTp{};
-        DWORD            prevTpLen = 0;
-
-        tp.PrivilegeCount           = 1;
-        tp.Privileges[0].Luid       = luid;
-        tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-
-        // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges()
-        // succeeds, we still need to query GetLastError() to ensure that the privileges
-        // were actually obtained.
-
-        if (AdjustTokenPrivileges_f(hProcessToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), &prevTp,
-                                    &prevTpLen)
-            && GetLastError() == ERROR_SUCCESS)
-        {
-            // Round up size to full pages and allocate
-            allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
-            mem       = VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
-                                     PAGE_READWRITE);
-
-            // Privilege no longer needed, restore previous state
-            AdjustTokenPrivileges_f(hProcessToken, FALSE, &prevTp, 0, nullptr, nullptr);
-        }
-    }
-
-    CloseHandle(hProcessToken);
-
-    return mem;
-
-    #endif
+    return windows_try_with_large_page_priviliges(
+      [&](size_t largePageSize) {
+          // Round up size to full pages and allocate
+          allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
+          return VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
+                              PAGE_READWRITE);
+      },
+      []() { return (void*) nullptr; });
 }
 
 void* aligned_large_pages_alloc(size_t allocSize) {

--- a/src/memory.h
+++ b/src/memory.h
@@ -29,6 +29,29 @@
 
 #include "types.h"
 
+#if defined(_WIN64)
+
+    #if _WIN32_WINNT < 0x0601
+        #undef _WIN32_WINNT
+        #define _WIN32_WINNT 0x0601  // Force to include needed API prototypes
+    #endif
+
+    #if !defined(NOMINMAX)
+        #define NOMINMAX
+    #endif
+    #include <windows.h>
+
+    #include <psapi.h>
+
+extern "C" {
+using OpenProcessToken_t      = bool (*)(HANDLE, DWORD, PHANDLE);
+using LookupPrivilegeValueA_t = bool (*)(LPCSTR, LPCSTR, PLUID);
+using AdjustTokenPrivileges_t =
+  bool (*)(HANDLE, BOOL, PTOKEN_PRIVILEGES, DWORD, PTOKEN_PRIVILEGES, PDWORD);
+}
+#endif
+
+
 namespace Stockfish {
 
 void* std_aligned_alloc(size_t alignment, size_t size);
@@ -212,6 +235,81 @@ T* align_ptr_up(T* ptr) {
       reinterpret_cast<char*>((ptrint + (Alignment - 1)) / Alignment * Alignment));
 }
 
+#if defined(_WIN32)
+
+template<typename FuncYesT, typename FuncNoT>
+auto windows_try_with_large_page_priviliges([[maybe_unused]] FuncYesT&& fyes, FuncNoT&& fno) {
+
+    #if !defined(_WIN64)
+    return fno();
+    #else
+
+    HANDLE hProcessToken{};
+    LUID   luid{};
+
+    const size_t largePageSize = GetLargePageMinimum();
+    if (!largePageSize)
+        return fno();
+
+    // Dynamically link OpenProcessToken, LookupPrivilegeValue and AdjustTokenPrivileges
+
+    HMODULE hAdvapi32 = GetModuleHandle(TEXT("advapi32.dll"));
+
+    if (!hAdvapi32)
+        hAdvapi32 = LoadLibrary(TEXT("advapi32.dll"));
+
+    auto OpenProcessToken_f =
+      OpenProcessToken_t((void (*)()) GetProcAddress(hAdvapi32, "OpenProcessToken"));
+    if (!OpenProcessToken_f)
+        return fno();
+    auto LookupPrivilegeValueA_f =
+      LookupPrivilegeValueA_t((void (*)()) GetProcAddress(hAdvapi32, "LookupPrivilegeValueA"));
+    if (!LookupPrivilegeValueA_f)
+        return fno();
+    auto AdjustTokenPrivileges_f =
+      AdjustTokenPrivileges_t((void (*)()) GetProcAddress(hAdvapi32, "AdjustTokenPrivileges"));
+    if (!AdjustTokenPrivileges_f)
+        return fno();
+
+    // We need SeLockMemoryPrivilege, so try to enable it for the process
+
+    if (!OpenProcessToken_f(  // OpenProcessToken()
+          GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken))
+        return fno();
+
+    if (!LookupPrivilegeValueA_f(nullptr, "SeLockMemoryPrivilege", &luid))
+        return fno();
+
+    TOKEN_PRIVILEGES tp{};
+    TOKEN_PRIVILEGES prevTp{};
+    DWORD            prevTpLen = 0;
+
+    tp.PrivilegeCount           = 1;
+    tp.Privileges[0].Luid       = luid;
+    tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+
+    // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges()
+    // succeeds, we still need to query GetLastError() to ensure that the privileges
+    // were actually obtained.
+
+    if (!AdjustTokenPrivileges_f(hProcessToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), &prevTp,
+                                 &prevTpLen)
+        || GetLastError() != ERROR_SUCCESS)
+        return fno();
+
+    auto&& ret = fyes(largePageSize);
+
+    // Privilege no longer needed, restore previous state
+    AdjustTokenPrivileges_f(hProcessToken, FALSE, &prevTp, 0, nullptr, nullptr);
+
+    CloseHandle(hProcessToken);
+
+    return std::forward<decltype(ret)>(ret);
+
+    #endif
+}
+
+#endif
 
 }  // namespace Stockfish
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -23,11 +23,15 @@
 #include <array>
 #include <cassert>
 #include <chrono>
-#include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <exception>  // IWYU pragma: keep
+// IWYU pragma: no_include <__exception/terminate.h>
+#include <functional>
 #include <iosfwd>
 #include <optional>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -291,6 +295,94 @@ inline uint64_t mul_hi64(uint64_t a, uint64_t b) {
 }
 
 
+template<typename T>
+inline void hash_combine(std::size_t& seed, const T& v) {
+    std::hash<T> hasher;
+    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template<>
+inline void hash_combine(std::size_t& seed, const std::size_t& v) {
+    seed ^= v + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+template<typename T>
+inline std::size_t get_raw_data_hash(const T& value) {
+    return std::hash<std::string_view>{}(
+      std::string_view(reinterpret_cast<const char*>(&value), sizeof(value)));
+}
+
+template<std::size_t Capacity>
+class FixedString {
+   public:
+    FixedString() :
+        length_(0) {
+        data_[0] = '\0';
+    }
+
+    FixedString(const char* str) {
+        size_t len = std::strlen(str);
+        if (len > Capacity)
+            std::terminate();
+        std::memcpy(data_, str, len);
+        length_        = len;
+        data_[length_] = '\0';
+    }
+
+    FixedString(const std::string& str) {
+        if (str.size() > Capacity)
+            std::terminate();
+        std::memcpy(data_, str.data(), str.size());
+        length_        = str.size();
+        data_[length_] = '\0';
+    }
+
+    std::size_t size() const { return length_; }
+    std::size_t capacity() const { return Capacity; }
+
+    const char* c_str() const { return data_; }
+    const char* data() const { return data_; }
+
+    char& operator[](std::size_t i) { return data_[i]; }
+
+    const char& operator[](std::size_t i) const { return data_[i]; }
+
+    FixedString& operator+=(const char* str) {
+        size_t len = std::strlen(str);
+        if (length_ + len > Capacity)
+            std::terminate();
+        std::memcpy(data_ + length_, str, len);
+        length_ += len;
+        data_[length_] = '\0';
+        return *this;
+    }
+
+    FixedString& operator+=(const FixedString& other) { return (*this += other.c_str()); }
+
+    operator std::string() const { return std::string(data_, length_); }
+
+    operator std::string_view() const { return std::string_view(data_, length_); }
+
+    template<typename T>
+    bool operator==(const T& other) const noexcept {
+        return (std::string_view) (*this) == other;
+    }
+
+    template<typename T>
+    bool operator!=(const T& other) const noexcept {
+        return (std::string_view) (*this) != other;
+    }
+
+    void clear() {
+        length_  = 0;
+        data_[0] = '\0';
+    }
+
+   private:
+    char        data_[Capacity + 1];  // +1 for null terminator
+    std::size_t length_;
+};
+
 struct CommandLine {
    public:
     CommandLine(int _argc, char** _argv) :
@@ -318,5 +410,12 @@ void move_to_front(std::vector<T>& vec, Predicate pred) {
 }
 
 }  // namespace Stockfish
+
+template<std::size_t N>
+struct std::hash<Stockfish::FixedString<N>> {
+    std::size_t operator()(const Stockfish::FixedString<N>& fstr) const noexcept {
+        return std::hash<std::string_view>{}((std::string_view) fstr);
+    }
+};
 
 #endif  // #ifndef MISC_H_INCLUDED

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -181,6 +181,15 @@ class AffineTransform {
 
         return !stream.fail();
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_raw_data_hash(biases));
+        hash_combine(h, get_raw_data_hash(weights));
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -224,6 +224,15 @@ class AffineTransformSparseInput {
 
         return !stream.fail();
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_raw_data_hash(biases));
+        hash_combine(h, get_raw_data_hash(weights));
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -58,6 +58,12 @@ class ClippedReLU {
     // Write network parameters
     bool write_parameters(std::ostream&) const { return true; }
 
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -58,6 +58,12 @@ class SqrClippedReLU {
     // Write network parameters
     bool write_parameters(std::ostream&) const { return true; }
 
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_hash_value(0));
+        return h;
+    }
+
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -21,7 +21,6 @@
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <memory>
 #include <optional>
 #include <type_traits>
 #include <vector>
@@ -30,7 +29,6 @@
 #include "../incbin/incbin.h"
 
 #include "../evaluate.h"
-#include "../memory.h"
 #include "../misc.h"
 #include "../position.h"
 #include "../types.h"
@@ -101,50 +99,13 @@ bool read_parameters(std::istream& stream, T& reference) {
 
 // Write evaluation function parameters
 template<typename T>
-bool write_parameters(std::ostream& stream, T& reference) {
+bool write_parameters(std::ostream& stream, const T& reference) {
 
     write_little_endian<std::uint32_t>(stream, T::get_hash_value());
     return reference.write_parameters(stream);
 }
 
 }  // namespace Detail
-
-template<typename Arch, typename Transformer>
-Network<Arch, Transformer>::Network(const Network<Arch, Transformer>& other) :
-    evalFile(other.evalFile),
-    embeddedType(other.embeddedType) {
-
-    if (other.featureTransformer)
-        featureTransformer = make_unique_large_page<Transformer>(*other.featureTransformer);
-
-    network = make_unique_aligned<Arch[]>(LayerStacks);
-
-    if (!other.network)
-        return;
-
-    for (std::size_t i = 0; i < LayerStacks; ++i)
-        network[i] = other.network[i];
-}
-
-template<typename Arch, typename Transformer>
-Network<Arch, Transformer>&
-Network<Arch, Transformer>::operator=(const Network<Arch, Transformer>& other) {
-    evalFile     = other.evalFile;
-    embeddedType = other.embeddedType;
-
-    if (other.featureTransformer)
-        featureTransformer = make_unique_large_page<Transformer>(*other.featureTransformer);
-
-    network = make_unique_aligned<Arch[]>(LayerStacks);
-
-    if (!other.network)
-        return *this;
-
-    for (std::size_t i = 0; i < LayerStacks; ++i)
-        network[i] = other.network[i];
-
-    return *this;
-}
 
 template<typename Arch, typename Transformer>
 void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::string evalfilePath) {
@@ -160,14 +121,14 @@ void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
 
     for (const auto& directory : dirs)
     {
-        if (evalFile.current != evalfilePath)
+        if (std::string(evalFile.current) != evalfilePath)
         {
             if (directory != "<internal>")
             {
                 load_user_net(directory, evalfilePath);
             }
 
-            if (directory == "<internal>" && evalfilePath == evalFile.defaultName)
+            if (directory == "<internal>" && evalfilePath == std::string(evalFile.defaultName))
             {
                 load_internal();
             }
@@ -185,7 +146,7 @@ bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename
         actualFilename = filename.value();
     else
     {
-        if (evalFile.current != evalFile.defaultName)
+        if (std::string(evalFile.current) != std::string(evalFile.defaultName))
         {
             msg = "Failed to export a net. "
                   "A non-embedded net can only be saved if the filename is specified";
@@ -232,7 +193,7 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
     const auto psqt =
-      featureTransformer->transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
+      featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
     const auto positional = network[bucket].propagate(transformedFeatures);
     return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
@@ -244,7 +205,7 @@ void Network<Arch, Transformer>::verify(std::string                             
     if (evalfilePath.empty())
         evalfilePath = evalFile.defaultName;
 
-    if (evalFile.current != evalfilePath)
+    if (std::string(evalFile.current) != evalfilePath)
     {
         if (f)
         {
@@ -255,7 +216,7 @@ void Network<Arch, Transformer>::verify(std::string                             
                                "including the directory name, to the network file.";
             std::string msg4 = "The default net can be downloaded from: "
                                "https://tests.stockfishchess.org/api/nn/"
-                             + evalFile.defaultName;
+                             + std::string(evalFile.defaultName);
             std::string msg5 = "The engine will be terminated now.";
 
             std::string msg = "ERROR: " + msg1 + '\n' + "ERROR: " + msg2 + '\n' + "ERROR: " + msg3
@@ -269,9 +230,9 @@ void Network<Arch, Transformer>::verify(std::string                             
 
     if (f)
     {
-        size_t size = sizeof(*featureTransformer) + sizeof(Arch) * LayerStacks;
+        size_t size = sizeof(featureTransformer) + sizeof(Arch) * LayerStacks;
         f("NNUE evaluation using " + evalfilePath + " (" + std::to_string(size / (1024 * 1024))
-          + "MiB, (" + std::to_string(featureTransformer->InputDimensions) + ", "
+          + "MiB, (" + std::to_string(featureTransformer.InputDimensions) + ", "
           + std::to_string(network[0].TransformedFeatureDimensions) + ", "
           + std::to_string(network[0].FC_0_OUTPUTS) + ", " + std::to_string(network[0].FC_1_OUTPUTS)
           + ", 1))");
@@ -306,7 +267,7 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
         const auto materialist =
-          featureTransformer->transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
+          featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
         const auto positional = network[bucket].propagate(transformedFeatures);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);
@@ -360,8 +321,7 @@ void Network<Arch, Transformer>::load_internal() {
 
 template<typename Arch, typename Transformer>
 void Network<Arch, Transformer>::initialize() {
-    featureTransformer = make_unique_large_page<Transformer>();
-    network            = make_unique_aligned<Arch[]>(LayerStacks);
+    initialized = true;
 }
 
 
@@ -384,6 +344,20 @@ std::optional<std::string> Network<Arch, Transformer>::load(std::istream& stream
     return read_parameters(stream, description) ? std::make_optional(description) : std::nullopt;
 }
 
+
+template<typename Arch, typename Transformer>
+std::size_t Network<Arch, Transformer>::get_content_hash() const {
+    if (!initialized)
+        return 0;
+
+    std::size_t h = 0;
+    hash_combine(h, featureTransformer);
+    for (auto&& layerstack : network)
+        hash_combine(h, layerstack);
+    hash_combine(h, evalFile);
+    hash_combine(h, static_cast<int>(embeddedType));
+    return h;
+}
 
 // Read network header
 template<typename Arch, typename Transformer>
@@ -418,13 +392,13 @@ bool Network<Arch, Transformer>::write_header(std::ostream&      stream,
 
 template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::read_parameters(std::istream& stream,
-                                                 std::string&  netDescription) const {
+                                                 std::string&  netDescription) {
     std::uint32_t hashValue;
     if (!read_header(stream, &hashValue, &netDescription))
         return false;
     if (hashValue != Network::hash)
         return false;
-    if (!Detail::read_parameters(stream, *featureTransformer))
+    if (!Detail::read_parameters(stream, featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {
@@ -440,7 +414,7 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
                                                   const std::string& netDescription) const {
     if (!write_header(stream, Network::hash, netDescription))
         return false;
-    if (!Detail::write_parameters(stream, *featureTransformer))
+    if (!Detail::write_parameters(stream, featureTransformer))
         return false;
     for (std::size_t i = 0; i < LayerStacks; ++i)
     {

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -19,16 +19,18 @@
 #ifndef NETWORK_H_INCLUDED
 #define NETWORK_H_INCLUDED
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <utility>
 
-#include "../memory.h"
+#include "../misc.h"
 #include "../types.h"
 #include "nnue_accumulator.h"
 #include "nnue_architecture.h"
@@ -48,6 +50,9 @@ enum class EmbeddedNNUEType {
 
 using NetworkOutput = std::tuple<Value, Value>;
 
+// The network must be a trivial type, i.e. the memory must be in-line.
+// This is required to allow sharing the network via shared memory, as
+// there is no way to run destructors.
 template<typename Arch, typename Transformer>
 class Network {
     static constexpr IndexType FTDimensions = Arch::TransformedFeatureDimensions;
@@ -57,14 +62,16 @@ class Network {
         evalFile(file),
         embeddedType(type) {}
 
-    Network(const Network& other);
-    Network(Network&& other) = default;
+    Network(const Network& other) = default;
+    Network(Network&& other)      = default;
 
-    Network& operator=(const Network& other);
-    Network& operator=(Network&& other) = default;
+    Network& operator=(const Network& other) = default;
+    Network& operator=(Network&& other)      = default;
 
     void load(const std::string& rootDirectory, std::string evalfilePath);
     bool save(const std::optional<std::string>& filename) const;
+
+    std::size_t get_content_hash() const;
 
     NetworkOutput evaluate(const Position&                         pos,
                            AccumulatorStack&                       accumulatorStack,
@@ -88,17 +95,19 @@ class Network {
     bool read_header(std::istream&, std::uint32_t*, std::string*) const;
     bool write_header(std::ostream&, std::uint32_t, const std::string&) const;
 
-    bool read_parameters(std::istream&, std::string&) const;
+    bool read_parameters(std::istream&, std::string&);
     bool write_parameters(std::ostream&, const std::string&) const;
 
     // Input feature converter
-    LargePagePtr<Transformer> featureTransformer;
+    Transformer featureTransformer;
 
     // Evaluation function
-    AlignedPtr<Arch[]> network;
+    Arch network[LayerStacks];
 
     EvalFile         evalFile;
     EmbeddedNNUEType embeddedType;
+
+    bool initialized = false;
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();
@@ -124,9 +133,9 @@ using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
 
 
 struct Networks {
-    Networks(NetworkBig&& nB, NetworkSmall&& nS) :
-        big(std::move(nB)),
-        small(std::move(nS)) {}
+    Networks(std::unique_ptr<NetworkBig>&& nB, std::unique_ptr<NetworkSmall>&& nS) :
+        big(std::move(*nB)),
+        small(std::move(*nS)) {}
 
     NetworkBig   big;
     NetworkSmall small;
@@ -134,5 +143,23 @@ struct Networks {
 
 
 }  // namespace Stockfish
+
+template<typename ArchT, typename FeatureTransformerT>
+struct std::hash<Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>> {
+    std::size_t operator()(
+      const Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>& network) const noexcept {
+        return network.get_content_hash();
+    }
+};
+
+template<>
+struct std::hash<Stockfish::Eval::NNUE::Networks> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
+        std::size_t h = 0;
+        Stockfish::hash_combine(h, networks.big);
+        Stockfish::hash_combine(h, networks.small);
+        return h;
+    }
+};
 
 #endif

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -86,17 +86,17 @@ void AccumulatorStack::reset(const Position&    rootPos,
 
     update_accumulator_refresh_cache<WHITE, TransformedFeatureDimensionsBig,
                                      &AccumulatorState::accumulatorBig>(
-      *networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
+      networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
     update_accumulator_refresh_cache<BLACK, TransformedFeatureDimensionsBig,
                                      &AccumulatorState::accumulatorBig>(
-      *networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
+      networks.big.featureTransformer, rootPos, m_accumulators[0], caches.big);
 
     update_accumulator_refresh_cache<WHITE, TransformedFeatureDimensionsSmall,
                                      &AccumulatorState::accumulatorSmall>(
-      *networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
+      networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
     update_accumulator_refresh_cache<BLACK, TransformedFeatureDimensionsSmall,
                                      &AccumulatorState::accumulatorSmall>(
-      *networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
+      networks.small.featureTransformer, rootPos, m_accumulators[0], caches.small);
 }
 
 void AccumulatorStack::push(const DirtyPiece& dirtyPiece) noexcept {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -97,7 +97,7 @@ struct AccumulatorCaches {
         void clear(const Network& network) {
             for (auto& entries1D : entries)
                 for (auto& entry : entries1D)
-                    entry.clear(network.featureTransformer->biases);
+                    entry.clear(network.featureTransformer.biases);
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -91,7 +91,7 @@ struct NetworkArchitecture {
             && fc_2.write_parameters(stream);
     }
 
-    std::int32_t propagate(const TransformedFeatureType* transformedFeatures) {
+    std::int32_t propagate(const TransformedFeatureType* transformedFeatures) const {
         struct alignas(CacheLineSize) Buffer {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
@@ -130,8 +130,28 @@ struct NetworkArchitecture {
 
         return outputValue;
     }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, fc_0.get_content_hash());
+        hash_combine(h, ac_sqr_0.get_content_hash());
+        hash_combine(h, ac_0.get_content_hash());
+        hash_combine(h, fc_1.get_content_hash());
+        hash_combine(h, ac_1.get_content_hash());
+        hash_combine(h, fc_2.get_content_hash());
+        hash_combine(h, get_hash_value());
+        return h;
+    }
 };
 
 }  // namespace Stockfish::Eval::NNUE
+
+template<Stockfish::Eval::NNUE::IndexType L1, int L2, int L3>
+struct std::hash<Stockfish::Eval::NNUE::NetworkArchitecture<L1, L2, L3>> {
+    std::size_t
+    operator()(const Stockfish::Eval::NNUE::NetworkArchitecture<L1, L2, L3>& arch) const noexcept {
+        return arch.get_content_hash();
+    }
+};
 
 #endif  // #ifndef NNUE_ARCHITECTURE_H_INCLUDED

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -254,8 +254,8 @@ inline void write_leb_128(std::ostream& stream, const IntType* values, std::size
         }
     };
 
-    auto write = [&](std::uint8_t byte) {
-        buf[buf_pos++] = byte;
+    auto write = [&](std::uint8_t b) {
+        buf[buf_pos++] = b;
         if (buf_pos == BUF_SIZE)
             flush();
     };

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -321,18 +321,26 @@ class FeatureTransformer {
     }
 
     // Write network parameters
-    bool write_parameters(std::ostream& stream) {
+    bool write_parameters(std::ostream& stream) const {
+        std::unique_ptr<FeatureTransformer> copy = std::make_unique<FeatureTransformer>(*this);
 
-        unpermute_weights();
-        scale_weights(false);
+        copy->unpermute_weights();
+        copy->scale_weights(false);
 
-        write_leb_128<BiasType>(stream, biases, HalfDimensions);
-        write_leb_128<WeightType>(stream, weights, HalfDimensions * InputDimensions);
-        write_leb_128<PSQTWeightType>(stream, psqtWeights, PSQTBuckets * InputDimensions);
+        write_leb_128<BiasType>(stream, copy->biases, HalfDimensions);
+        write_leb_128<WeightType>(stream, copy->weights, HalfDimensions * InputDimensions);
+        write_leb_128<PSQTWeightType>(stream, copy->psqtWeights, PSQTBuckets * InputDimensions);
 
-        permute_weights();
-        scale_weights(true);
         return !stream.fail();
+    }
+
+    std::size_t get_content_hash() const {
+        std::size_t h = 0;
+        hash_combine(h, get_raw_data_hash(biases));
+        hash_combine(h, get_raw_data_hash(weights));
+        hash_combine(h, get_raw_data_hash(psqtWeights));
+        hash_combine(h, get_hash_value());
+        return h;
     }
 
     // Convert input features
@@ -470,5 +478,15 @@ class FeatureTransformer {
 };
 
 }  // namespace Stockfish::Eval::NNUE
+
+
+template<Stockfish::Eval::NNUE::IndexType TransformedFeatureDimensions>
+struct std::hash<Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>> {
+    std::size_t
+    operator()(const Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>& ft)
+      const noexcept {
+        return ft.get_content_hash();
+    }
+};
 
 #endif  // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -120,12 +120,12 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             format_cp_compact(value, &board[y + 2][x + 2], pos);
     };
 
-    AccumulatorStack accumulators;
-    accumulators.reset(pos, networks, caches);
+    auto accumulators = std::make_unique<AccumulatorStack>();
+    accumulators->reset(pos, networks, caches);
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    auto [psqt, positional] = networks.big.evaluate(pos, accumulators, &caches.big);
+    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, &caches.big);
     Value base              = psqt + positional;
     base                    = pos.side_to_move() == WHITE ? base : -base;
 
@@ -140,8 +140,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
             {
                 pos.remove_piece(sq);
 
-                accumulators.reset(pos, networks, caches);
-                std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, &caches.big);
+                accumulators->reset(pos, networks, caches);
+                std::tie(psqt, positional) = networks.big.evaluate(pos, *accumulators, &caches.big);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
                 v                          = base - eval;
@@ -157,8 +157,8 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
         ss << board[row] << '\n';
     ss << '\n';
 
-    accumulators.reset(pos, networks, caches);
-    auto t = networks.big.trace_evaluate(pos, accumulators, &caches.big);
+    accumulators->reset(pos, networks, caches);
+    auto t = networks.big.trace_evaluate(pos, *accumulators, &caches.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -20,8 +20,10 @@
 #define NNUE_MISC_H_INCLUDED
 
 #include <cstddef>
+#include <memory>
 #include <string>
 
+#include "../misc.h"
 #include "../types.h"
 #include "nnue_architecture.h"
 
@@ -31,16 +33,16 @@ class Position;
 
 namespace Eval::NNUE {
 
+// EvalFile uses fixed string types because it's part of the network structure which must be trivial.
 struct EvalFile {
     // Default net name, will use one of the EvalFileDefaultName* macros defined
     // in evaluate.h
-    std::string defaultName;
+    FixedString<256> defaultName;
     // Selected net name, either via uci option or default
-    std::string current;
+    FixedString<256> current;
     // Net description extracted from the net file
-    std::string netDescription;
+    FixedString<256> netDescription;
 };
-
 
 struct NnueEvalTrace {
     static_assert(LayerStacks == PSQTBuckets);
@@ -57,5 +59,16 @@ std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& ca
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish
+
+template<>
+struct std::hash<Stockfish::Eval::NNUE::EvalFile> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::EvalFile& evalFile) const noexcept {
+        std::size_t h = 0;
+        Stockfish::hash_combine(h, evalFile.defaultName);
+        Stockfish::hash_combine(h, evalFile.current);
+        Stockfish::hash_combine(h, evalFile.netDescription);
+        return h;
+    }
+};
 
 #endif  // #ifndef NNUE_MISC_H_INCLUDED

--- a/src/search.h
+++ b/src/search.h
@@ -134,19 +134,19 @@ struct LimitsType {
 // The UCI stores the uci options, thread pool, and transposition table.
 // This struct is used to easily forward data to the Search::Worker class.
 struct SharedState {
-    SharedState(const OptionsMap&                               optionsMap,
-                ThreadPool&                                     threadPool,
-                TranspositionTable&                             transpositionTable,
-                const LazyNumaReplicated<Eval::NNUE::Networks>& nets) :
+    SharedState(const OptionsMap&                                         optionsMap,
+                ThreadPool&                                               threadPool,
+                TranspositionTable&                                       transpositionTable,
+                const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nets) :
         options(optionsMap),
         threads(threadPool),
         tt(transpositionTable),
         networks(nets) {}
 
-    const OptionsMap&                               options;
-    ThreadPool&                                     threads;
-    TranspositionTable&                             tt;
-    const LazyNumaReplicated<Eval::NNUE::Networks>& networks;
+    const OptionsMap&                                         options;
+    ThreadPool&                                               threads;
+    TranspositionTable&                                       tt;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
 };
 
 class Worker;
@@ -347,10 +347,10 @@ class Worker {
 
     Tablebases::Config tbConfig;
 
-    const OptionsMap&                               options;
-    ThreadPool&                                     threads;
-    TranspositionTable&                             tt;
-    const LazyNumaReplicated<Eval::NNUE::Networks>& networks;
+    const OptionsMap&                                         options;
+    ThreadPool&                                               threads;
+    TranspositionTable&                                       tt;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
 
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;


### PR DESCRIPTION
## Summary
- integrate the upstream shared-memory NNUE infrastructure and hashing utilities
- replicate NNUE networks system-wide through LazyNumaReplicatedSystemWide and report allocation status
- extend memory helpers to negotiate Windows large-page privileges for shared network buffers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e76469eac83278b7765647bfc2770)