### PR TITLE
Guard has_utf8_hint for non-Windows builds

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -77,10 +77,12 @@ std::string to_lower_ascii(std::string_view input) {
     return lowered;
 }
 
+#if !defined(_WIN32)
 bool has_utf8_hint(std::string_view value) {
     const auto lowered = to_lower_ascii(value);
     return lowered.find("utf-8") != std::string::npos || lowered.find("utf8") != std::string::npos;
 }
+#endif
 
 std::string_view select_logo_from_environment() {
     if (const char* style_env = std::getenv("REVOLUTION_LOGO_STYLE"))


### PR DESCRIPTION
## Summary
- wrap the `has_utf8_hint` helper in a non-Windows guard since it is only used on POSIX builds

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691223224bb0832793eb0b1150541cef)