### PR TITLE
Fix path separator replacement on Windows builds

### DIFF
--- a/src/book/book_utils.cpp
+++ b/src/book/book_utils.cpp
@@ -29,7 +29,8 @@ std::string unquote(std::string s) {
 
 std::filesystem::path make_path(const std::string& path) {
     std::string cleaned = unquote(path);
-    std::replace(cleaned.begin(), cleaned.end(), '\\', std::filesystem::path::preferred_separator);
+    std::replace(cleaned.begin(), cleaned.end(), '\\',
+                 static_cast<char>(std::filesystem::path::preferred_separator));
     std::filesystem::path p(cleaned);
 
     if (p.is_relative())


### PR DESCRIPTION
## Summary
- cast the preferred separator to char when normalizing book utility paths

## Testing
- make -C src build ARCH=x86-64-sse41-popcnt COMP=clang -j4 *(fails: clang++ missing in container and required NNUE downloads unavailable)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69155849ac3c8327bd3af3b4b21e5aef)