### PR TITLE
Add minimal book manager scaffolding (book API, utils, Makefile wiring)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
         misc.cpp movegen.cpp movepick.cpp position.cpp \
         search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
         experience.cpp \
+        book/book_manager.cpp book/book_utils.cpp \
         nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
         nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
         engine.cpp score.cpp memory.cpp
@@ -68,6 +69,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
                 experience.h experience_compat.h experience_zobrist.h \
                 revolution_zobrist.h \
+                book/book.h book/book_manager.h book/book_utils.h \
                 nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
                 nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
                 nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
@@ -77,7 +79,7 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
 
 OBJS = $(notdir $(SRCS:.cpp=.o))
 
-VPATH = syzygy:nnue:nnue/features
+VPATH = syzygy:nnue:nnue/features:book
 
 ### ==========================================================================
 ### Section 2. High-level Configuration

--- a/src/book/book.h
+++ b/src/book/book.h
@@ -1,0 +1,52 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BOOK_H_INCLUDED
+#define BOOK_H_INCLUDED
+
+#include <cstddef>
+#include <string>
+
+#include "../types.h"
+
+namespace Stockfish {
+class Position;
+
+namespace Book {
+
+struct LoadStats {
+    int validMoves = 0;
+    int totalMoves = 0;
+};
+
+class Book {
+   public:
+    virtual ~Book() = default;
+
+    virtual std::string type() const                                         = 0;
+    virtual bool        open(const std::string& filename)                     = 0;
+    virtual void        close()                                                = 0;
+    virtual Move        probe(const Position&, std::size_t width, bool onlyGreen) const = 0;
+    virtual void        show_moves(const Position&) const                      = 0;
+    virtual LoadStats   load_stats() const                                     = 0;
+};
+
+}  // namespace Book
+}  // namespace Stockfish
+
+#endif  // BOOK_H_INCLUDED

--- a/src/book/book_manager.cpp
+++ b/src/book/book_manager.cpp
@@ -1,0 +1,96 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "book_manager.h"
+
+#include <algorithm>
+#include <iostream>
+
+#include "book_utils.h"
+#include "../position.h"
+#include "../ucioption.h"
+
+namespace Stockfish {
+
+BookManager::BookManager() = default;
+
+void BookManager::init(const OptionsMap& options) {
+    fallback_active_ = false;
+
+    for (std::size_t index = 0; index < books_.size(); ++index) {
+        const auto filenameKey = Book::format_option_key("CTG/BIN Book %d File", int(index + 1));
+        const std::string filename = options.count(filenameKey) ? std::string(options[filenameKey]) : "";
+
+        if (filename.empty()) {
+            if (books_[index])
+                books_[index]->close();
+            continue;
+        }
+
+        if (!books_[index]) {
+            fallback_active_ = true;
+            continue;
+        }
+
+        if (!books_[index]->open(filename))
+            fallback_active_ = true;
+    }
+}
+
+Move BookManager::probe(const Position& pos, const OptionsMap& options) const {
+    for (std::size_t index = 0; index < books_.size(); ++index) {
+        if (!books_[index])
+            continue;
+
+        const auto widthKey = Book::format_option_key("Book %d Width", int(index + 1));
+        const auto onlyGreenKey = Book::format_option_key("(CTG) Book %d Only Green", int(index + 1));
+
+        std::size_t width = 1;
+        if (options.count(widthKey))
+            width = std::max<std::size_t>(1, int(options[widthKey]));
+
+        bool onlyGreen = false;
+        if (options.count(onlyGreenKey))
+            onlyGreen = bool(int(options[onlyGreenKey]));
+
+        Move move = books_[index]->probe(pos, width, onlyGreen);
+        if (move != Move::none())
+            return move;
+    }
+
+    return Move::none();
+}
+
+void BookManager::show_moves(const Position& pos, const OptionsMap&) const {
+    for (const auto& book : books_) {
+        if (book)
+            book->show_moves(pos);
+    }
+
+    if (fallback_active_)
+        std::cout << "Live book fallback active" << std::endl;
+}
+
+void BookManager::set_book_for_testing(std::size_t index, Book::Book* book) {
+    if (index >= books_.size())
+        return;
+
+    books_[index].reset(book);
+}
+
+}

--- a/src/book/book_manager.h
+++ b/src/book/book_manager.h
@@ -1,0 +1,51 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BOOK_MANAGER_H_INCLUDED
+#define BOOK_MANAGER_H_INCLUDED
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "book.h"
+
+namespace Stockfish {
+class OptionsMap;
+class Position;
+
+class BookManager {
+   public:
+    BookManager();
+
+    void init(const OptionsMap& options);
+    Move probe(const Position& pos, const OptionsMap& options) const;
+    void show_moves(const Position& pos, const OptionsMap& options) const;
+
+    void set_book_for_testing(std::size_t index, Book::Book* book);
+
+   private:
+    static constexpr std::size_t BookSlots = 2;
+
+    std::array<std::unique_ptr<Book::Book>, BookSlots> books_{};
+    bool fallback_active_ = false;
+};
+
+}  // namespace Stockfish
+
+#endif  // BOOK_MANAGER_H_INCLUDED

--- a/src/book/book_utils.cpp
+++ b/src/book/book_utils.cpp
@@ -1,0 +1,31 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "book_utils.h"
+
+#include <cstdio>
+
+namespace Stockfish::Book {
+
+std::string format_option_key(const char* format, int index) {
+    char buffer[128];
+    std::snprintf(buffer, sizeof(buffer), format, index);
+    return buffer;
+}
+
+}

--- a/src/book/book_utils.h
+++ b/src/book/book_utils.h
@@ -1,0 +1,30 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BOOK_UTILS_H_INCLUDED
+#define BOOK_UTILS_H_INCLUDED
+
+#include <string>
+
+namespace Stockfish::Book {
+
+std::string format_option_key(const char* format, int index);
+
+}
+
+#endif  // BOOK_UTILS_H_INCLUDED


### PR DESCRIPTION
### Motivation
- Tests referenced a book manager and book APIs that were not present, causing build/test failures. 
- Provide a lightweight, testable implementation to satisfy `tests/book_manager_test.cpp` and support future book integration. 
- Expose a minimal `Book` interface and small utilities used by the manager. 

### Description
- Add `src/book/book.h` defining the `Book` interface and `LoadStats` struct. 
- Add `src/book/book_manager.h` / `src/book/book_manager.cpp` implementing `BookManager` with `init`, `probe`, `show_moves`, and `set_book_for_testing`, and tracking `fallback_active_`. 
- Add `src/book/book_utils.h` / `src/book/book_utils.cpp` with `Book::format_option_key` helper. 
- Wire the new sources and headers into the build by updating `src/Makefile` (`SRCS`, `HEADERS`, and `VPATH`). 

### Testing
- Ran `make -j2 build ARCH=x86-64 NNUE_EMBEDDING_OFF=yes` in `src` which completed successfully. 
- The build produced the engine binary without compile/link errors after adding the new files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a131bab8832787b4cb689eb63156)