### PR TITLE
Update WDL model coefficients

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -527,8 +527,8 @@ WinRateParams win_rate_params(const Position& pos) {
     double m = std::clamp(material, 17, 78) / 58.0;
 
     // Return a = p_a(material) and b = p_b(material), see github.com/official-stockfish/WDL_model
-    constexpr double as[] = {-13.50030198, 40.92780883, -36.82753545, 386.83004070};
-    constexpr double bs[] = {96.53354896, -165.79058388, 90.89679019, 49.29561889};
+    constexpr double as[] = {-72.32565836, 185.93832038, -144.58862193, 416.44950446};
+    constexpr double bs[] = {83.86794042, -136.06112997, 69.98820887, 47.62901433};
 
     double a = (((as[0] * m + as[1]) * m + as[2]) * m) + as[3];
     double b = (((bs[0] * m + bs[1]) * m + bs[2]) * m) + bs[3];


### PR DESCRIPTION
### Motivation
- Refresh the internal WDL win-rate model parameters so the UCI win/draw/loss predictions use the latest fitted a/b coefficients from the updated WDL model.

### Description
- Replace the `as` and `bs` coefficient arrays in `win_rate_params` in `src/uci.cpp` with the new fitted values.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969806c645c832780afef9a02d3ebd3)