### PR TITLE
Allow retrieving string values from non-button options

### DIFF
--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -146,7 +146,9 @@ Option::operator int() const {
 }
 
 Option::operator std::string() const {
-    assert(type == "string");
+
+    assert(type != "button");
+
     return currentValue;
 }
 


### PR DESCRIPTION
## Summary
- allow Option::operator std::string() to return the stored value for any non-button option type instead of asserting on strings only
- keep returning the current value so callers can obtain combo, spin, or check option values without tripping debug assertions

## Testing
- make build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69121f03e8a88327acc8c504ddb6be38)