### PR TITLE
Rebrand engine to Revolution-4.30-070126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.20-040126
+# Revolution-4.30-070126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.20-040126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.30-070126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.20-040126
+ENGINE_NAME_BASE = Revolution-4.30-070126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.20-040126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.30-070126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.20-040126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.30-070126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.20-040126";
-constexpr std::string_view version = "Revolution-4.20-040126";
+constexpr std::string_view engineBaseName = "Revolution-4.30-070126";
+constexpr std::string_view version = "Revolution-4.30-070126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Bump the project release identifier from `Revolution-4.20-040126` to `Revolution-4.30-070126` so build artifacts and metadata show the new version.
- Ensure the engine UCI name and executable base reflect the new release identifier so GUI search results and binary names include `Revolution-4.30-070126` and any architecture suffix.
- Update documentation and benchmark headers to consistently report the new release string.

### Description
- Updated `ENGINE_NAME_BASE` in `src/Makefile` from `Revolution-4.20-040126` to `Revolution-4.30-070126` so built executables use the new base name.
- Updated `engineBaseName` and `version` constants in `src/misc.cpp` to `Revolution-4.30-070126` so UCI/engine info prints the new identifier.
- Replaced the release string in `README.md` and the benchmark output files `src/bench_prefetch_on.txt` and `src/bench_prefetch_off.txt` to reflect the new version.
- The Makefile still appends architecture-specific suffixes (e.g. `-sse41popcnt`, `-avx2`, `-bmi2`, `-FMA3`, `-avx512`) so compiled executables will appear as `Revolution-4.30-070126$(ARCH_SUFFIX)`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e9e8ae070832780b3bc56662adcfe)