### PR TITLE
Ensure comp is initialized before Windows static flag check

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -488,11 +488,15 @@ DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
 
 ifeq ($(COMP),)
-	COMP=gcc
+COMP=gcc
 endif
 
+# Ensure the lowercase helper variable is set before it is consulted in
+# platform-specific branches.
+comp ?= $(COMP)
+
 ifeq ($(COMP),gcc)
-	comp=gcc
+comp=gcc
 	CXX=g++
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-declarations -Wstack-usage=128000
 


### PR DESCRIPTION
## Summary
- initialize the lowercase `comp` variable before it is used in platform checks
- prevent Windows clang builds from incorrectly forcing static linking during profile builds

## Testing
- not run (environment lacks clang toolchain)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f22076f84832788e44c0cf89c02fd)