### PR TITLE
Update Revolution branding to 3.70

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Revolution-3.60-221125.exe
+        EXE = Revolution-3.70-291125.exe
 else
-        EXE = Revolution-3.60-221125
+        EXE = Revolution-3.70-291125
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -38,9 +38,9 @@ namespace Stockfish {
 namespace {
 
 // Revolution engine identification strings.
-constexpr std::string_view kEngineNameShort = "Revolution-3.60-221125";
-constexpr std::string_view kEngineDisplayName = "Revolution-3.60-221125";
-constexpr std::string_view kEngineHeader = "Revolution-3.60-221125";
+constexpr std::string_view kEngineNameShort = "Revolution-3.760-291125";
+constexpr std::string_view kEngineDisplayName = "Revolution-3.70-291125";
+constexpr std::string_view kEngineHeader = "Revolution-3.70-291125";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -206,7 +206,7 @@ void UCIEngine::loop() {
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout
-              << "\nRevolution-3.60-221125 is a UCI chess engine derived from Stockfish."
+              << "\n" << engine_version_info() << " is a UCI chess engine derived from Stockfish."
                  "\nIt is released as free software licensed under the GNU GPLv3 License."
                  "\nRevolution UCI Chess Engines develops structural changes and explores new ideas"
                  "\nto improve the project while complying with the applicable license requirements."


### PR DESCRIPTION
## Summary
- update executable name in the Makefile to Revolution-3.70-291125
- refresh UCI-facing branding strings to the new Revolution-3.70-291125 and analysis identifier Revolution-3.760-291125

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b294da78c832783f8017b7c26ce84)