### PR TITLE
qsearch: prevent bestValue from decreasing during SEE pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1706,7 +1706,7 @@ Value Search::Worker::qsearch(Position& pos, Stack* ss, Value alpha, Value beta)
                 // we can prune this move.
                 if (!pos.see_ge(move, alpha - futilityBase))
                 {
-                    bestValue = std::min(alpha, futilityBase);
+                    bestValue = std::max(bestValue, std::min(alpha, futilityBase));
                     continue;
                 }
             }


### PR DESCRIPTION
### Motivation
- Fix a regression where `bestValue` could be decreased during qsearch SEE-based pruning, producing incorrect search values.
- Align behavior with upstream Stockfish change (dev-20260106-c27c1747) that prevents `bestValue` from going down.
- Reduce rare (~2%) occurrences of unexpected `bestValue` decreases during quiescence search.

### Description
- Modified `src/search.cpp` in the qsearch pruning path to avoid lowering `bestValue` by replacing `bestValue = std::min(alpha, futilityBase)` with `bestValue = std::max(bestValue, std::min(alpha, futilityBase))`.
- The change ensures `bestValue` remains monotonic non-decreasing when pruning via SEE and futility heuristics.
- Single-line behavioral fix applied and committed as part of the patch.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9cc808e883278a7e59d484802bc9)