### PR TITLE
Update branding to Revolution-3.60-221125

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.60-221125 (update scripts Revolution-3.60-221125)** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.60-221125** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -39,9 +39,8 @@ namespace {
 
 // Revolution engine identification strings.
 constexpr std::string_view kEngineNameShort = "Revolution-3.60-221125";
-constexpr std::string_view kEngineDisplayName =
-    "Revolution-3.60-221125 (update scripts Revolution-3.60-221125)";
-constexpr std::string_view kEngineHeader = "Revolution-3.60";
+constexpr std::string_view kEngineDisplayName = "Revolution-3.60-221125";
+constexpr std::string_view kEngineHeader = "Revolution-3.60-221125";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -206,8 +206,7 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nRevolution-3.60-221125 (update scripts Revolution-3.60-221125) is a UCI chess engine"
-                 " derived from Stockfish."
+              << "\nRevolution-3.60-221125 is a UCI chess engine derived from Stockfish."
                  "\nIt is released as free software licensed under the GNU GPLv3 License."
                  "\nRevolution UCI Chess Engines develops structural changes and explores new ideas"
                  "\nto improve the project while complying with the applicable license requirements."


### PR DESCRIPTION
## Summary
- set the engine identification strings and headers to Revolution-3.60-221125
- refresh the UCI help text and README description to match the new branding

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921ec65b6848327b6f6bcc786366826)