### PR TITLE
Default builds to portable x86-64-v2 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ make -j profile-build
 
 Run `make help` inside `src` to see all available build targets and configuration options.
 
+By default, `make` now builds a portable `x86-64-v2` binary (SSE4.1/POPCNT) so release artifacts run on CPUs without AVX2/FMA3.
+Specify `ARCH=native` if you are compiling for your own machine and want to enable every instruction set your processor supports.
+
 ### Windows (MSYS2) prerequisites for Clang builds
 
 To run `make -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` without toolchain errors on Windows, install the MSYS2 packages that provide Clang, LLD, and `make` in the **clang64** shell:

--- a/src/Makefile
+++ b/src/Makefile
@@ -122,8 +122,10 @@ VPATH = syzygy:nnue:nnue/features:learn:wdl:book:book/polyglot:book/ctg
 
 ### 2.1. General and architecture defaults
 
+DEFAULT_ARCH := x86-64-v2
+
 ifeq ($(ARCH),)
-   ARCH = native
+   ARCH = $(DEFAULT_ARCH)
 endif
 
 ifeq ($(ARCH), native)


### PR DESCRIPTION
## Summary
- set the default Makefile architecture to x86-64-v2 for portable binaries instead of host-specific builds
- document the new default and how to opt into native builds when desired

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f431328688327a06ddfabaa08d8f4)