### PR TITLE
Rebrand engine to Revolution-3.60-181125

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution-3.50-131125.exe
+        EXE = Revolution-3.60-181125.exe
 else
-        EXE = revolution-3.50-131125
+        EXE = Revolution-3.60-181125
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -38,8 +38,10 @@ namespace Stockfish {
 namespace {
 
 // Revolution engine identification strings.
-constexpr std::string_view kEngineNameShort = "revolution-3.50-131125";
-constexpr std::string_view kEngineDisplayName = "revolution-3.50-131125 - UCI chess engine";
+constexpr std::string_view kEngineNameShort    = "Revolution-3.60-181125";
+constexpr std::string_view kEngineDisplayName  = "Revolution-3.60-181125 - UCI chess engine";
+constexpr std::string_view kEngineUciHeader    =
+    "Revolution-3.60 Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -120,8 +122,11 @@ std::string engine_version_info() {
 std::string engine_info(bool to_uci) {
     constexpr std::string_view kAuthorLine =
         "Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
-    return std::string(kEngineDisplayName) + (to_uci ? "\nid author " : "\n")
-         + std::string(kAuthorLine);
+
+    if (to_uci)
+        return std::string(kEngineUciHeader);
+
+    return std::string(kEngineDisplayName) + "\n" + std::string(kAuthorLine);
 }
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -206,7 +206,7 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nrevolution-3.50-131125 is a UCI chess engine derived from Stockfish."
+              << "\nRevolution-3.60-181125 is a UCI chess engine derived from Stockfish."
                  "\nIt is released as free software licensed under the GNU GPLv3 License."
                  "\nRevolution UCI Chess Engines develops structural changes and explores new ideas"
                  "\nto improve the project while complying with the applicable license requirements."


### PR DESCRIPTION
## Summary
- update engine identification strings and UCI header to the Revolution-3.60-181125 branding
- refresh the UCI help message to mention the new version
- set the build executable name in the makefile to the new release identifier

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2c57a8908327ac49590b5fc26e8e)