### PR TITLE
Rebrand to Revolution-4.60-230126

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.40-120126
+# Revolution-4.60-230126
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.40-120126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.60-230126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.40-120126
+ENGINE_NAME_BASE = Revolution-4.60-230126
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.60-230126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.40-120126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.60-230126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.40-120126";
-constexpr std::string_view version = "Revolution-4.40-120126";
+constexpr std::string_view engineBaseName = "Revolution-4.60-230126";
+constexpr std::string_view version = "Revolution-4.60-230126";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Bump the engine release identifier to `Revolution-4.60-230126` so the UCI name and produced executables (with architecture suffixes) show the new branding.

### Description
- Updated `engineBaseName` and `version` in `src/misc.cpp` to `Revolution-4.60-230126`.
- Updated `ENGINE_NAME_BASE` in `src/Makefile` to `Revolution-4.60-230126` so generated binary names include the new base and existing arch suffix logic remains intact.
- Replaced release mentions in `README.md`, `src/bench_prefetch_on.txt`, and `src/bench_prefetch_off.txt` to reflect the new version.

### Testing
- No automated tests were run; changes are limited to branding strings and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735ecacd1c8327a356d3b31a56c7e3)