### PR TITLE
Cherry-pick statscore history bonus

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1885,7 +1885,7 @@ void update_all_stats(const Position& pos,
     Piece                  movedPiece     = pos.moved_piece(bestMove);
     PieceType              capturedPiece;
 
-    int bonus = std::min(121 * depth - 77, 1633) + 375 * (bestMove == ttMove);
+    int bonus = std::min(121 * depth - 77, 1633) + 375 * (bestMove == ttMove) + (ss - 1)->statScore / 32;
     int malus = std::min(825 * depth - 196, 2159) - 16 * moveCount;
 
     if (!pos.capture_stage(bestMove))


### PR DESCRIPTION
## Summary
- bring in Stockfish change that incorporates `statScore` into the history bonus computation while retaining the local tuning constants.

## Testing
- `cd src && ./Revolution-4.0-211225-bmi2 bench 16 1 4`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efcf432fc8327833ef55d28224f59)