### PR TITLE
Handle storage directory without exceptions

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -45,16 +45,19 @@ void LearningData::set_storage_directory(std::string path) {
         return;
     }
 
-    try
-    {
-        storageRoot = std::filesystem::path(std::move(path));
-    }
-    catch (const std::filesystem::filesystem_error& e)
+    std::filesystem::path newStorageRoot(std::move(path));
+    std::error_code       ec;
+    std::filesystem::status(newStorageRoot, ec);
+
+    if (ec)
     {
         storageRoot.clear();
-        std::cerr << "info string Failed to set experience storage directory: " << e.what()
+        std::cerr << "info string Failed to set experience storage directory: " << ec.message()
                   << std::endl;
+        return;
     }
+
+    storageRoot = std::move(newStorageRoot);
 }
 
 std::filesystem::path LearningData::resolve_path(const std::string& filename) const {


### PR DESCRIPTION
## Summary
- replace the learning storage path setup with non-throwing filesystem status handling so builds with exceptions disabled succeed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c63ece8c8832790db44561fcf16e9)