### PR TITLE
Lower default x86 build target to SSE4.1 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,9 @@ make -j profile-build
 
 Run `make help` inside `src` to see all available build targets and configuration options.
 
-By default, `make` now builds a portable `x86-64-v2` binary (SSE4.1/POPCNT) so release artifacts run on CPUs without AVX2/FMA3.
-Specify `ARCH=native` if you are compiling for your own machine and want to enable every instruction set your processor supports.
+By default, `make` now builds a portable `x86-64-sse41-popcnt` binary so release artifacts run even on older Xeon systems without
+SSE4.2, AVX2, or FMA3. Specify `ARCH=native` if you are compiling for your own machine and want to enable every instruction set
+your processor supports.
 
 ### Windows (MSYS2) prerequisites for Clang builds
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -122,7 +122,7 @@ VPATH = syzygy:nnue:nnue/features:learn:wdl:book:book/polyglot:book/ctg
 
 ### 2.1. General and architecture defaults
 
-DEFAULT_ARCH := x86-64-v2
+DEFAULT_ARCH := x86-64-sse41-popcnt
 
 ifeq ($(ARCH),)
    ARCH = $(DEFAULT_ARCH)


### PR DESCRIPTION
## Summary
- default builds now target x86-64-sse41-popcnt for broader compatibility
- document the new baseline in the README

## Testing
- make help | head


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4647e5e08327a20379efa18ab3c0)