### PR TITLE
Rebrand engine to Revolution-4.70-010226

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.60-230126
+# Revolution-4.70-010226
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.60-230126** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.70-010226** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.60-230126
+ENGINE_NAME_BASE = Revolution-4.70-010226
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.60-230126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.70-010226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.60-230126 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.70-010226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.60-230126";
-constexpr std::string_view version = "Revolution-4.60-230126";
+constexpr std::string_view engineBaseName = "Revolution-4.70-010226";
+constexpr std::string_view version = "Revolution-4.70-010226";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Align engine identification and build-time executable base name with the new release `Revolution-4.70-010226` so the engine and generated binaries report the updated version to UCI GUIs and benchmarks.

### Description
- Update `engineBaseName` and `version` to `Revolution-4.70-010226` in `src/misc.cpp` and set `ENGINE_NAME_BASE = Revolution-4.70-010226` in `src/Makefile`, and refresh branding text in `README.md`, `src/bench_prefetch_off.txt` and `src/bench_prefetch_on.txt`; architecture-specific suffixes (e.g. `-sse41popcnt`, `-avx2`, `-bmi2`, `-FMA3`, `-avx512`) continue to be appended via the Makefile `ENGINE_ARCH_SUFFIX`/`EXE_SUFFIX` logic.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc7c1b2b48327b685ab3aea9cd527)