### PR TITLE
Rebrand to Revolution-3.60-221125

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# revolution-3.50-131125
+# Revolution-3.60-221125
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **revolution-3.50-131125 - UCI chess engine** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.60-221125 (update scripts Revolution-3.60-221125)** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = revolution-3.50-131125.exe
+        EXE = Revolution-3.60-221125.exe
 else
-        EXE = revolution-3.50-131125
+        EXE = Revolution-3.60-221125
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -38,8 +38,10 @@ namespace Stockfish {
 namespace {
 
 // Revolution engine identification strings.
-constexpr std::string_view kEngineNameShort = "revolution-3.50-131125";
-constexpr std::string_view kEngineDisplayName = "revolution-3.50-131125 - UCI chess engine";
+constexpr std::string_view kEngineNameShort = "Revolution-3.60-221125";
+constexpr std::string_view kEngineDisplayName =
+    "Revolution-3.60-221125 (update scripts Revolution-3.60-221125)";
+constexpr std::string_view kEngineHeader = "Revolution-3.60";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -120,8 +122,10 @@ std::string engine_version_info() {
 std::string engine_info(bool to_uci) {
     constexpr std::string_view kAuthorLine =
         "Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
-    return std::string(kEngineDisplayName) + (to_uci ? "\nid author " : "\n")
-         + std::string(kAuthorLine);
+    if (to_uci)
+        return std::string(kEngineDisplayName) + "\nid author " + std::string(kAuthorLine);
+
+    return std::string(kEngineHeader) + " " + std::string(kAuthorLine);
 }
 
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -206,7 +206,8 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nrevolution-3.50-131125 is a UCI chess engine derived from Stockfish."
+              << "\nRevolution-3.60-221125 (update scripts Revolution-3.60-221125) is a UCI chess engine"
+                 " derived from Stockfish."
                  "\nIt is released as free software licensed under the GNU GPLv3 License."
                  "\nRevolution UCI Chess Engines develops structural changes and explores new ideas"
                  "\nto improve the project while complying with the applicable license requirements."


### PR DESCRIPTION
## Summary
- update engine branding to Revolution-3.60-221125, including UCI header and help text
- set build targets to produce Revolution-3.60-221125 binaries
- refresh README to describe the new release identifier

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e656badc8327a1c5ddbe987fce95)