### PR TITLE
Handle missing experience files gracefully

### DIFF
--- a/src/learn/learn.cpp
+++ b/src/learn/learn.cpp
@@ -60,11 +60,14 @@ bool LearningData::load(const std::filesystem::path& filename) {
     if (filename.empty())
         return false;
 
+    if (!std::filesystem::exists(filename))
+        return false;
+
     std::ifstream in(filename, std::ios::in | std::ios::binary);
 
     if (!in.is_open())
     {
-        record_load_error("Unable to open experience file <" + filename.string() + ">");
+        record_load_error("Unable to open existing experience file <" + filename.string() + ">");
         return false;
     }
 


### PR DESCRIPTION
## Summary
- avoid reporting an error when optional experience files are missing
- clarify error message when an existing experience file cannot be opened

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f31312d088327a49c91ef1df28211)