### PR TITLE
Reset live book fallback when no books are requested

### DIFF
--- a/src/book/book_manager.cpp
+++ b/src/book/book_manager.cpp
@@ -170,12 +170,15 @@ void BookManager::update_fallback_status(const OptionsMap& options) {
         }
     }
 
-    if (!hasBook && anyRequested && !liveBookFallback)
+    if (!hasBook && anyRequested)
     {
-        liveBookFallback = true;
-        sync_cout << "info string All CTG/BIN books failed, falling back to live book" << sync_endl;
+        if (!liveBookFallback)
+        {
+            liveBookFallback = true;
+            sync_cout << "info string All CTG/BIN books failed, falling back to live book" << sync_endl;
+        }
     }
-    else if (hasBook)
+    else
         liveBookFallback = false;
 }
 


### PR DESCRIPTION
## Summary
- ensure the live book fallback is turned off when no CTG/BIN books are configured
- keep fallback activation logging confined to first activation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0caa0c6083279a62b44f6d6c61c3)