### PR TITLE
Avoid shadowing stats member in CTG book

### DIFF
--- a/src/book/ctg/ctg.cpp
+++ b/src/book/ctg/ctg.cpp
@@ -788,34 +788,34 @@ bool CtgBook::lookup_position(CtgPositionData& positionData) const {
 }
 
 void CtgBook::get_stats(const CtgPositionData& positionData,
-                        CtgMoveStats&          stats,
+                        CtgMoveStats&          moveStats,
                         bool                   isMove) const {
     const unsigned char* posPageData = positionData.positionPage;
     posPageData += *posPageData;
     posPageData += 3;
 
     //Win-loss-draw
-    stats.win  = (posPageData[0] << 16) | (posPageData[1] << 8) | posPageData[2];
-    stats.loss = (posPageData[3] << 16) | (posPageData[4] << 8) | posPageData[5];
-    stats.draw = (posPageData[6] << 16) | (posPageData[7] << 8) | posPageData[8];
+    moveStats.win  = (posPageData[0] << 16) | (posPageData[1] << 8) | posPageData[2];
+    moveStats.loss = (posPageData[3] << 16) | (posPageData[4] << 8) | posPageData[5];
+    moveStats.draw = (posPageData[6] << 16) | (posPageData[7] << 8) | posPageData[8];
 
     if (positionData.invert)
     {
-        int temp   = stats.win;
-        stats.win  = stats.loss;
-        stats.loss = temp;
+        int temp      = moveStats.win;
+        moveStats.win = moveStats.loss;
+        moveStats.loss = temp;
     }
 
     //Rating
     posPageData += 9 + 4 + 7;
-    stats.ratingDiv = (posPageData[0] << 16) | (posPageData[1] << 8) | posPageData[2];
-    stats.ratingSum =
+    moveStats.ratingDiv = (posPageData[0] << 16) | (posPageData[1] << 8) | posPageData[2];
+    moveStats.ratingSum =
       (posPageData[3] << 24) | (posPageData[4] << 16) | (posPageData[5] << 8) | posPageData[6];
 
     if (!isMove)
         return;
 
-    CtgMove& ctgMove = (CtgMove&) stats;
+    CtgMove& ctgMove = (CtgMove&) moveStats;
 
     //Recommendations
     ctgMove.recommendation = CtgMoveRecommendation(

--- a/src/book/ctg/ctg.h
+++ b/src/book/ctg/ctg.h
@@ -34,7 +34,7 @@ class CtgBook: public Book {
     uint32_t gen_position_hash(CtgPositionData& positionData) const;
     bool     lookup_position(CtgPositionData& positionData) const;
 
-    void get_stats(const CtgPositionData& positionData, CtgMoveStats& stats, bool isMove) const;
+    void get_stats(const CtgPositionData& positionData, CtgMoveStats& moveStats, bool isMove) const;
     Move get_pseudo_move(const CtgPositionData& positionData, int moveNum) const;
     bool get_move(const Position&        pos,
                   const CtgPositionData& positionData,


### PR DESCRIPTION
## Summary
- rename the get_stats parameter to avoid shadowing the class member
- update references in the implementation accordingly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b9e4bfd48327b4139a6e8eb8b4d2)