### PR TITLE
Add bench reference extraction to compilation workflow

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,7 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Extract the bench number from the commit history
+        run: |
+          for hash in $(git rev-list -100 HEAD); do
+            benchref=$(git show -s $hash | tac | grep -m 1 -o -x '[[:space:]]*\b[Bb]ench[ :]\+[1-9][0-9]\{5,7\}\b[[:space:]]*' | sed 's/[^0-9]//g') && break || true
+          done
+          [[ -n "$benchref" ]] && echo "benchref=$benchref" >> $GITHUB_ENV && echo "From commit: $hash" && echo "Reference bench: $benchref" || echo "No bench found"
 
       - name: Install fixed GCC on Linux
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- fetch the full git history during compilation workflow runs
- extract and export the latest bench reference so signature checks can compare against it

## Testing
- Not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926255a7dec83278b47923de7bc8a64)