### PR TITLE
Handle missing Wine for Windows profile builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1053,6 +1053,10 @@ ci-local: net
 	done
 
 profile-build: net config-sanity objclean profileclean
+	@if [ "$(target_windows)" = "yes" ] && [ -z "$(WINE_PATH)" ]; then \
+		echo "Error: profile-build for Windows targets requires Wine. Set WINE_PATH or install wine."; \
+		exit 1; \
+	fi
 	@echo ""
 	@echo "Step 1/4. Building instrumented executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)


### PR DESCRIPTION
## Summary
- add a guard in the profile-build target to fail fast when targeting Windows without Wine available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1108d3a88327b60d3f45a747f7f4)