### PR TITLE
Fix BUILD_ARCH_SUFFIX quoting for mingw/clang builds

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -905,7 +905,7 @@ ifneq ($(ARCH), )
 endif
 
 ### 3.7.4 Expose architecture suffix used for branding
-CXXFLAGS += -DBUILD_ARCH_SUFFIX=\"$(UCI_SUFFIX)\"
+CXXFLAGS += '-DBUILD_ARCH_SUFFIX="$(UCI_SUFFIX)"'
 
 ### 3.8 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase


### PR DESCRIPTION
### Motivation
- mingw/clang produced errors like `unknown argument: '-sse41popcnt"'` when `UCI_SUFFIX` contains leading spaces. 
- The root cause was the existing escaping which allowed the shell/command line to split the `-DBUILD_ARCH_SUFFIX` into malformed pieces. 
- The goal is to ensure the entire `-DBUILD_ARCH_SUFFIX="..."` flag is passed to the compiler as a single argument even when `UCI_SUFFIX` contains spaces.

### Description
- Update `src/Makefile` to replace `CXXFLAGS += -DBUILD_ARCH_SUFFIX=\"$(UCI_SUFFIX)\"` with `CXXFLAGS += '-DBUILD_ARCH_SUFFIX="$(UCI_SUFFIX)"'`.
- Use single quotes around the flag so the shell preserves internal spaces while allowing `$(UCI_SUFFIX)` to be expanded.
- No other code paths were modified.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a5a1cb6883279dbd06614706ce92)