### PR TITLE
Rebrand engine to Revolution-3.80-021225

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-3.60-221125
+# Revolution-3.80-021225
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.60-221125** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.80-021225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = Revolution-3.70-291125.exe
+        EXE = Revolution-3.80-021225.exe
 else
-        EXE = Revolution-3.70-291125
+        EXE = Revolution-3.80-021225
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -38,9 +38,9 @@ namespace Stockfish {
 namespace {
 
 // Revolution engine identification strings.
-constexpr std::string_view kEngineNameShort = "Revolution-3.760-291125";
-constexpr std::string_view kEngineDisplayName = "Revolution-3.70-291125";
-constexpr std::string_view kEngineHeader = "Revolution-3.70-291125";
+constexpr std::string_view kEngineNameShort = "Revolution-3.80-021225";
+constexpr std::string_view kEngineDisplayName = "Revolution-3.80-021225";
+constexpr std::string_view kEngineHeader = "Revolution-3.80-021225";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We


### PR DESCRIPTION
## Summary
- update README branding to Revolution-3.80-021225
- align engine identification strings and executable name with new version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f4d920c948327acf7c96a978c1241)