### PR TITLE
Fix tabs in profile build recipes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1076,14 +1076,14 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make); \
 	echo ""; \
 	echo "Step 2/4. Running benchmark for pgo-build ..."; \
-        LLVM_PROFILE_FILE=stockfish-%p.profraw $(PGOBENCH) > PGOBENCH.out 2>&1; \
-        tail -n 4 PGOBENCH.out; \
-        echo ""; \
-        echo "Step 3/4. Building optimized executable ..."; \
+	LLVM_PROFILE_FILE=stockfish-%p.profraw $(PGOBENCH) > PGOBENCH.out 2>&1; \
+	tail -n 4 PGOBENCH.out; \
+	echo ""; \
+	echo "Step 3/4. Building optimized executable ..."; \
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean; \
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use); \
 	echo ""; \
-		echo "Step 4/4. Deleting profile data ..."; \
+	echo "Step 4/4. Deleting profile data ..."; \
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean; \
 	fi
 
@@ -1238,11 +1238,11 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-        $(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
-        $(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-        EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
-        EXTRALDFLAGS='-fprofile-use ' \
-        all
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
+	all
 
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null


### PR DESCRIPTION
## Summary
- convert profile-build recipe lines to use tabs so make accepts them
- fix icx profile-use target indentation

## Testing
- make -n profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2cc7dc948327baaa2625adce896a)