### PR TITLE
Invoke default signal handler after cleanup

### DIFF
--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -104,6 +104,12 @@ class CleanupHooks {
 
     static void handle_signal(int sig) noexcept {
         SharedMemoryRegistry::cleanup_all();
+        struct sigaction sa;
+        sa.sa_handler = SIG_DFL;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;
+        sigaction(sig, &sa, nullptr);
+        raise(sig);
         _Exit(128 + sig);
     }
 


### PR DESCRIPTION
### Motivation
- Restore the default signal handler before re-raising fatal signals so Linux emits the normal crash feedback (core dump / diagnostic message) when a signal occurs after custom handlers are installed.
- Preserve shared-memory cleanup while ensuring visibility of SIGILL/SIGSEGV/SIGBUS/etc., matching the intent of the upstream Stockfish patch and with no functional change intended beyond reporting.

### Description
- Modified `CleanupHooks::handle_signal` in `src/shm_linux.h` to set `sa.sa_handler = SIG_DFL`, call `sigaction` for the current signal, and `raise(sig)` after running `SharedMemoryRegistry::cleanup_all()`.
- Kept the existing shared-memory cleanup and retained the fallback `_Exit(128 + sig)` in case control returns from `raise`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710cdbdfc88327b6ce7e557ec3f3bb)