### PR TITLE
Rebrand engine to Revolution-4.0-211225 and adjust UCI arch suffix formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-3.90-151225
+# Revolution-4.0-211225
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-3.90-151225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.0-211225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -38,7 +38,7 @@ else ifeq ($(COMP),mingw)
 endif
 
 ### Executable naming
-BRANDING = Revolution-3.90-151225
+BRANDING = Revolution-4.0-211225
 EXE_BASE = $(BRANDING)
 EXE_SUFFIX =
 
@@ -152,6 +152,13 @@ endif
 
 ifeq ($(EXE_SUFFIX),)
         EXE_SUFFIX := $(BRANDING_SUFFIX)
+endif
+
+empty :=
+space := $(empty) $(empty)
+UCI_SUFFIX :=
+ifneq ($(BRANDING_SUFFIX),)
+        UCI_SUFFIX := $(space)$(BRANDING_SUFFIX)
 endif
 
 # explicitly check for the list of supported architectures (as listed with make help),
@@ -896,7 +903,7 @@ ifneq ($(ARCH), )
 endif
 
 ### 3.7.4 Expose architecture suffix used for branding
-CXXFLAGS += -DBUILD_ARCH_SUFFIX=\"$(EXE_SUFFIX)\"
+CXXFLAGS += -DBUILD_ARCH_SUFFIX=\"$(UCI_SUFFIX)\"
 
 ### 3.8 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-3.90-151225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.0-211225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-3.90-151225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.0-211225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,7 +44,7 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view version = "Revolution-3.90-151225";
+constexpr std::string_view version = "Revolution-4.0-211225";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation

- Update the project branding to `Revolution-4.0-211225` so the engine and docs report the new release identifier. 
- Ensure the UCI-visible engine name presented to GUIs includes a separating space before the architecture suffix so GUIs show e.g. `Revolution-4.0-211225 -sse41popcnt`.
- Preserve the executable naming convention so compiled binaries remain like `Revolution-4.0-211225-sse41popcnt` (no extra space in the filename).
- Keep bench output and README branding consistent with the new version string.

### Description

- Changed the `version` constant in `src/misc.cpp` to `Revolution-4.0-211225`.
- Updated `BRANDING` in `src/Makefile` and replaced occurrences in documentation and bench files such as `README.md`, `src/bench_prefetch_on.txt`, and `src/bench_prefetch_off.txt`.
- Added `UCI_SUFFIX` logic to `src/Makefile` that prepends a space to the architecture branding and switched the `-DBUILD_ARCH_SUFFIX` compile define to use `$(UCI_SUFFIX)` while leaving `EXE_SUFFIX` (and thus the executable name) unchanged.
- Committed the updated files to record the rebrand and build-metadata change.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a08544e483278f1e6d2184c3851a)