### PR TITLE
Rebrand engine to Revolution-3.90-151225

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-3.80-021225
+# Revolution-3.90-151225
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.80-021225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.90-151225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,10 +38,18 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable name
+ENGINE_BASE = Revolution-3.90-151225
+ENGINE_SUFFIX =
+ifneq (,$(findstring sse41-popcnt,$(ARCH)))
+        ENGINE_SUFFIX = -sse41popcnt
+else ifneq (,$(findstring avx2,$(ARCH)))
+        ENGINE_SUFFIX = -avx2
+endif
+
 ifeq ($(target_windows),yes)
-        EXE = Revolution-3.80-021225.exe
+        EXE = $(ENGINE_BASE)$(ENGINE_SUFFIX).exe
 else
-        EXE = Revolution-3.80-021225
+        EXE = $(ENGINE_BASE)$(ENGINE_SUFFIX)
 endif
 
 ### Installation dir definitions

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -29,6 +29,7 @@
 #include <iterator>
 #include <limits>
 #include <mutex>
+#include <string>
 #include <string_view>
 
 #include "types.h"
@@ -38,9 +39,22 @@ namespace Stockfish {
 namespace {
 
 // Revolution engine identification strings.
-constexpr std::string_view kEngineNameShort = "Revolution-3.80-021225";
-constexpr std::string_view kEngineDisplayName = "Revolution-3.80-021225";
-constexpr std::string_view kEngineHeader = "Revolution-3.80-021225";
+constexpr std::string_view kEngineNameBase = "Revolution-3.90-151225";
+
+std::string engine_arch_suffix() {
+#if defined(ARCH)
+    constexpr std::string_view kCompiledArch = stringify(ARCH);
+#else
+    constexpr std::string_view kCompiledArch = "";
+#endif
+
+    if (kCompiledArch.find("sse41-popcnt") != std::string_view::npos)
+        return " -sse41popcnt";
+    if (kCompiledArch.find("avx2") != std::string_view::npos)
+        return " -avx2";
+
+    return "";
+}
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -115,16 +129,18 @@ class Logger {
 
 // Returns the short public identification string for the Revolution engine.
 std::string engine_version_info() {
-    return std::string(kEngineNameShort);
+    return std::string(kEngineNameBase) + engine_arch_suffix();
 }
 
 std::string engine_info(bool to_uci) {
     constexpr std::string_view kAuthorLine =
         "Developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
-    if (to_uci)
-        return std::string(kEngineDisplayName) + "\nid author " + std::string(kAuthorLine);
+    const std::string engine_name = engine_version_info();
 
-    return std::string(kEngineHeader) + " " + std::string(kAuthorLine);
+    if (to_uci)
+        return engine_name + "\nid author " + std::string(kAuthorLine);
+
+    return engine_name + " " + std::string(kAuthorLine);
 }
 
 


### PR DESCRIPTION
## Summary
- update branding to Revolution-3.90-151225 and refresh README copy
- append architecture-specific suffixes to executable and reported engine name based on build target

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403377c7608327ac3f8af3aa777de8)