### PR TITLE
Fix indentation in clang profile target

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1210,11 +1210,11 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-        $(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
-        $(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-        EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
-        EXTRALDFLAGS='-fprofile-use ' \
-        all
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
+	all
 
 gcc-profile-make:
 	@mkdir -p profdir


### PR DESCRIPTION
## Summary
- replace spaces with tabs in the clang-profile-use Makefile target to satisfy make requirements

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2b0f455883279415226f3857f8c1)