### PR TITLE
Guard clang version detection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -679,12 +679,15 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(comp),clang)
-		clangmajorversion := $(shell $(CXX) -dumpversion 2>/dev/null | cut -f1 -d.)
-		ifeq ($(shell expr $(clangmajorversion) \< 16),1)
-			CXXFLAGS += -fexperimental-new-pass-manager
-		endif
-	endif
+        ifeq ($(comp),clang)
+                clangmajorversion := $(shell $(CXX) -dumpversion 2>/dev/null | cut -f1 -d.)
+
+                ifneq ($(clangmajorversion),)
+                        ifeq ($(shell expr $(clangmajorversion) \< 16),1)
+                                CXXFLAGS += -fexperimental-new-pass-manager
+                        endif
+                endif
+        endif
 endif
 
 ### 3.4 Bits


### PR DESCRIPTION
## Summary
- guard the clang version check in the Makefile so it skips when no version is detected

## Testing
- make build -j2
- make build -j2 COMP=clang (fails: clang++ not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f1fecacc8327abeb805f4ee9cd0d)