### PR TITLE
Update default NNUE network to nn-c288c895ea92

### DIFF
--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,353 +1,353 @@
 Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
-info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
+info string NNUE file 'nn-c288c895ea92.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread
 
 Position: 1/50 (rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -15 nodes 20 nps 20000 hashfull 0 tbhits 0 time 1 pv a2a3
 bestmove a2a3
 
 Position: 2/50 (r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 11 multipv 1 score cp -13 nodes 115 nps 57500 hashfull 1 tbhits 0 time 2 pv e2a6 h3g2 f3g2 b4c3 d2c3 e6d5
 bestmove e2a6 ponder h3g2
 
 Position: 3/50 (8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -6 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g2g3 h4g3
 bestmove g2g3 ponder h4g3
 
 Position: 4/50 (4rrk1/pp1n3p/3q2pQ/2p1pb2/2PP4/2P3N1/P2B2PP/4RRK1 b - - 7 19)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 15 multipv 1 score cp -12 nodes 506 nps 253000 hashfull 4 tbhits 0 time 2 pv d6d4 d2e3
 bestmove d6d4 ponder d2e3
 
 Position: 5/50 (rq3rk1/ppp2ppp/1bnpN3/3N2B1/4P3/7P/PPPQ1PP1/2KR3R b - - 0 14)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 10 multipv 1 score cp -13 nodes 55 nps 55000 hashfull 0 tbhits 0 time 1 pv f7e6
 bestmove f7e6
 
 Position: 6/50 (r1bq1r1k/1pp1n1pp/1p1p4/4p2Q/4PpP1/1BNP4/PPP2P1P/3R1RK1 b - g3 0 14)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -14 nodes 32 nps 32000 hashfull 0 tbhits 0 time 1 pv f4f3
 bestmove f4f3
 
 Position: 7/50 (r3r1k1/2p2ppp/p1p1bn2/8/1q2P3/2NPQN2/PPP3PP/R4RK1 b - - 2 15)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -13 nodes 49 nps 49000 hashfull 1 tbhits 0 time 1 pv b4b2
 bestmove b4b2
 
 Position: 8/50 (r1bbk1nr/pp3p1p/2n5/1N4p1/2Np1B2/8/PPP2PPP/2KR1B1R w kq - 0 13)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -3 nodes 87 nps 87000 hashfull 2 tbhits 0 time 1 pv c4d6 e8e7 d6c8 a8c8 f4g5 g8f6 g5f6 e7f6 b5d4
 bestmove c4d6 ponder e8e7
 
 Position: 9/50 (r1bq1rk1/ppp1nppp/4n3/3p3Q/3P4/1BP1B3/PP1N2PP/R4RK1 w - - 1 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -12 nodes 54 nps 54000 hashfull 0 tbhits 0 time 1 pv h5f7 f8f7
 bestmove h5f7 ponder f8f7
 
 Position: 10/50 (4r1k1/r1q2ppp/ppp2n2/4P3/5Rb1/1N1BQ3/PPP3PP/R5K1 w - - 1 17)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 7 multipv 1 score cp -11 nodes 70 nps 70000 hashfull 1 tbhits 0 time 1 pv e5f6 e8e3
 bestmove e5f6 ponder e8e3
 
 Position: 11/50 (2rqkb1r/ppp2p2/2npb1p1/1N1Nn2p/2P1PP2/8/PP2B1PP/R1BQK2R b KQ - 0 11)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -14 nodes 110 nps 110000 hashfull 0 tbhits 0 time 1 pv d8h4 e1f1
 bestmove d8h4 ponder e1f1
 
 Position: 12/50 (r1bq1r1k/b1p1npp1/p2p3p/1p6/3PP3/1B2NN2/PP3PPP/R2Q1RK1 w - - 1 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -14 nodes 37 nps 37000 hashfull 0 tbhits 0 time 1 pv b3f7
 bestmove b3f7
 
 Position: 13/50 (3r1rk1/p5pp/bpp1pp2/8/q1PP1P2/b3P3/P2NQRPP/1R2B1K1 b - - 6 22)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -13 nodes 40 nps 40000 hashfull 0 tbhits 0 time 1 pv a3b4
 bestmove a3b4
 
 Position: 14/50 (r1q2rk1/2p1bppp/2Pp4/p6b/Q1PNp3/4B3/PP1R1PPP/2K4R w - - 2 18)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -13 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv a4a5
 bestmove a4a5
 
 Position: 15/50 (4k2r/1pb2ppp/1p2p3/1R1p4/3P4/2r1PN2/P4PPP/1R4K1 b - - 3 22)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 34 nps 34000 hashfull 0 tbhits 0 time 1 pv e6e5
 bestmove e6e5
 
 Position: 16/50 (3q2k1/pb3p1p/4pbp1/2r5/PpN2N2/1P2P2P/5PP1/Q2R2K1 b - - 4 26)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp -11 nodes 64 nps 64000 hashfull 1 tbhits 0 time 1 pv f6a1
 bestmove f6a1
 
 Position: 17/50 (6k1/6p1/6Pp/ppp5/3pn2P/1P3K2/1PP2P2/3N4 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -5 nodes 29 nps 29000 hashfull 0 tbhits 0 time 1 pv e4d2 f3e2
 bestmove e4d2 ponder f3e2
 
 Position: 18/50 (3b4/5kp1/1p1p1p1p/pP1PpP1P/P1P1P3/3KN3/8/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 12 nps 12000 hashfull 0 tbhits 0 time 1 pv c4c5
 bestmove c4c5
 
 Position: 19/50 (2K5/p7/7P/5pR1/8/5k2/r7/8 w - - 4 3)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -2 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g5g3 f3g3
 bestmove g5g3 ponder f3g3
 
 Position: 20/50 (8/6pk/1p6/8/PP3p1p/5P2/4KP1q/3Q4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -9 nodes 28 nps 28000 hashfull 0 tbhits 0 time 1 pv d1d3 h7g8
 bestmove d1d3 ponder h7g8
 
 Position: 21/50 (7k/3p2pp/4q3/8/4Q3/5Kp1/P6b/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp 0 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv e4h7 h8h7
 bestmove e4h7 ponder h8h7
 
 Position: 22/50 (8/2p5/8/2kPKp1p/2p4P/2P5/3P4/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp 2 nodes 16 nps 16000 hashfull 0 tbhits 0 time 1 pv e5f4
 bestmove e5f4
 
 Position: 23/50 (8/1p3pp1/7p/5P1P/2k3P1/8/2K2P2/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -5 nodes 9 nps 9000 hashfull 0 tbhits 0 time 1 pv f2f3
 bestmove f2f3
 
 Position: 24/50 (8/pp2r1k1/2p1p3/3pP2p/1P1P1P1P/P5KR/8/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -7 nodes 9 nps 9000 hashfull 0 tbhits 0 time 1 pv a3a4
 bestmove a3a4
 
 Position: 25/50 (8/3p4/p1bk3p/Pp6/1Kp1PpPp/2P2P1P/2P5/5B2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 11 nps 11000 hashfull 0 tbhits 0 time 1 pv h6h5
 bestmove h6h5
 
 Position: 26/50 (5k2/7R/4P2p/5K2/p1r2P1p/8/8/8 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -14 nodes 26 nps 26000 hashfull 0 tbhits 0 time 1 pv c4c5 f5e4
 bestmove c4c5 ponder f5e4
 
 Position: 27/50 (6k1/6p1/P6p/r1N5/5p2/7P/1b3PP1/4R1K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -9 nodes 29 nps 29000 hashfull 0 tbhits 0 time 1 pv f2f3
 bestmove f2f3
 
 Position: 28/50 (1r3k2/4q3/2Pp3b/3Bp3/2Q2p2/1p1P2P1/1P2KP2/3N4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -5 nodes 50 nps 50000 hashfull 0 tbhits 0 time 1 pv c4f4 h6f4
 bestmove c4f4 ponder h6f4
 
 Position: 29/50 (6k1/4pp1p/3p2p1/P1pPb3/R7/1r2P1PP/3B1P2/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -11 nodes 25 nps 25000 hashfull 0 tbhits 0 time 1 pv e3e4
 bestmove e3e4
 
 Position: 30/50 (8/3p3B/5p2/5P2/p7/PP5b/k7/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp 1 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g1h2
 bestmove g1h2
 
 Position: 31/50 (5rk1/q6p/2p3bR/1pPp1rP1/1P1Pp3/P3B1Q1/1K3P2/R7 w - - 93 90)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 9 multipv 1 score cp -7 nodes 59 nps 59000 hashfull 0 tbhits 0 time 1 pv a1b1
 bestmove a1b1
 
 Position: 32/50 (4rrk1/1p1nq3/p7/2p1P1pp/3P2bp/3Q1Bn1/PPPB4/1K2R1NR w - - 40 21)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 11 multipv 1 score cp -9 nodes 108 nps 108000 hashfull 1 tbhits 0 time 1 pv d3g6 e7g7 g6g7 g8g7 f3g4 h5g4 d4c5
 bestmove d3g6 ponder e7g7
 
 Position: 33/50 (r3k2r/3nnpbp/q2pp1p1/p7/Pp1PPPP1/4BNN1/1P5P/R2Q1RK1 w kq - 0 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -14 nodes 36 nps 36000 hashfull 0 tbhits 0 time 1 pv b2b3
 bestmove b2b3
 
 Position: 34/50 (3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -13 nodes 40 nps 40000 hashfull 1 tbhits 0 time 1 pv g7f8
 bestmove g7f8
 
 Position: 35/50 (4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 17 multipv 1 score cp -4 nodes 488 nps 244000 hashfull 5 tbhits 0 time 2 pv b6d7 g3e2 b3c4 g6f5 c2e2 f7d7 e4f5
 bestmove b6d7 ponder g3e2
 
 Position: 36/50 (k7/2n1n3/1nbNbn2/2NbRBn1/1nbRQR2/2NBRBN1/3N1N2/7K w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 29 multipv 1 score cp 3 nodes 238582 nps 513079 hashfull 977 tbhits 0 time 465 pv d2c4
 bestmove d2c4
 
 Position: 37/50 (K7/8/8/BNQNQNB1/N5N1/R1Q1q2r/n5n1/bnqnqnbk w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 23 multipv 1 score cp -3 nodes 33617 nps 509348 hashfull 240 tbhits 0 time 66 pv e5e3 f1e3 c3e1 c1c5 a4c5 g2e1 g4e3 b1a3 b5a3
 bestmove e5e3 ponder f1e3
 
 Position: 38/50 (8/8/8/8/5kp1/P7/8/1K1N4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 3 nodes 10 nps 10000 hashfull 0 tbhits 0 time 1 pv a3a4
 bestmove a3a4
 
 Position: 39/50 (8/8/8/5N2/8/p7/8/2NK3k w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 10 nodes 17 nps 17000 hashfull 0 tbhits 0 time 1 pv c1a2
 bestmove c1a2
 
 Position: 40/50 (8/3k4/8/8/8/4B3/4KB2/2B5 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 12 nodes 21 nps 21000 hashfull 0 tbhits 0 time 1 pv c1b2
 bestmove c1b2
 
 Position: 41/50 (8/8/1P6/5pr1/8/4R3/7k/2K5 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp -3 nodes 25 nps 25000 hashfull 0 tbhits 0 time 1 pv e3e2 g5g2 e2g2 h2g2
 bestmove e3e2 ponder g5g2
 
 Position: 42/50 (8/2p4P/8/kr6/6R1/8/8/1K6 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -4 nodes 8 nps 8000 hashfull 0 tbhits 0 time 1 pv g4b4
 bestmove g4b4
 
 Position: 43/50 (8/8/3P3k/8/1p6/8/1P6/1K3n2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -3 nodes 12 nps 12000 hashfull 0 tbhits 0 time 1 pv f1d2 b1a1
 bestmove f1d2 ponder b1a1
 
 Position: 44/50 (8/R7/2q5/8/6k1/8/1P5p/K6R w - - 0 124)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 6 multipv 1 score cp 12 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv a7g7 c6g6 g7g6 g4f3 h1h2
 bestmove a7g7 ponder c6g6
 
 Position: 45/50 (6k1/3b3r/1p1p4/p1n2p2/1PPNpP1q/P3Q1p1/1R1RB1P1/5K2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -12 nodes 57 nps 57000 hashfull 1 tbhits 0 time 1 pv a5a4
 bestmove a5a4
 
 Position: 46/50 (r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -7 nodes 55 nps 55000 hashfull 0 tbhits 0 time 1 pv a2a3
 bestmove a2a3
 
 Position: 47/50 (8/8/8/8/8/6k1/6p1/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 0 score cp 0
 bestmove (none)
 
 Position: 48/50 (7k/7P/6K1/8/3B4/8/8/8 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 0 score mate 0
 bestmove (none)
 
 Position: 49/50 (bb1n1rkr/ppp1Q1pp/3n1p2/3p4/3P4/6Pq/PPP1PP1P/BB1NNRKR w HFhf - 0 5)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -9 nodes 40 nps 40000 hashfull 0 tbhits 0 time 1 pv e7g7 g8g7
 bestmove e7g7 ponder g8g7
 
 Position: 50/50 (nqbnrkrb/pppppppp/8/8/8/8/PPPPPPPP/NQBNRKRB w GEge - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -15 nodes 20 nps 20000 hashfull 0 tbhits 0 time 1 pv a2a3

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,353 +1,353 @@
 Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
-info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
+info string NNUE file 'nn-c288c895ea92.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread
 
 Position: 1/50 (rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -15 nodes 20 nps 20000 hashfull 0 tbhits 0 time 1 pv a2a3
 bestmove a2a3
 
 Position: 2/50 (r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 10)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 11 multipv 1 score cp -13 nodes 115 nps 57500 hashfull 1 tbhits 0 time 2 pv e2a6 h3g2 f3g2 b4c3 d2c3 e6d5
 bestmove e2a6 ponder h3g2
 
 Position: 3/50 (8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 11)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -6 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g2g3 h4g3
 bestmove g2g3 ponder h4g3
 
 Position: 4/50 (4rrk1/pp1n3p/3q2pQ/2p1pb2/2PP4/2P3N1/P2B2PP/4RRK1 b - - 7 19)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 15 multipv 1 score cp -12 nodes 506 nps 168666 hashfull 4 tbhits 0 time 3 pv d6d4 d2e3
 bestmove d6d4 ponder d2e3
 
 Position: 5/50 (rq3rk1/ppp2ppp/1bnpN3/3N2B1/4P3/7P/PPPQ1PP1/2KR3R b - - 0 14)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 10 multipv 1 score cp -13 nodes 55 nps 55000 hashfull 0 tbhits 0 time 1 pv f7e6
 bestmove f7e6
 
 Position: 6/50 (r1bq1r1k/1pp1n1pp/1p1p4/4p2Q/4PpP1/1BNP4/PPP2P1P/3R1RK1 b - g3 0 14)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -14 nodes 32 nps 32000 hashfull 0 tbhits 0 time 1 pv f4f3
 bestmove f4f3
 
 Position: 7/50 (r3r1k1/2p2ppp/p1p1bn2/8/1q2P3/2NPQN2/PPP3PP/R4RK1 b - - 2 15)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -13 nodes 49 nps 49000 hashfull 1 tbhits 0 time 1 pv b4b2
 bestmove b4b2
 
 Position: 8/50 (r1bbk1nr/pp3p1p/2n5/1N4p1/2Np1B2/8/PPP2PPP/2KR1B1R w kq - 0 13)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -3 nodes 87 nps 87000 hashfull 2 tbhits 0 time 1 pv c4d6 e8e7 d6c8 a8c8 f4g5 g8f6 g5f6 e7f6 b5d4
 bestmove c4d6 ponder e8e7
 
 Position: 9/50 (r1bq1rk1/ppp1nppp/4n3/3p3Q/3P4/1BP1B3/PP1N2PP/R4RK1 w - - 1 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -12 nodes 54 nps 54000 hashfull 0 tbhits 0 time 1 pv h5f7 f8f7
 bestmove h5f7 ponder f8f7
 
 Position: 10/50 (4r1k1/r1q2ppp/ppp2n2/4P3/5Rb1/1N1BQ3/PPP3PP/R5K1 w - - 1 17)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 7 multipv 1 score cp -11 nodes 70 nps 70000 hashfull 1 tbhits 0 time 1 pv e5f6 e8e3
 bestmove e5f6 ponder e8e3
 
 Position: 11/50 (2rqkb1r/ppp2p2/2npb1p1/1N1Nn2p/2P1PP2/8/PP2B1PP/R1BQK2R b KQ - 0 11)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -14 nodes 110 nps 110000 hashfull 0 tbhits 0 time 1 pv d8h4 e1f1
 bestmove d8h4 ponder e1f1
 
 Position: 12/50 (r1bq1r1k/b1p1npp1/p2p3p/1p6/3PP3/1B2NN2/PP3PPP/R2Q1RK1 w - - 1 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -14 nodes 37 nps 37000 hashfull 0 tbhits 0 time 1 pv b3f7
 bestmove b3f7
 
 Position: 13/50 (3r1rk1/p5pp/bpp1pp2/8/q1PP1P2/b3P3/P2NQRPP/1R2B1K1 b - - 6 22)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -13 nodes 40 nps 40000 hashfull 0 tbhits 0 time 1 pv a3b4
 bestmove a3b4
 
 Position: 14/50 (r1q2rk1/2p1bppp/2Pp4/p6b/Q1PNp3/4B3/PP1R1PPP/2K4R w - - 2 18)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -13 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv a4a5
 bestmove a4a5
 
 Position: 15/50 (4k2r/1pb2ppp/1p2p3/1R1p4/3P4/2r1PN2/P4PPP/1R4K1 b - - 3 22)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 34 nps 34000 hashfull 0 tbhits 0 time 1 pv e6e5
 bestmove e6e5
 
 Position: 16/50 (3q2k1/pb3p1p/4pbp1/2r5/PpN2N2/1P2P2P/5PP1/Q2R2K1 b - - 4 26)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp -11 nodes 64 nps 64000 hashfull 1 tbhits 0 time 1 pv f6a1
 bestmove f6a1
 
 Position: 17/50 (6k1/6p1/6Pp/ppp5/3pn2P/1P3K2/1PP2P2/3N4 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -5 nodes 29 nps 29000 hashfull 0 tbhits 0 time 1 pv e4d2 f3e2
 bestmove e4d2 ponder f3e2
 
 Position: 18/50 (3b4/5kp1/1p1p1p1p/pP1PpP1P/P1P1P3/3KN3/8/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 12 nps 12000 hashfull 0 tbhits 0 time 1 pv c4c5
 bestmove c4c5
 
 Position: 19/50 (2K5/p7/7P/5pR1/8/5k2/r7/8 w - - 4 3)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -2 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g5g3 f3g3
 bestmove g5g3 ponder f3g3
 
 Position: 20/50 (8/6pk/1p6/8/PP3p1p/5P2/4KP1q/3Q4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -9 nodes 28 nps 28000 hashfull 0 tbhits 0 time 1 pv d1d3 h7g8
 bestmove d1d3 ponder h7g8
 
 Position: 21/50 (7k/3p2pp/4q3/8/4Q3/5Kp1/P6b/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp 0 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv e4h7 h8h7
 bestmove e4h7 ponder h8h7
 
 Position: 22/50 (8/2p5/8/2kPKp1p/2p4P/2P5/3P4/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp 2 nodes 16 nps 16000 hashfull 0 tbhits 0 time 1 pv e5f4
 bestmove e5f4
 
 Position: 23/50 (8/1p3pp1/7p/5P1P/2k3P1/8/2K2P2/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -5 nodes 9 nps 9000 hashfull 0 tbhits 0 time 1 pv f2f3
 bestmove f2f3
 
 Position: 24/50 (8/pp2r1k1/2p1p3/3pP2p/1P1P1P1P/P5KR/8/8 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -7 nodes 9 nps 9000 hashfull 0 tbhits 0 time 1 pv a3a4
 bestmove a3a4
 
 Position: 25/50 (8/3p4/p1bk3p/Pp6/1Kp1PpPp/2P2P1P/2P5/5B2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -10 nodes 11 nps 11000 hashfull 0 tbhits 0 time 1 pv h6h5
 bestmove h6h5
 
 Position: 26/50 (5k2/7R/4P2p/5K2/p1r2P1p/8/8/8 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -14 nodes 26 nps 26000 hashfull 0 tbhits 0 time 1 pv c4c5 f5e4
 bestmove c4c5 ponder f5e4
 
 Position: 27/50 (6k1/6p1/P6p/r1N5/5p2/7P/1b3PP1/4R1K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -9 nodes 29 nps 29000 hashfull 0 tbhits 0 time 1 pv f2f3
 bestmove f2f3
 
 Position: 28/50 (1r3k2/4q3/2Pp3b/3Bp3/2Q2p2/1p1P2P1/1P2KP2/3N4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 12 multipv 1 score cp -5 nodes 50 nps 50000 hashfull 0 tbhits 0 time 1 pv c4f4 h6f4
 bestmove c4f4 ponder h6f4
 
 Position: 29/50 (6k1/4pp1p/3p2p1/P1pPb3/R7/1r2P1PP/3B1P2/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -11 nodes 25 nps 25000 hashfull 0 tbhits 0 time 1 pv e3e4
 bestmove e3e4
 
 Position: 30/50 (8/3p3B/5p2/5P2/p7/PP5b/k7/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp 1 nodes 18 nps 18000 hashfull 0 tbhits 0 time 1 pv g1h2
 bestmove g1h2
 
 Position: 31/50 (5rk1/q6p/2p3bR/1pPp1rP1/1P1Pp3/P3B1Q1/1K3P2/R7 w - - 93 90)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 9 multipv 1 score cp -7 nodes 59 nps 59000 hashfull 0 tbhits 0 time 1 pv a1b1
 bestmove a1b1
 
 Position: 32/50 (4rrk1/1p1nq3/p7/2p1P1pp/3P2bp/3Q1Bn1/PPPB4/1K2R1NR w - - 40 21)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 11 multipv 1 score cp -9 nodes 108 nps 108000 hashfull 1 tbhits 0 time 1 pv d3g6 e7g7 g6g7 g8g7 f3g4 h5g4 d4c5
 bestmove d3g6 ponder e7g7
 
 Position: 33/50 (r3k2r/3nnpbp/q2pp1p1/p7/Pp1PPPP1/4BNN1/1P5P/R2Q1RK1 w kq - 0 16)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -14 nodes 36 nps 36000 hashfull 0 tbhits 0 time 1 pv b2b3
 bestmove b2b3
 
 Position: 34/50 (3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -13 nodes 40 nps 40000 hashfull 1 tbhits 0 time 1 pv g7f8
 bestmove g7f8
 
 Position: 35/50 (4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 17 multipv 1 score cp -4 nodes 488 nps 162666 hashfull 5 tbhits 0 time 3 pv b6d7 g3e2 b3c4 g6f5 c2e2 f7d7 e4f5
 bestmove b6d7 ponder g3e2
 
 Position: 36/50 (k7/2n1n3/1nbNbn2/2NbRBn1/1nbRQR2/2NBRBN1/3N1N2/7K w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 29 multipv 1 score cp 3 nodes 238582 nps 477164 hashfull 977 tbhits 0 time 500 pv d2c4
 bestmove d2c4
 
 Position: 37/50 (K7/8/8/BNQNQNB1/N5N1/R1Q1q2r/n5n1/bnqnqnbk w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 23 multipv 1 score cp -3 nodes 33617 nps 473478 hashfull 240 tbhits 0 time 71 pv e5e3 f1e3 c3e1 c1c5 a4c5 g2e1 g4e3 b1a3 b5a3
 bestmove e5e3 ponder f1e3
 
 Position: 38/50 (8/8/8/8/5kp1/P7/8/1K1N4 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 3 nodes 10 nps 10000 hashfull 0 tbhits 0 time 1 pv a3a4
 bestmove a3a4
 
 Position: 39/50 (8/8/8/5N2/8/p7/8/2NK3k w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 10 nodes 17 nps 17000 hashfull 0 tbhits 0 time 1 pv c1a2
 bestmove c1a2
 
 Position: 40/50 (8/3k4/8/8/8/4B3/4KB2/2B5 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp 12 nodes 21 nps 21000 hashfull 0 tbhits 0 time 1 pv c1b2
 bestmove c1b2
 
 Position: 41/50 (8/8/1P6/5pr1/8/4R3/7k/2K5 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 5 multipv 1 score cp -3 nodes 25 nps 25000 hashfull 0 tbhits 0 time 1 pv e3e2 g5g2 e2g2 h2g2
 bestmove e3e2 ponder g5g2
 
 Position: 42/50 (8/2p4P/8/kr6/6R1/8/8/1K6 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -4 nodes 8 nps 8000 hashfull 0 tbhits 0 time 1 pv g4b4
 bestmove g4b4
 
 Position: 43/50 (8/8/3P3k/8/1p6/8/1P6/1K3n2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -3 nodes 12 nps 12000 hashfull 0 tbhits 0 time 1 pv f1d2 b1a1
 bestmove f1d2 ponder b1a1
 
 Position: 44/50 (8/R7/2q5/8/6k1/8/1P5p/K6R w - - 0 124)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 6 multipv 1 score cp 12 nodes 39 nps 39000 hashfull 0 tbhits 0 time 1 pv a7g7 c6g6 g7g6 g4f3 h1h2
 bestmove a7g7 ponder c6g6
 
 Position: 45/50 (6k1/3b3r/1p1p4/p1n2p2/1PPNpP1q/P3Q1p1/1R1RB1P1/5K2 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 4 multipv 1 score cp -12 nodes 57 nps 57000 hashfull 1 tbhits 0 time 1 pv a5a4
 bestmove a5a4
 
 Position: 46/50 (r2r1n2/pp2bk2/2p1p2p/3q4/3PN1QP/2P3R1/P4PP1/5RK1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -7 nodes 55 nps 55000 hashfull 0 tbhits 0 time 1 pv a2a3
 bestmove a2a3
 
 Position: 47/50 (8/8/8/8/8/6k1/6p1/6K1 w - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 0 score cp 0
 bestmove (none)
 
 Position: 48/50 (7k/7P/6K1/8/3B4/8/8/8 b - - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 0 score mate 0
 bestmove (none)
 
 Position: 49/50 (bb1n1rkr/ppp1Q1pp/3n1p2/3p4/3P4/6Pq/PPP1PP1P/BB1NNRKR w HFhf - 0 5)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 3 multipv 1 score cp -9 nodes 40 nps 40000 hashfull 0 tbhits 0 time 1 pv e7g7 g8g7
 bestmove e7g7 ponder g8g7
 
 Position: 50/50 (nqbnrkrb/pppppppp/8/8/8/8/PPPPPPPP/NQBNRKRB w GEge - 0 1)
-info string NNUE evaluation using nn-2962dca31855.nnue (125MiB, (102384, 1024, 15, 32, 1))
+info string NNUE evaluation using nn-c288c895ea92.nnue (125MiB, (102384, 1024, 15, 32, 1))
 info string NNUE evaluation using nn-37f18f62d772.nnue (6MiB, (22528, 128, 15, 32, 1))
 info string Network replica 1: Shared memory.
 info depth 1 seldepth 2 multipv 1 score cp -15 nodes 20 nps 20000 hashfull 0 tbhits 0 time 1 pv a2a3

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
+#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
### Motivation
- Switch the default big NNUE network to `nn-c288c895ea92.nnue` so the engine uses the requested network identifier.
- Refresh benchmark reference outputs to reflect the new default network name used in evaluation logs.

### Description
- Update the macro `EvalFileDefaultNameBig` in `src/evaluate.h` from `"nn-2962dca31855.nnue"` to `"nn-c288c895ea92.nnue"`.
- Replace occurrences of the old network name in `src/bench_prefetch_on.txt` and `src/bench_prefetch_off.txt` so benchmark outputs match the new default.
- Committed changes across `src/evaluate.h`, `src/bench_prefetch_on.txt`, and `src/bench_prefetch_off.txt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710ba971648327b268582f4166a153)