### PR TITLE
Fix hash specialization for FeatureTransformer

### DIFF
--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -480,13 +480,18 @@ class FeatureTransformer {
 }  // namespace Stockfish::Eval::NNUE
 
 
-template<Stockfish::Eval::NNUE::IndexType TransformedFeatureDimensions>
-struct std::hash<Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>> {
-    std::size_t
-    operator()(const Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions>& ft)
+namespace std {
+
+template<Stockfish::Eval::NNUE::IndexType TransformedFeatureDimensions,
+         Stockfish::Eval::NNUE::Accumulator<TransformedFeatureDimensions>
+           Stockfish::Eval::NNUE::AccumulatorState::*accPtr>
+struct hash<Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions, accPtr>> {
+    std::size_t operator()(const Stockfish::Eval::NNUE::FeatureTransformer<TransformedFeatureDimensions, accPtr>& ft)
       const noexcept {
         return ft.get_content_hash();
     }
 };
+
+}  // namespace std
 
 #endif  // #ifndef NNUE_FEATURE_TRANSFORMER_H_INCLUDED


### PR DESCRIPTION
## Summary
- provide the missing template parameter in the `std::hash` specialization for `FeatureTransformer`
- wrap the specialization within `namespace std` so it properly customizes the standard hash

## Testing
- make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" *(fails: `clang++` not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e856a0b808327bf5e0084fb968c90)