### PR TITLE
Silence profile data warnings in PGO builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1210,11 +1210,11 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
-	EXTRALDFLAGS='-fprofile-use ' \
-	all
+$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
+$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+EXTRACXXFLAGS='-fprofile-use=stockfish.profdata -Wno-profile-instr-unprofiled' \
+EXTRALDFLAGS='-fprofile-use ' \
+all
 
 gcc-profile-make:
 	@mkdir -p profdir
@@ -1238,11 +1238,11 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
-	EXTRALDFLAGS='-fprofile-use ' \
-	all
+$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
+$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata -Wno-profile-instr-unprofiled' \
+EXTRALDFLAGS='-fprofile-use ' \
+all
 
 .depend: $(SRCS)
 	-@$(CXX) $(DEPENDFLAGS) -MM $(SRCS) > $@ 2> /dev/null


### PR DESCRIPTION
## Summary
- add profile-instrumentation warning suppression to clang and icx PGO use targets to keep builds clean

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f305d738c8327aea5dc3f7e8ec5f9)