### PR TITLE
Update default big NNUE network

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-c0ae49f08b40.nnue"
+#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
## Summary
- update the default big NNUE network name to nn-2962dca31855.nnue

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b1427a78832795f8e7164241b1eb)