### PR TITLE
Rename built executable to stockfish

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Revolution-3.60-181125.exe
+        EXE = stockfish.exe
 else
-        EXE = Revolution-3.60-181125
+        EXE = stockfish
 endif
 
 ### Installation dir definitions


### PR DESCRIPTION
## Summary
- rename the built executable to `stockfish` so scripts expect the correct binary name

## Testing
- make clean
- make build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c2f7013e883278993220297e45fe1)