### PR TITLE
Rebrand engine to Revolution-4.60-210126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.50-160126
+# Revolution-4.60-210126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.50-160126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.60-210126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.50-160126
+ENGINE_NAME_BASE = Revolution-4.60-210126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.60-210126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-c288c895ea92.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.50-160126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.60-210126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-c288c895ea92.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.50-160126";
-constexpr std::string_view version = "Revolution-4.50-160126";
+constexpr std::string_view engineBaseName = "Revolution-4.60-210126";
+constexpr std::string_view version = "Revolution-4.60-210126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation

- Update the project branding to the new release label so the engine identifies as `Revolution-4.60-210126` in UCI output and documentation. 
- Align build defaults and benchmark headers with the new release name so produced executables include the correct base name and architecture suffixes when compiled.

### Description

- Updated `ENGINE_NAME_BASE` to `Revolution-4.60-210126` in `src/Makefile` so the default executable base name and build artifacts use the new label. 
- Changed `engineBaseName` and `version` to `Revolution-4.60-210126` in `src/misc.cpp` so `engine_uci_name()` and reported version match the rebrand. 
- Replaced release identifier text in `README.md` and the header lines of `src/bench_prefetch_on.txt` and `src/bench_prefetch_off.txt` to reflect the new release label. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710e8887b083279b31c5174f3d9fb3)