### PR TITLE
Remove unused moves_loop label in search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1113,8 +1113,6 @@ Value Search::Worker::search(
         }
     }
 
-moves_loop:  // When in check, search starts here
-
     // Step 12. A small Probcut idea
     probCutBeta = beta + 418;
     if ((ttData.bound & BOUND_LOWER) && ttData.depth >= depth - 4 && ttData.value >= probCutBeta


### PR DESCRIPTION
## Summary
- remove unused moves_loop label in search.cpp to silence compiler warning

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f2f351fc483278a6985459ba5c079)