### PR TITLE
Fix UCI engine name string

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -40,8 +40,7 @@ namespace {
 // Revolution engine identification strings.
 constexpr std::string_view kEngineNameShort    = "Revolution-3.60-181125";
 constexpr std::string_view kEngineDisplayName  = "Revolution-3.60-181125 - UCI chess engine";
-constexpr std::string_view kEngineUciHeader    =
-    "Revolution-3.60 Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
+constexpr std::string_view kEngineUciHeader    = kEngineNameShort;
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We


### PR DESCRIPTION
## Summary
- align UCI-reported engine name with Revolution-3.60-181125 identifier

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4a188bf88327a81f72d38f4382cb)