### PR TITLE
Handle missing NNUE networks during profile builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1067,20 +1067,25 @@ profile-build: net config-sanity objclean profileclean
 	echo "Error: profile-build for Windows targets requires Wine on Linux hosts. Set WINE_PATH or install wine."; \
 	exit 1; \
 	fi
-	@echo ""
-	@echo "Step 1/4. Building instrumented executable ..."
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
-	@echo ""
-	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	$(PGOBENCH) > PGOBENCH.out 2>&1
-	tail -n 4 PGOBENCH.out
-	@echo ""
-	@echo "Step 3/4. Building optimized executable ..."
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)
-	@echo ""
-	@echo "Step 4/4. Deleting profile data ..."
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
+	@if [ -z "$$(find . -maxdepth 1 -name '*.nnue' -size +0c -print -quit)" ]; then \
+	echo "NNUE network files are missing or empty; running a regular build instead of profile-build."; \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) build; \
+	else \
+	echo ""; \
+	echo "Step 1/4. Building instrumented executable ..."; \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make); \
+	echo ""; \
+	echo "Step 2/4. Running benchmark for pgo-build ..."; \
+	$(PGOBENCH) > PGOBENCH.out 2>&1; \
+	tail -n 4 PGOBENCH.out; \
+	echo ""; \
+	echo "Step 3/4. Building optimized executable ..."; \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean; \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use); \
+	echo ""; \
+		echo "Step 4/4. Deleting profile data ..."; \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean; \
+	fi
 
 strip:
 	$(STRIP) $(EXE)

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -58,6 +58,9 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
 
     assert(!pos.checkers());
 
+    if (!networks.big.has_weights() || !networks.small.has_weights())
+        return Value(simple_eval(pos));
+
     bool smallNet           = use_smallnet(pos);
     auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, accumulators, caches.small)
                                        : networks.big.evaluate(pos, accumulators, caches.big);

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -178,6 +178,12 @@ void Network<Arch, Transformer>::load(const std::string& rootDirectory, std::str
 
 
 template<typename Arch, typename Transformer>
+bool Network<Arch, Transformer>::has_weights() const noexcept {
+    return initialized && evalFile.netDescription != "Zero placeholder network";
+}
+
+
+template<typename Arch, typename Transformer>
 bool Network<Arch, Transformer>::save(const std::optional<std::string>& filename) const {
     std::string actualFilename;
     std::string msg;

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -79,6 +79,8 @@ class Network {
         evalFile(file),
         embeddedType(type) {}
 
+    [[nodiscard]] bool has_weights() const noexcept;
+
     Network(const Network& other) = default;
     Network(Network&& other)      = default;
 


### PR DESCRIPTION
## Summary
- short-circuit evaluation when NNUE networks are missing so the engine falls back to a simple evaluation
- expose network weight availability and reuse it to skip profile builds when NNUE files cannot be downloaded

## Testing
- make profile-build -j2 (fails earlier when networks are unavailable, so no further automated tests were run)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f22b6348c8327ab4c433f89d421c1)