### PR TITLE
Clarify Wine requirement for Windows profile builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ pacman -S --needed mingw-w64-clang-x86_64-toolchain mingw-w64-clang-x86_64-make 
 
 The `mingw-w64-clang-x86_64-toolchain` meta-package bundles `clang++` and `lld`, while `mingw-w64-clang-x86_64-make` supplies `make` for the MinGW environment. Using the `clang64` shell ensures the correct paths are set so the build command succeeds without additional flags.
 
-When running `profile-build` for Windows targets, Wine must also be available so the instrumented binary can execute during profile-guided optimization. Install Wine in the `clang64` environment with:
+When running `profile-build` for Windows targets **from Linux**, Wine must also be available so the instrumented binary can execute during profile-guided optimization. Install Wine in the `clang64` environment with:
 
 ```bash
 pacman -S --needed mingw-w64-clang-x86_64-wine

--- a/src/Makefile
+++ b/src/Makefile
@@ -1053,10 +1053,10 @@ ci-local: net
 	done
 
 profile-build: net config-sanity objclean profileclean
-	@if [ "$(target_windows)" = "yes" ] && [ -z "$(WINE_PATH)" ]; then \
-		echo "Error: profile-build for Windows targets requires Wine. Set WINE_PATH or install wine."; \
-		exit 1; \
-	fi
+@if [ "$(target_windows)" = "yes" ] && [ -z "$(WINE_PATH)" ] && [ "$(KERNEL)" = "Linux" ]; then \
+echo "Error: profile-build for Windows targets requires Wine on Linux hosts. Set WINE_PATH or install wine."; \
+exit 1; \
+fi
 	@echo ""
 	@echo "Step 1/4. Building instrumented executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)


### PR DESCRIPTION
## Summary
- require Wine for Windows `profile-build` targets only when running on Linux hosts
- clarify README to note Wine is only needed when invoking `profile-build` for Windows from Linux

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1a78e55c832796ba41169bfee994)