### PR TITLE
Fix profile-build target formatting

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1053,17 +1053,10 @@ ci-local: net
 	done
 
 profile-build: net config-sanity objclean profileclean
- codex/disable-wine-for-linux-builds-da8kwd
 	@if [ "$(target_windows)" = "yes" ] && [ -z "$(WINE_PATH)" ] && [ "$(KERNEL)" = "Linux" ]; then \
 	echo "Error: profile-build for Windows targets requires Wine on Linux hosts. Set WINE_PATH or install wine."; \
 	exit 1; \
 	fi
-=======
-@if [ "$(target_windows)" = "yes" ] && [ -z "$(WINE_PATH)" ] && [ "$(KERNEL)" = "Linux" ]; then \
-echo "Error: profile-build for Windows targets requires Wine on Linux hosts. Set WINE_PATH or install wine."; \
-exit 1; \
-fi
-main
 	@echo ""
 	@echo "Step 1/4. Building instrumented executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)


### PR DESCRIPTION
## Summary
- restore the profile-build target commands after removing stray corruption
- keep the profile-guided build steps intact for the Windows/Wine guard

## Testing
- make -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" (fails: clang++ not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1d8fd2c48327a6a4d84e62c21913)