### PR TITLE
Avoid requests dependency in Syzygy downloader

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -14,7 +14,7 @@ import pathlib
 import concurrent.futures
 import tempfile
 import shutil
-import requests
+import urllib.request
 
 CYAN_COLOR = "\033[36m"
 GRAY_COLOR = "\033[2m"
@@ -99,10 +99,10 @@ class Syzygy:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tarball_path = os.path.join(tmpdirname, f"{file}.tar.gz")
 
-                response = requests.get(url, stream=True)
-                with open(tarball_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
+                with urllib.request.urlopen(url) as response, open(
+                    tarball_path, "wb"
+                ) as f:
+                    shutil.copyfileobj(response, f)
 
                 with tarfile.open(tarball_path, "r:gz") as tar:
                     tar.extractall(tmpdirname)


### PR DESCRIPTION
## Summary
- replace the `requests` dependency in the Syzygy download helper with Python's built-in `urllib.request`
- stream the downloaded tarball to disk using `shutil.copyfileobj`

## Testing
- python -m compileall tests/testing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e845e26dc83279b52e319c6c01a7c)