### PR TITLE
Rebrand engine/version to Revolution-4.40-120126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.30-070126
+# Revolution-4.40-120126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.30-070126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.40-120126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.30-070126
+ENGINE_NAME_BASE = Revolution-4.40-120126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.30-070126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.30-070126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.30-070126";
-constexpr std::string_view version = "Revolution-4.30-070126";
+constexpr std::string_view engineBaseName = "Revolution-4.40-120126";
+constexpr std::string_view version = "Revolution-4.40-120126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Rebrand the engine to the new release identifier so UCI/GUI and benchmark outputs present the updated name and architecture suffix variants (e.g. `-sse41popcnt`, `-avx2`, `-bmi2`, `-FMA3`, `-avx512`).
- Keep on-disk/printed artifacts and documentation consistent with the new release string.

### Description
- Update `engineBaseName` and `version` in `src/misc.cpp` to `Revolution-4.40-120126` so `engine_uci_name()` and version printing reflect the new ID.
- Update `ENGINE_NAME_BASE` in `src/Makefile` to `Revolution-4.40-120126` so produced executables include the base name and the `BUILD_ARCH_SUFFIX`-derived suffix.
- Refresh release text in `README.md` and the benchmark headers `src/bench_prefetch_off.txt` and `src/bench_prefetch_on.txt` to reference `Revolution-4.40-120126`.
- Files changed: `README.md`, `src/Makefile`, `src/misc.cpp`, `src/bench_prefetch_off.txt`, and `src/bench_prefetch_on.txt`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964d95b14a08327a6d99eee2145e5ff)