### PR TITLE
Replace requests dependency in tests

### DIFF
--- a/tests/testing.py
+++ b/tests/testing.py
@@ -14,7 +14,7 @@ import pathlib
 import concurrent.futures
 import tempfile
 import shutil
-import requests
+import urllib.request
 
 CYAN_COLOR = "\033[36m"
 GRAY_COLOR = "\033[2m"
@@ -96,10 +96,10 @@ class Syzygy:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tarball_path = os.path.join(tmpdirname, f"{file}.tar.gz")
 
-                response = requests.get(url, stream=True)
-                with open(tarball_path, "wb") as f:
-                    for chunk in response.iter_content(chunk_size=8192):
-                        f.write(chunk)
+                with urllib.request.urlopen(url) as response, open(
+                    tarball_path, "wb"
+                ) as f:
+                    shutil.copyfileobj(response, f)
 
                 with tarfile.open(tarball_path, "r:gz") as tar:
                     tar.extractall(tmpdirname)


### PR DESCRIPTION
## Summary
- use urllib.request for Syzygy downloads to avoid relying on the external requests module

## Testing
- make build ARCH=x86-64-bmi2
- python tests/testing.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b20b6a0c8327b58e088b53640ebb)