### PR TITLE
Improve experience file loading safety and error reporting

### DIFF
--- a/src/learn/learn.h
+++ b/src/learn/learn.h
@@ -44,6 +44,9 @@ class LearningData {
     void               resume();
     [[nodiscard]] bool is_paused() const { return isPaused; }
 
+    [[nodiscard]] bool has_load_errors() const { return !loadErrors.empty(); }
+    [[nodiscard]] const std::vector<std::string>& get_load_errors() const { return loadErrors; }
+
     void quick_reset_exp();
     void set_learning_mode(OptionsMap& options, const std::string& mode);
     [[nodiscard]] LearningMode learning_mode() const;
@@ -65,7 +68,14 @@ class LearningData {
     static void               show_exp(const Position& pos);
 
    private:
+    static constexpr std::streamsize ExperienceEntrySize    = sizeof(PersistedLearningMove);
+    static constexpr int             ExperienceFileVersion  = 1;
     bool                        load(const std::filesystem::path& filename);
+    [[nodiscard]] bool         validate_file_size(const std::filesystem::path& filename,
+                                                  std::ifstream&               stream,
+                                                  std::streamoff               fileSize);
+    void                       record_load_error(const std::string& message);
+    void                       report_load_errors(const std::string& command) const;
     void                        insert_or_update(PersistedLearningMove* plm, bool qLearning);
     [[nodiscard]] std::filesystem::path resolve_path(const std::string& filename) const;
 
@@ -74,6 +84,7 @@ class LearningData {
     bool                                         isReadOnly;
     bool                                         needPersisting;
     LearningMode                                 learningMode;
+    std::vector<std::string>                     loadErrors;
     std::unordered_multimap<Key, LearningMove*>  HT;
     std::vector<void*>                           mainDataBuffers;
     std::vector<void*>                           newMovesDataBuffers;


### PR DESCRIPTION
## Summary
- validate experience files against the expected BrainLearn record format and track load errors before merging quality-indexed files
- provide clearer UCI command messaging for showexp and quickresetexp when experience data fails to load
- persist experience data through a temporary file with atomic replacement to reduce corruption risk

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b241b60c0832787b416ba50fc02c5)