### PR TITLE
Rebrand engine build and version metadata

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -38,10 +38,12 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
+ENGINE = Revolution-3.60-181125
+
 ifeq ($(target_windows),yes)
-        EXE = stockfish.exe
+        EXE = $(ENGINE).exe
 else
-        EXE = stockfish
+        EXE = $(ENGINE)
 endif
 
 ### Installation dir definitions
@@ -885,8 +887,8 @@ endif
 ### ==========================================================================
 
 help:
-	@echo "" && \
-	echo "To compile stockfish, type: " && \
+        @echo "" && \
+        echo "To compile $(ENGINE), type: " && \
 	echo "" && \
 	echo "make -j target [ARCH=arch] [COMP=compiler] [COMPCXX=cxx]" && \
 	echo "" && \
@@ -1003,17 +1005,17 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+        @rm -f $(ENGINE) $(ENGINE).exe $(EXE) *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
-	@rm -rf profdir
-	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f stockfish.profdata *.profraw
-	@rm -f stockfish.*args*
-	@rm -f stockfish.*lt*
-	@rm -f stockfish.res
-	@rm -f ./-lstdc++.res
+        @rm -rf profdir
+        @rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
+        @rm -f $(ENGINE).profdata *.profraw
+        @rm -f $(ENGINE).*args*
+        @rm -f $(ENGINE).*lt*
+        @rm -f $(ENGINE).res
+        @rm -f ./-lstdc++.res
 
 # evaluation network (nnue)
 net:
@@ -1110,11 +1112,11 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
-	EXTRALDFLAGS='-fprofile-use ' \
-	all
+        $(XCRUN) $(LLVM_PROFDATA) merge -output=$(ENGINE).profdata *.profraw
+        $(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+        EXTRACXXFLAGS='-fprofile-use=$(ENGINE).profdata' \
+        EXTRALDFLAGS='-fprofile-use ' \
+        all
 
 gcc-profile-make:
 	@mkdir -p profdir
@@ -1138,11 +1140,11 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
-	EXTRALDFLAGS='-fprofile-use ' \
-	all
+        $(XCRUN) $(LLVM_PROFDATA) merge -output=$(ENGINE).profdata *.profraw
+        $(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+        EXTRACXXFLAGS='-fprofile-instr-use=$(ENGINE).profdata' \
+        EXTRALDFLAGS='-fprofile-use ' \
+        all
 
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -42,6 +42,8 @@ constexpr std::string_view kEngineNameShort    = "Revolution-3.60-181125";
 constexpr std::string_view kEngineDisplayName  = "Revolution-3.60-181125 - UCI chess engine";
 constexpr std::string_view kEngineUciHeader    =
     "Revolution-3.60 Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
+constexpr std::string_view kEngineAnalysisTag =
+    "Revolution-3.60-181125 (update scripts Revolution-3.60-181125)";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -116,7 +118,7 @@ class Logger {
 
 // Returns the short public identification string for the Revolution engine.
 std::string engine_version_info() {
-    return std::string(kEngineNameShort);
+    return std::string(kEngineAnalysisTag);
 }
 
 std::string engine_info(bool to_uci) {


### PR DESCRIPTION
## Summary
- set the build executable name to Revolution-3.60-181125 and update clean/profile targets accordingly
- update UCI branding strings to include the requested analysis tag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c34c3c37083279b5b5f279baad329)