### PR TITLE
Make shared-memory hashing deterministic

### DIFF
--- a/src/numa.h
+++ b/src/numa.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
@@ -1394,8 +1395,10 @@ class LazyNumaReplicatedSystemWide: public NumaReplicatedBase {
         // as a descriminator, locate the hardware/system numadomain this cpuindex belongs to
         CpuIndex    cpu     = *cfg.nodes[idx].begin();  // get a CpuIndex from NumaIndex
         NumaIndex   sys_idx = cfg_sys.is_cpu_assigned(cpu) ? cfg_sys.nodeByCpu.at(cpu) : 0;
-        std::string s       = cfg_sys.to_string() + "$" + std::to_string(sys_idx);
-        return std::hash<std::string>{}(s);
+        char        sys_idx_buf[32];
+        std::snprintf(sys_idx_buf, sizeof(sys_idx_buf), "%zu", static_cast<std::size_t>(sys_idx));
+        std::string s = cfg_sys.to_string() + "$" + sys_idx_buf;
+        return stable_hash(s);
     }
 
     void ensure_present(NumaIndex idx) const {

--- a/src/shm_linux.h
+++ b/src/shm_linux.h
@@ -35,6 +35,8 @@
 #include <type_traits>
 #include <unordered_set>
 
+#include "misc.h"
+
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/file.h>
@@ -176,7 +178,7 @@ class SharedMemory: public detail::SharedMemoryBase {
     }
 
     static std::string make_sentinel_base(const std::string& name) {
-        uint64_t hash = std::hash<std::string>{}(name);
+        uint64_t hash = Stockfish::stable_hash(name);
         char     buf[32];
         std::snprintf(buf, sizeof(buf), "sfshm_%016" PRIx64, static_cast<uint64_t>(hash));
         return buf;
@@ -436,7 +438,9 @@ class SharedMemory: public detail::SharedMemoryBase {
         std::string path = "/dev/shm/";
         path += sentinel_base_;
         path.push_back('.');
-        path += std::to_string(pid);
+        char pid_buf[32];
+        std::snprintf(pid_buf, sizeof(pid_buf), "%ld", static_cast<long>(pid));
+        path += pid_buf;
         return path;
     }
 


### PR DESCRIPTION
### Motivation
- PGO/profile builds could produce non-deterministic results because `std::hash` (and other environment-dependent hashing) and `std::to_string` were used when building identifiers and content hashes, which can include invocation-dependent salts or platform differences. 
- Shared-memory names and sentinel paths used runtime-dependent values (e.g. `pid`, `std::hash<std::string>`, `std::to_string`) that may vary between runs and affect PGO profile data and binary outputs. 
- The goal is to remove invocation-dependent hashing and formatting so profile-guided builds are deterministic without changing runtime functionality.

### Description
- Added a deterministic basic FNV-1a string/raw-data hash helper as `basic_hash` and a `stable_hash` wrapper in `src/misc.h`, and routed `hash_combine`/`get_raw_data_hash` to use it for string/raw data hashes. 
- Replaced uses of `std::hash<std::string>`/`std::hash<T>` in shared-memory and NUMA name/identifier generation with `stable_hash`, and replaced `std::to_string` usage for name composition with `snprintf` formatted buffers (changes in `src/shm.h`).
- Made sentinel and shared-memory base names deterministic by using `Stockfish::stable_hash` and `std::snprintf` in `src/shm_linux.h` (including deterministic PID formatting for sentinel paths). 
- Updated NUMA discriminator calculation to build the string with `snprintf` and use `stable_hash` instead of `std::hash` and `std::to_string` (`src/numa.h`).
- Adjusted the `std::hash<Stockfish::FixedString<N>>` specialization to use `Stockfish::basic_hash` to ensure deterministic hashing of fixed strings (`src/misc.h`).
- Minor include and header adjustments to support the new helpers (`<type_traits>`, `<cstdio>`, and `#include "misc.h"` in `src/shm_linux.h`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69733fc97f0c83279e65bc976c76ca56)