### PR TITLE
Fix undefined behavior in NNUE accumulator initialization

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -78,8 +78,8 @@ struct AccumulatorCaches {
             void clear(const std::array<BiasType, Size>& biases) {
 
                 accumulation = biases;
-                std::memset((uint8_t*) this + offsetof(Entry, psqtAccumulation), 0,
-                            sizeof(Entry) - offsetof(Entry, psqtAccumulation));
+                std::memset(reinterpret_cast<std::byte*>(this) + offsetof(Entry, psqtAccumulation),
+                            0, sizeof(Entry) - offsetof(Entry, psqtAccumulation));
             }
         };
 


### PR DESCRIPTION
## Summary
- replace the uint8_t pointer aliasing in NNUE accumulator entry clearing with a std::byte pointer to avoid undefined behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69176b2f3a70832785ae23ae22e1e436)