### PR TITLE
Avoid static linking for clang Windows builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -521,7 +521,13 @@ ifeq ($(COMP),gcc)
 endif
 
 ifeq ($(target_windows),yes)
-	LDFLAGS += -static
+        # Clang/LLD generated Windows binaries can fail when fully static,
+        # especially under profiling builds. Avoid forcing -static in that
+        # configuration while keeping the current behavior for other
+        # toolchains.
+        ifneq ($(comp),clang)
+                LDFLAGS += -static
+        endif
 endif
 
 ifeq ($(COMP),mingw)


### PR DESCRIPTION
## Summary
- skip forced static linking when building Windows binaries with clang/LLD to avoid profile-build crashes

## Testing
- not run (clang toolchain not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1f38781083279d16f0e4484ac3a0)