### PR TITLE
Rebrand engine to Revolution-4.50-160126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.40-120126
+# Revolution-4.50-160126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.40-120126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.50-160126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.40-120126
+ENGINE_NAME_BASE = Revolution-4.50-160126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.40-120126";
-constexpr std::string_view version = "Revolution-4.40-120126";
+constexpr std::string_view engineBaseName = "Revolution-4.50-160126";
+constexpr std::string_view version = "Revolution-4.50-160126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Update the engine branding and version to the new release identifier so compiled binaries and UCI identification show `Revolution-4.50-160126` with architecture suffixes (e.g. `-sse41popcnt`, `-avx2`, `-bmi2`, `-FMA3`, `-avx512`).
- Keep documentation and benchmark headers consistent with the shipped engine name so GUIs and users see the correct release string.

### Description
- Changed the executable base name in `src/Makefile` by setting `ENGINE_NAME_BASE = Revolution-4.50-160126` so produced binaries use the new base name.
- Updated engine branding constants in `src/misc.cpp` by replacing `engineBaseName` and `version` with `Revolution-4.50-160126`.
- Updated user-facing text in `README.md` and the benchmark output headers `src/bench_prefetch_on.txt` and `src/bench_prefetch_off.txt` to reflect the new release string.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696981d463408327bb5df9bc9368d16c)