### PR TITLE
Normalize book extension detection for case-insensitive matching

### DIFF
--- a/src/book/book.cpp
+++ b/src/book/book.cpp
@@ -4,18 +4,27 @@
 #include "ctg/ctg.h"
 #include "book.h"
 
+#include <cctype>
+#include <filesystem>
+
 namespace Stockfish {
 namespace Book {
 /*static*/ Book* Book::create_book(const std::string& filename) {
-    size_t extIndex = filename.find_last_of('.');
-    if (extIndex == std::string::npos)
+    const auto extension = std::filesystem::path(filename).extension().string();
+
+    if (extension.empty())
         return nullptr;
 
-    std::string ext = filename.substr(extIndex + 1);
+    std::string normalized = extension;
+    if (!normalized.empty() && normalized.front() == '.')
+        normalized.erase(0, 1);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
 
-    if (ext == "ctg" || ext == "cto" || ext == "ctb")
+    if (normalized == "ctg" || normalized == "cto" || normalized == "ctb")
         return new CTG::CtgBook();
-    else if (ext == "bin")
+    else if (normalized == "bin")
         return new Polyglot::PolyglotBook();
     else
         return nullptr;


### PR DESCRIPTION
## Summary
- normalize book file extensions before dispatching to ensure CTG/CTO/CTB/BIN files are recognized regardless of case
- include the required headers for the new normalization logic

## Testing
- make -C src build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" -j4

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691554a96b94832798690b72b075e00f)