### PR TITLE
Handle direct Android clang toolchains generically

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -633,9 +633,9 @@ ifeq ($(COMP),armv7a-linux-androideabi16-clang)
         LDFLAGS += -static-libstdc++
 endif
 
-ifeq ($(COMP),aarch64-linux-android21-clang)
-        comp=aarch64-linux-android21-clang
-        CXX=aarch64-linux-android21-clang++
+ifneq ($(filter aarch64-linux-android%-clang,$(COMP)),)
+        comp=$(COMP)
+        CXX=$(COMP)++
         OS=Android
         CXXFLAGS += -stdlib=libc++ -pedantic -Wextra -Wshadow -Wmissing-prototypes \
                     -Wconditional-uninitialized


### PR DESCRIPTION
## Summary
- recognize aarch64 Android clang toolchains generically so Android settings apply
- automatically set compiler and strip tools for matching Android toolchains to avoid missing pthread/rt libs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938de5312ac8327b0b5eb6e79100c0d)