### PR TITLE
Fix POSIX feature macros for shared memory

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -19,6 +19,10 @@
 #ifndef SHM_LINUX_H_INCLUDED
 #define SHM_LINUX_H_INCLUDED
 
+#ifndef _POSIX_C_SOURCE
+    #define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <atomic>
 #include <cassert>
 #include <cerrno>
@@ -40,6 +44,7 @@
 #include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #if defined(__NetBSD__) || defined(__DragonFly__) || defined(__linux__)


### PR DESCRIPTION
## Summary
- define _POSIX_C_SOURCE to expose POSIX APIs used by shared memory support
- include sys/types.h alongside existing POSIX headers

## Testing
- make build (fails: No rule to make target 'build')
- make (fails: No targets specified and no makefile found)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f3698109c8327a908f9c92fc43402)