### PR TITLE
Remove embedded NNUE binaries; restore SF18 EvalFile defaults and handle "<embedded>" loader behavior

### DIFF
--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -86,7 +86,7 @@ class Network {
 
    private:
     void load_user_net(const std::string&, const std::string&);
-    void load_internal();
+    void load_internal(std::string_view currentName);
 
     void initialize();
 


### PR DESCRIPTION
### Motivation
- Remove embedded NNUE weight binaries from the repository to comply with binary-file restrictions while preserving the runtime behavior for embedded nets.
- Restore default `EvalFile`/`EvalFileSmall` UCI option defaults to the Stockfish 18 filenames rather than the literal `"<embedded>"` marker.
- Ensure the NNUE loader can accept the `"<embedded>"` marker and still set `evalFile.current` deterministically when an embedded/net-default load occurs.

### Description
- Deleted supplied embedded files `src/nnue/NNUE_EMBEDDED.txt`, `src/nnue/nn-37f18f62d772.nnue`, and `src/nnue/nn-c288c895ea92.nnue` to remove binary blobs from the tree.
- Restored default EvalFile option values in `src/engine.cpp` to use `EvalFileDefaultNameBig` and `EvalFileDefaultNameSmall` instead of the literal `"<embedded>"` string.
- Updated `Network::load` in `src/nnue/network.cpp` to recognize the `"<embedded>"` marker, map it to the embedded/default net, and track the desired name via a `desiredName` variable so `evalFile.current` is set correctly.
- Added `load_internal(std::string_view currentName)` in `src/nnue/network.cpp`/`src/nnue/network.h` so internal (embedded) loads can set `evalFile.current` to the appropriate name, and adjusted `save` logic to treat `"<embedded>"` as a valid `evalFile.current` when exporting.

### Testing
- No automated builds or runtime tests were executed as part of this update.
- Repository state and file removals were verified by the automated commit operations that removed the embedded files and updated source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fbdcfe07483279b6fd9224c7e8230)