### PR TITLE
Guard dirty threat bitboard updates

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1040,7 +1040,7 @@ void Position::undo_move(Move m) {
 template<bool PutPiece>
 inline void add_dirty_threat(
   DirtyThreats* const dts, Piece pc, Piece threatened, Square s, Square threatenedSq) {
-    if (PutPiece)
+    if constexpr (PutPiece)
     {
         dts->threatenedSqs |= square_bb(threatenedSq);
         dts->threateningSqs |= square_bb(s);


### PR DESCRIPTION
## Summary
- Guard dirty threat bitboard updates with a compile-time PutPiece check matching upstream patch c109a88e

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931aed0548c832794e01f3e0d47eff9)