### PR TITLE
Enforce embedded-first NNUE loading, remove zeroed fallback, and log embedded loads

### DIFF
--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -19,6 +19,7 @@
 #ifndef NETWORK_H_INCLUDED
 #define NETWORK_H_INCLUDED
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -78,6 +79,10 @@ class Network {
                            AccumulatorCaches::Cache<FTDimensions>& cache) const;
 
     bool is_loaded() const noexcept { return initialized; }
+    bool embedded_loaded_ok() const noexcept { return embeddedLoaded; }
+    std::size_t embedded_bytes() const noexcept { return embeddedBytes; }
+    std::array<int, 5> embedded_dims() const noexcept { return embeddedDims; }
+    std::string default_name() const { return std::string(evalFile.defaultName); }
 
     void verify(std::string evalfilePath, const std::function<void(std::string_view)>&) const;
     NnueEvalTrace trace_evaluate(const Position&                         pos,
@@ -85,7 +90,7 @@ class Network {
                                  AccumulatorCaches::Cache<FTDimensions>& cache) const;
 
    private:
-    void load_user_net(const std::string&, const std::string&);
+    bool load_user_net(const std::string&, const std::string&);
     bool load_internal(std::string_view currentName);
 
     void initialize();
@@ -109,6 +114,10 @@ class Network {
     EmbeddedNNUEType embeddedType;
 
     bool initialized = false;
+    bool embeddedLoaded = false;
+
+    std::size_t        embeddedBytes = 0;
+    std::array<int, 5> embeddedDims{};
 
     // Hash value of evaluation function structure
     static constexpr std::uint32_t hash = Transformer::get_hash_value() ^ Arch::get_hash_value();


### PR DESCRIPTION
### Motivation
- Ensure that when the default embedded NNUE filenames are used the engine always loads the embedded blobs and never falls back to a zeroed net. 
- Fail fast on invalid embedded NNUEs and provide an explicit embedded-load log so startup and bench runs show which embedded blobs were used.

### Description
- Updated `Network<...>::load` to treat the default/empty/EvalFile option as an embedded-first path that calls `load_internal()` and returns immediately on success, otherwise only probe disk directories and stop on the first successful disk load.
- Changed `load_user_net()` to return `bool` so the caller can stop iterating directories when a disk load succeeds, and added POD fields on `Network` (`embeddedLoaded`, `embeddedBytes`, `embeddedDims`) with getters to avoid storing `std::string` in the templated trivial type.
- Converted the old “zeroed fallback” behavior into a fail-fast path: if `load_internal()` fails for the default embedded name the engine prints a FATAL `info string` and exits non-zero.
- Added mandatory embedded-load logging from `Engine` (called after `load_networks` / per-network loads) that prints the two required lines: `info string NNUE big loaded: <name> -> <embedded> (<bytes> bytes, (<dims>))` and `info string NNUE small loaded: <name> -> <embedded> (<bytes> bytes, (<dims>))`.

### Testing
- Ran `make -C src -j2` and the build completed successfully producing `src/Revolution-...` (build succeeded).
- Started the engine with the UCI handshake and confirmed the embedded-load lines appear and the legacy fallback string is absent, e.g. startup output included:
```
info string NNUE big loaded: nn-c288c895ea92.nnue -> <embedded> (108919594 bytes, (102384, 1024, 15, 32, 1))
info string NNUE small loaded: nn-37f18f62d772.nnue -> <embedded> (3519630 bytes, (22528, 128, 15, 32, 1))
```
- Verified the fallback message does not appear with a grep (no matches):
```
$ rg "missing or incompatible, using zeroed fallback" /tmp/uci_output.txt || echo "no matches"
no matches
```
- Ran `bench 1` and confirmed bench output contains the embedded-load lines and the engine produced `bestmove`, for example:
```
info string NNUE big loaded: nn-c288c895ea92.nnue -> <embedded> (108919594 bytes, (102384, 1024, 15, 32, 1))
info string NNUE small loaded: nn-37f18f62d772.nnue -> <embedded> (3519630 bytes, (22528, 128, 15, 32, 1))
21:bestmove e2e4 ponder e7e5
```

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fcd86425c8327beb6e9426b0226a7)