### PR TITLE
Add fallback NNUE network when files are missing

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -134,6 +134,14 @@ void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
             }
         }
     }
+
+    if (std::string(evalFile.current) != evalfilePath)
+    {
+        sync_cout << "WARNING: Unable to load network file '" << evalfilePath
+                  << "'. Falling back to a zeroed placeholder network." << sync_endl;
+
+        use_dummy_network(evalfilePath);
+    }
 }
 
 
@@ -297,6 +305,19 @@ void Network<Arch, Transformer>::load_internal() {
         evalFile.current        = evalFile.defaultName;
         evalFile.netDescription = description.value();
     }
+}
+
+
+template<typename Arch, typename Transformer>
+void Network<Arch, Transformer>::use_dummy_network(const std::string& evalfilePath) {
+    initialize();
+
+    featureTransformer = Transformer{};
+    for (auto& layerstack : network)
+        layerstack = Arch{};
+
+    evalFile.current        = evalfilePath;
+    evalFile.netDescription = "Zero placeholder network";
 }
 
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -85,8 +85,9 @@ class Network {
                                  AccumulatorCaches::Cache<FTDimensions>* cache) const;
 
    private:
-    void load_user_net(const std::string&, const std::string&);
-    void load_internal();
+   void load_user_net(const std::string&, const std::string&);
+   void load_internal();
+    void use_dummy_network(const std::string& evalfilePath);
 
     void initialize();
 


### PR DESCRIPTION
## Summary
- warn when network files cannot be loaded and install a zeroed placeholder network instead
- reset feature transformers and layers to default data so evaluation can proceed even without downloaded nets

## Testing
- make build ARCH=x86-64


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921e75a3a7083279854ecefc2114d51)