### PR TITLE
Rebrand engine to Revolution-4.20-040126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.0-211225
+# Revolution-4.20-040126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.0-211225** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.20-040126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.10-261225
+ENGINE_NAME_BASE = Revolution-4.20-040126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 
@@ -159,6 +159,12 @@ ifeq ($(ARCH),x86-64-sse41-popcnt)
         ENGINE_ARCH_SUFFIX := -sse41popcnt
 else ifeq ($(ARCH),x86-64-avx2)
         ENGINE_ARCH_SUFFIX := -avx2
+else ifeq ($(ARCH),x86-64-bmi2)
+        ENGINE_ARCH_SUFFIX := -bmi2
+else ifeq ($(ARCH),x86-64-fma3)
+        ENGINE_ARCH_SUFFIX := -FMA3
+else ifeq ($(ARCH),x86-64-avx512)
+        ENGINE_ARCH_SUFFIX := -avx512
 else ifeq ($(ARCH),x86-64)
         ENGINE_ARCH_SUFFIX :=
 endif

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.0-211225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.20-040126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.0-211225 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.20-040126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.10-261225";
-constexpr std::string_view version = "Revolution-4.10-261225";
+constexpr std::string_view engineBaseName = "Revolution-4.20-040126";
+constexpr std::string_view version = "Revolution-4.20-040126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
## Summary
- update engine branding to Revolution-4.20-040126 across documentation and version metadata
- add architecture-specific suffixes for BMI2, FMA3, and AVX-512 builds to appear in GUI search results
- refresh bundled bench output headers to reflect the new release name


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c43c2f8c8327bb9dadfa9d381566)