### PR TITLE
Add Zen4 architecture target

### DIFF
--- a/scripts/get_native_properties.sh
+++ b/scripts/get_native_properties.sh
@@ -39,7 +39,9 @@ set_arch_loongarch64() {
 
 # Set the file CPU x86_64 architecture
 set_arch_x86_64() {
-  if check_flags 'avx512f' 'avx512cd' 'avx512vl' 'avx512dq' 'avx512bw' 'avx512ifma' 'avx512vbmi' 'avx512vbmi2' 'avx512vpopcntdq' 'avx512bitalg' 'avx512vnni' 'vpclmulqdq' 'gfni' 'vaes'; then
+  if [ "$vendor_id" = "AuthenticAMD" ] && check_flags 'avx512f' 'avx512bw' 'avx512dq' 'avx512vl' 'avx2' 'bmi2'; then
+    true_arch='x86-64-zen4'
+  elif check_flags 'avx512f' 'avx512cd' 'avx512vl' 'avx512dq' 'avx512bw' 'avx512ifma' 'avx512vbmi' 'avx512vbmi2' 'avx512vpopcntdq' 'avx512bitalg' 'avx512vnni' 'vpclmulqdq' 'gfni' 'vaes'; then
     true_arch='x86-64-avx512icl'
   elif check_flags 'avx512vnni' 'avx512dq' 'avx512f' 'avx512bw' 'avx512vl'; then
     true_arch='x86-64-vnni512'
@@ -98,6 +100,8 @@ case $uname_s in
     case $uname_m in
       'x86_64')
         file_os='ubuntu'
+        vendor_id=$(awk '/^vendor_id/{print $3; exit}' /proc/cpuinfo)
+        cpu_family=$(awk '/^cpu family/{print $4; exit}' /proc/cpuinfo)
         check_znver_1_2
         set_arch_x86_64
         ;;
@@ -142,6 +146,8 @@ case $uname_s in
     ;;
   'CYGWIN'*|'MINGW'*|'MSYS'*) # Windows x86_64system with POSIX compatibility layer
     get_flags
+    vendor_id=$(awk '/^vendor_id/{print $3; exit}' /proc/cpuinfo)
+    cpu_family=$(awk '/^cpu family/{print $4; exit}' /proc/cpuinfo)
     check_znver_1_2
     set_arch_x86_64
     file_os='windows'

--- a/src/Makefile
+++ b/src/Makefile
@@ -133,7 +133,7 @@ endif
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-v4 x86-64-avxvnni \
+                 x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-zen4 x86-64-v4 x86-64-avxvnni \
                  x86-64-v3 x86-64-bmi2 x86-64-avx2 x86-64-FMA3 x86-64-v2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
@@ -250,6 +250,18 @@ ifeq ($(ARCH),x86-64-v3)
         avx2 = yes
         fma3 = yes
         pext = yes
+endif
+
+ifeq ($(ARCH),x86-64-zen4)
+        popcnt = yes
+        sse = yes
+        sse2 = yes
+        ssse3 = yes
+        sse41 = yes
+        avx2 = yes
+        fma3 = yes
+        pext = yes
+        avx512 = yes
 endif
 
 ifeq ($(findstring -avx2,$(ARCH)),-avx2)
@@ -791,10 +803,10 @@ ifeq ($(vnni512),yes)
 endif
 
 ifeq ($(avx512icl),yes)
-	CXXFLAGS += -DUSE_AVX512 -DUSE_VNNI -DUSE_AVX512ICL
-	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		CXXFLAGS += -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vpopcntdq -mavx512bitalg -mavx512vnni -mvpclmulqdq -mgfni -mvaes
-	endif
+        CXXFLAGS += -DUSE_AVX512 -DUSE_VNNI -DUSE_AVX512ICL
+        ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+                CXXFLAGS += -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mavx512ifma -mavx512vbmi -mavx512vbmi2 -mavx512vpopcntdq -mavx512bitalg -mavx512vnni -mvpclmulqdq -mgfni -mvaes
+        endif
 endif
 
 ifeq ($(sse41),yes)
@@ -955,16 +967,17 @@ help:
 	echo "Supported archs:" && \
 	echo "" && \
 	echo "native                  > select the best architecture for the host processor (default)" && \
-        echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
-        echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
-        echo "x86-64-v4               > x86 64-bit with avx512 baseline support" && \
-        echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
-        echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support" && \
-        echo "x86-64-v3               > x86 64-bit with avx2/bmi2/fma3 baseline" && \
-        echo "x86-64-avx2             > x86 64-bit with avx2 support" && \
-        echo "x86-64-v2               > x86 64-bit with sse4.1/popcnt baseline" && \
-        echo "x86-64-bmi2             > x86 64-bit with bmi2 support" && \
-        echo "x86-64-FMA3             > x86 64-bit with avx2 and fma3 support" && \
+	echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
+	echo "x86-64-zen4             > AMD Zen 4 with avx2/bmi2/fma3 and avx512 support" && \
+	echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
+	echo "x86-64-v4               > x86 64-bit with avx512 baseline support" && \
+	echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
+	echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support" && \
+	echo "x86-64-v3               > x86 64-bit with avx2/bmi2/fma3 baseline" && \
+	echo "x86-64-avx2             > x86 64-bit with avx2 support" && \
+	echo "x86-64-v2               > x86 64-bit with sse4.1/popcnt baseline" && \
+	echo "x86-64-bmi2             > x86 64-bit with bmi2 support" && \
+	echo "x86-64-FMA3             > x86 64-bit with avx2 and fma3 support" && \
         echo "x86-64-sse41-popcnt     > x86 64-bit with sse41 and popcnt support" && \
         echo "x86-64-modern           > deprecated, currently x86-64-sse41-popcnt" && \
 	echo "x86-64-ssse3            > x86 64-bit with ssse3 support" && \


### PR DESCRIPTION
## Summary
- add an x86-64-zen4 architecture preset enabling AVX2, BMI2, FMA3, and AVX-512 flags
- update native architecture detection to prefer the Zen 4 preset on AMD AVX-512 systems and refresh help output

## Testing
- cd src && make help | head -n 15


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0ac5a1ec83278c2751d257698d5e)