### PR TITLE
Add UCI author identification for Fritz compatibility

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -41,6 +41,7 @@ namespace {
 constexpr std::string_view kEngineNameShort    = "Revolution-3.60-181125";
 constexpr std::string_view kEngineDisplayName  = "Revolution-3.60-181125 - UCI chess engine";
 constexpr std::string_view kEngineUciHeader    = kEngineNameShort;
+constexpr std::string_view kEngineAuthor       = "Jorge Ruiz, Stockfish developers";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -126,6 +127,11 @@ std::string engine_info(bool to_uci) {
         return std::string(kEngineUciHeader);
 
     return std::string(kEngineDisplayName) + "\n" + std::string(kAuthorLine);
+}
+
+// Returns the authors string used in the UCI handshake.
+std::string engine_author_info() {
+    return std::string(kEngineAuthor);
 }
 
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -43,6 +43,7 @@ namespace Stockfish {
 
 std::string engine_version_info();
 std::string engine_info(bool to_uci = false);
+std::string engine_author_info();
 std::string compiler_info();
 
 // Preloads the given address in L1/L2 cache. This is a non-blocking

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -134,6 +134,7 @@ void UCIEngine::loop() {
         else if (token == "uci")
         {
             sync_cout << "id name " << engine_info(true) << "\n"
+                      << "id author " << engine_author_info() << "\n"
                       << engine.get_options() << sync_endl;
 
             sync_cout << "uciok" << sync_endl;


### PR DESCRIPTION
## Summary
- add an explicit author string for the UCI handshake
- include the author line in the engine's UCI identification to satisfy GUIs

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c68c607e88327888b94faa7a06cb6)