### PR TITLE
Simplify profile build recipes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1204,17 +1204,11 @@ misc.o: FORCE
 FORCE:
 
 clang-profile-make:
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-generate ' \
-	EXTRALDFLAGS=' -fprofile-generate' \
-	all
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXTRACXXFLAGS='-fprofile-generate ' EXTRALDFLAGS=' -fprofile-generate' all
 
 clang-profile-use:
 	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata stockfish-*.profraw
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata -Wno-profile-instr-unprofiled' \
-	EXTRALDFLAGS='-fprofile-use ' \
-	all
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXTRACXXFLAGS='-fprofile-use=stockfish.profdata -Wno-profile-instr-unprofiled' EXTRALDFLAGS='-fprofile-use ' all
 
 gcc-profile-make:
 	@mkdir -p profdir


### PR DESCRIPTION
## Summary
- collapse clang profile make/use recipes into single command lines to avoid separator issues

## Testing
- make help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f33871cbc8327a3e74b746b84b029)