### PR TITLE
Load embedded NNUE defaults first and log embedded loads

### DIFF
--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -86,7 +86,7 @@ class Network {
 
    private:
     void load_user_net(const std::string&, const std::string&);
-    void load_internal(std::string_view currentName);
+    bool load_internal(std::string_view currentName);
 
     void initialize();
 


### PR DESCRIPTION
### Motivation
- The engine was falling back to the “zeroed fallback” path even when embedded NNUE blobs were present because the default-load control flow iterated filesystem search before using embedded data. 
- The change must force embedded blobs to win for default NNUE names and emit unambiguous one-time logs showing bytes + dims for big and small nets.

### Description
- Route default/default-embedded requests straight to the embedded loader by changing `Network::load` in `src/nnue/network.cpp` to call `load_internal` immediately for defaults or when `<embedded>` is requested. 
- Make `load_internal` return a `bool` (signature updated in `src/nnue/network.h`) so callers can detect embedded validation failure, and fail fast with `info string FATAL: embedded NNUE is invalid/incompatible (this build is broken)` + exit if embedded data is missing/invalid. 
- Add one-time process-wide logging flags (`gLoggedEmbeddedBig` / `gLoggedEmbeddedSmall`) and emit the mandated lines exactly as: `info string NNUE big loaded: <nnue_filename> -> <embedded> (<bytes> bytes, (<dims>))` and equivalent for small, including bytes and dims, printed once per process start. 
- Prevent filesystem search/download attempts for default filenames; retain existing disk-loading behavior for user-specified non-default eval files.

### Testing
- No automated tests were executed in this environment. 
- Changes were compiled conceptually (source edits committed) but runtime/build verification and the required smoke tests (`uci`/`isready`/`ucinewgame`/`position`/`go depth 8` and `bench`) were not run here and should be executed on target build platforms to confirm the two `<embedded>` log lines appear and the old “missing or incompatible, using zeroed fallback” message does not appear.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fcac22b8083278b0da1c806917143)