### PR TITLE
Apply material key consistency patch

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -336,8 +336,8 @@ void Position::set_check_info() const {
 // The function is only used when a new position is set up
 void Position::set_state() const {
 
-    st->key = st->materialKey = 0;
-    st->minorPieceKey         = 0;
+    st->key               = 0;
+    st->minorPieceKey     = 0;
     st->nonPawnKey[WHITE] = st->nonPawnKey[BLACK] = 0;
     st->pawnKey                                   = Zobrist::noPawns;
     st->nonPawnMaterial[WHITE] = st->nonPawnMaterial[BLACK] = VALUE_ZERO;
@@ -375,10 +375,15 @@ void Position::set_state() const {
         st->key ^= Zobrist::side;
 
     st->key ^= Zobrist::castling[st->castlingRights];
+    st->materialKey = compute_material_key();
+}
 
+Key Position::compute_material_key() const {
+    Key k = 0;
     for (Piece pc : Pieces)
         for (int cnt = 0; cnt < pieceCount[pc]; ++cnt)
-            st->materialKey ^= Zobrist::psq[pc][8 + cnt];
+            k ^= Zobrist::psq[pc][8 + cnt];
+    return k;
 }
 
 
@@ -1432,6 +1437,9 @@ void Position::flip() {
 }
 
 
+bool Position::material_key_is_ok() const { return compute_material_key() == st->materialKey; }
+
+
 // Performs some consistency checks for the position object
 // and raise an assert if something wrong is detected.
 // This is meant to be helpful when debugging.
@@ -1480,6 +1488,8 @@ bool Position::pos_is_ok() const {
                 || (castlingRightsMask[square<KING>(c)] & cr) != cr)
                 assert(0 && "pos_is_ok: Castling");
         }
+
+    assert(material_key_is_ok() && "pos_is_ok: materialKey");
 
     return true;
 }

--- a/src/position.h
+++ b/src/position.h
@@ -163,6 +163,7 @@ class Position {
 
     // Position consistency check, for debugging
     bool pos_is_ok() const;
+    bool material_key_is_ok() const;
     void flip();
 
     StateInfo* state() const;
@@ -174,6 +175,7 @@ class Position {
    private:
     // Initialization helpers (used while setting up a position)
     void set_castling_right(Color c, Square rfrom);
+    Key  compute_material_key() const;
     void set_state() const;
     void set_check_info() const;
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1214,6 +1214,8 @@ template<TBType Type>
 void* mapped(TBTable<Type>& e, const Position& pos) {
 
     static std::mutex mutex;
+    // Because TB is the only usage of materialKey, check it here in debug mode
+    assert(pos.material_key_is_ok());
 
     // Use 'acquire' to avoid a thread reading 'ready' == true while
     // another is still working. (compiler reordering may cause this).


### PR DESCRIPTION
## Summary
- reset state material-related keys via helper functions when setting up a position
- add a dedicated material key computation routine and expose a debug helper to validate it
- assert on material key mismatches from both Position::pos_is_ok and the Syzygy TB probe code

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919361376488327a5bed7e0a4711d72)