### PR TITLE
Handle LLVM PGO profraw generation during profile-build bench

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1068,7 +1068,17 @@ profile-build: $(NNUE_TARGET) config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	$(PGOBENCH) > PGOBENCH.out 2>&1
+	@LLVM_PROFILE_FILE="$(CURDIR)/pgo_%p.profraw" $(PGOBENCH) > PGOBENCH.out 2>&1 ; \
+	rc=$$?; \
+	profraw_count=$$(ls -1 "$(CURDIR)"/pgo_*.profraw 2>/dev/null | wc -l); \
+	if [ $$profraw_count -eq 0 ]; then \
+		echo "exit_code=$$rc"; \
+		tail -n 120 PGOBENCH.out; \
+		exit 1; \
+	fi; \
+	if [ $$rc -ne 0 ]; then \
+		echo "WARNING: bench exited with code $$rc but profraw files exist; continuing."; \
+	fi
 	@tail -n 4 PGOBENCH.out
 	@echo ""
 	@echo "Step 3/4. Building optimized executable ..."


### PR DESCRIPTION
### Motivation
- Prevent `make profile-build` from failing when the PGO benchmark process returns non-zero but LLVM/Clang did produce `.profraw` files, by ensuring the profile runtime can write to a guaranteed-writable path and by making the build decision based on actual profraw presence.

### Description
- Set `LLVM_PROFILE_FILE="$(CURDIR)/pgo_%p.profraw"` for the PGO benchmark invocation and capture the benchmark exit code in `rc`.
- Count generated profraw files in `$(CURDIR)` and `exit 1` with diagnostics if none are found, printing `exit_code=rc` and the last 120 lines of `PGOBENCH.out` for debugging.
- If profraws exist but the bench returned non-zero, print a warning and continue instead of failing the build; still print the final 4 lines of `PGOBENCH.out` as before.
- Preserve the existing Wine/`PGOBENCH` wrapper behavior; the new logic is localized to the benchmark step in `src/Makefile`.

### Testing
- No automated tests were run in this environment; please run `make profile-build` on an MSYS2/clang setup to verify the PGO pipeline and the failure diagnostics described in the PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711fdf6e84832784c9b2711879e72a)