### PR TITLE
Add minimalist logo and new UCI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # revolution-3.50-131125
 
+<p align="center">
+  <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
+</p>
+
 Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **revolution-3.50-131125 - UCI chess engine** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview

--- a/assets/revolution-logo.svg
+++ b/assets/revolution-logo.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80" role="img" aria-labelledby="title desc">
+  <title id="title">Revolution Chess Engine Logo</title>
+  <desc id="desc">Minimal tricolor cockade inspired by the French Revolution next to a stylized rook silhouette.</desc>
+  <defs>
+    <linearGradient id="tricolor" x1="0%" x2="100%" y1="0%" y2="0%">
+      <stop offset="0%" stop-color="#0055A4"/>
+      <stop offset="50%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#EF4135"/>
+    </linearGradient>
+  </defs>
+  <rect width="240" height="80" fill="none" rx="8" ry="8" stroke="#0f172a" stroke-width="2"/>
+  <g transform="translate(32 40)">
+    <circle r="26" fill="url(#tricolor)" stroke="#0f172a" stroke-width="3"/>
+    <circle r="12" fill="#0f172a"/>
+    <circle r="5" fill="#facc15"/>
+  </g>
+  <g transform="translate(120 16)" fill="#0f172a">
+    <path d="M0 48h36v8H0zm6-4h24l4-28h-8l-1.5-8h-13l-1.5 8h-8z"/>
+    <rect x="12" y="0" width="12" height="8" rx="2"/>
+  </g>
+  <text x="160" y="48" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="20" font-weight="600" fill="#0f172a">
+    Revolution
+  </text>
+  <text x="160" y="64" font-family="'Montserrat', 'Segoe UI', sans-serif" font-size="11" fill="#475569" letter-spacing="0.1em">
+    UCI CHESS ENGINE
+  </text>
+</svg>

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -109,6 +109,10 @@ Engine::Engine(std::optional<std::string> path) :
 
     options.add("Move Overhead", Option(10, 0, 5000));
 
+    options.add("Minimum Thinking Time", Option(100, 0, 5000));
+
+    options.add("Slow Mover", Option(100, 10, 1000));
+
     options.add("nodestime", Option(0, 0, 10000));
 
     options.add("UCI_Chess960", Option(false));


### PR DESCRIPTION
## Summary
- add a minimalist French Revolution-inspired SVG logo and surface it on the README cover section
- introduce Minimum Thinking Time and Slow Mover UCI spin options with their requested ranges
- store the reusable SVG asset in the repository

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ea9d93988327ab9af058f40a359c)