### PR TITLE
Set NNUE defaults to specified networks, add path-safe strict `net.sh`, and embed nets in build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -896,6 +896,8 @@ endif
 # Set NNUE_EMBEDDING_OFF to 'yes' (or '1', 'true', 'on') to disable embedding
 # and skip the automatic download step.
 NNUE_EMBEDDING_OFF ?= no
+NNUE_BIG := nn-c288c895ea92.nnue
+NNUE_SMALL := nn-37f18f62d772.nnue
 
 ifneq ($(filter 1 yes true on,$(NNUE_EMBEDDING_OFF)),)
         NNUE_EMBEDDING_OFF := yes
@@ -1124,7 +1126,7 @@ profileclean:
 
 # evaluation network (nnue)
 net:
-	@$(SHELL) ../scripts/net.sh
+	@cd nnue && $(SHELL) ./net.sh
 
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file
@@ -1205,6 +1207,8 @@ config-sanity: $(NNUE_TARGET)
 
 $(EXE): $(OBJS)
 	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
+	@cp -f nnue/$(NNUE_BIG) ./$(NNUE_BIG)
+	@cp -f nnue/$(NNUE_SMALL) ./$(NNUE_SMALL)
 
 # Force recompilation to ensure version info is up-to-date
 misc.o: FORCE

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-2962dca31855.nnue"
+#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -1,0 +1,10 @@
+#ifndef REVOLUTION_NNUE_EVALUATE_H_INCLUDED
+#define REVOLUTION_NNUE_EVALUATE_H_INCLUDED
+
+// This header is used by src/nnue/net.sh to locate the default NNUE filenames.
+// Keep these in sync with ../evaluate.h.
+
+#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
+#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+
+#endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED

--- a/src/nnue/net.sh
+++ b/src/nnue/net.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+evaluate_file="$script_dir/evaluate.h"
+
+wget_or_curl=$(
+  (command -v wget > /dev/null 2>&1 && echo "wget -qO-") || \
+  (command -v curl > /dev/null 2>&1 && echo "curl -skL")
+)
+
+sha256sum=$(
+  (command -v shasum > /dev/null 2>&1 && echo "shasum -a 256") || \
+  (command -v sha256sum > /dev/null 2>&1 && echo "sha256sum")
+)
+
+if [ -z "$sha256sum" ]; then
+  >&2 echo "Error: sha256sum or shasum -a 256 is required to validate NNUE files."
+  exit 1
+fi
+
+if [ ! -f "$evaluate_file" ]; then
+  >&2 echo "Error: expected $evaluate_file to exist."
+  exit 1
+fi
+
+get_nnue_filename() {
+  grep "$1" "$evaluate_file" | grep "#define" | sed "s/.*\(nn-[a-z0-9]\{12\}.nnue\).*/\1/"
+}
+
+validate_network() {
+  if [ -f "$1" ]; then
+    filename=$(basename "$1")
+    hash="$($sha256sum "$1" | awk '{print $1}' | cut -c 1-12)"
+    if [ "$filename" != "nn-$hash.nnue" ]; then
+      rm -f "$1"
+      return 1
+    fi
+    return 0
+  fi
+  return 1
+}
+
+fetch_network() {
+  _filename="$(get_nnue_filename "$1")"
+
+  if [ -z "$_filename" ]; then
+    >&2 echo "NNUE file name not found for: $1"
+    return 1
+  fi
+
+  target="$script_dir/$_filename"
+
+  if [ -f "$target" ]; then
+    if validate_network "$target"; then
+      echo "Existing $_filename validated, skipping download"
+      return 0
+    else
+      echo "Removing invalid NNUE file: $_filename"
+    fi
+  fi
+
+  if [ -z "$wget_or_curl" ]; then
+    >&2 printf "%s\n" "Neither wget or curl is installed." \
+      "Install one of these tools to download NNUE files automatically."
+    exit 1
+  fi
+
+  for url in \
+    "https://tests.stockfishchess.org/api/nn/$_filename" \
+    "https://github.com/official-stockfish/networks/raw/master/$_filename"; do
+    echo "Downloading from $url ..."
+    if $wget_or_curl "$url" > "$target"; then
+      if validate_network "$target"; then
+        echo "Successfully validated $_filename"
+        return 0
+      else
+        echo "Downloaded $_filename is invalid"
+        continue
+      fi
+    else
+      echo "Failed to download from $url"
+      rm -f "$target"
+    fi
+  done
+
+  >&2 echo "Failed to download $_filename"
+  return 1
+}
+
+fetch_network EvalFileDefaultNameBig && \
+fetch_network EvalFileDefaultNameSmall


### PR DESCRIPTION
### Motivation
- Pin Revolution to the exact NNUE network filenames required for releases and build tooling by changing the default big and small network names to the provided filenames. 
- Ensure `make net` reliably downloads and validates NNUE files from the official sources and fails hard if SHA tools are missing. 
- Guarantee the built engine always finds the NNUE files at runtime by copying the networks next to the executable as a post-build step. 

### Description
- Changed the built-in default NNUE name in `src/evaluate.h` to `nn-c288c895ea92.nnue` while keeping the small net as `nn-37f18f62d772.nnue`.
- Added `src/nnue/evaluate.h` containing the same `EvalFileDefaultNameBig` and `EvalFileDefaultNameSmall` so the downloader can discover filenames without relying on the top-level `evaluate.h` relative path.
- Added a path-safe `src/nnue/net.sh` that computes its own directory, reads the local `src/nnue/evaluate.h`, uses the official download URLs, requires either `shasum -a 256` or `sha256sum` (exits with error if neither is available), strictly validates filenames against the first 12 hex chars of the SHA256, deletes invalid downloads, and retries fallback URL(s).
- Wired the build `net` target to run `cd nnue && ./net.sh` and added a post-link step in `src/Makefile` to copy `src/nnue/nn-c288c895ea92.nnue` and `src/nnue/nn-37f18f62d772.nnue` next to the final executable so the engine finds them at runtime.

### Testing
- Ran `rm -f src/nnue/nn-*.nnue` to remove existing networks (succeeded).
- Ran `make net` from `src` which executed `src/nnue/net.sh` and validated/downloaded both `nn-c288c895ea92.nnue` and `nn-37f18f62d772.nnue` (succeeded); invalid partial downloads are removed and retried by the script.
- Ran `make -j build` from `src` which invoked the `net` step and proceeded to build, but the build failed with compiler errors in `nnue/features/full_threats.cpp` and `nnue/nnue_accumulator.cpp` so runtime UCI checks could not be executed (build failed).
- Because the build did not produce an executable, runtime commands like `./<revolution_binary> uci` / `isready` / `position startpos` / `go depth 1` were not run (skipped due to failed build).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973daeab53c8327b4b8077ecdfe215f)