### PR TITLE
Port Stockfish fac506bd: SFNNv11 NNUE architecture (+ net name nn-3dd094f3dfcf)

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-c288c895ea92.nnue"
+#define EvalFileDefaultNameBig "nn-3dd094f3dfcf.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -30,8 +30,8 @@ class Position;
 
 namespace Stockfish::Eval::NNUE::Features {
 
-static constexpr int numValidTargets[PIECE_NB] = {0, 6, 12, 10, 10, 12, 8, 0,
-                                                  0, 6, 12, 10, 10, 12, 8, 0};
+static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 8, 0,
+                                                  0, 6, 10, 8, 8, 10, 8, 0};
 
 void init_threat_offsets();
 
@@ -44,7 +44,7 @@ class FullThreats {
     static constexpr std::uint32_t HashValue = 0x8f234cb8u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = 79856;
+    static constexpr IndexType Dimensions = 66864;
 
     // clang-format off
     // Orient a square according to perspective (rotates by 180 for black)
@@ -61,10 +61,10 @@ class FullThreats {
 
     static constexpr int map[PIECE_TYPE_NB-2][PIECE_TYPE_NB-2] = {
       {0,  1, -1,  2, -1, -1},
-      {0,  1,  2,  3,  4,  5},
-      {0,  1,  2,  3, -1,  4},
-      {0,  1,  2,  3, -1,  4},
-      {0,  1,  2,  3,  4,  5},
+      {0,  1,  2,  3,  4, -1},
+      {0,  1,  2,  3, -1, -1},
+      {0,  1,  2,  3, -1, -1},
+      {0,  1,  2,  3,  4, -1},
       {0,  1,  2,  3, -1, -1}
     };
     // clang-format on


### PR DESCRIPTION
### Motivation
- Upgrade the NNUE architecture to SFNNv11 to match the exact upstream Stockfish change and set the new default big net name. 
- Reduce and re-layout threat features to reflect the SFNNv11 feature map so embedded/loaded nets remain compatible.

### Description
- Update default big NNUE filename in `src/evaluate.h` from `nn-c288c895ea92.nnue` to `nn-3dd094f3dfcf.nnue` while keeping the small net `nn-37f18f62d772.nnue` unchanged. 
- Apply upstream SFNNv11 changes to `src/nnue/features/full_threats.h` by updating `numValidTargets`, `Dimensions`, and the `map` table values to the new layout. 
- Provide the two NNUE files locally in the repository build path so the engine can build and run without external downloads: `nn-3dd094f3dfcf.nnue` and `nn-37f18f62d772.nnue`.

### Testing
- Ran `git diff` for the modified files and confirmed only the upstream-intended hunks in `src/evaluate.h` and `src/nnue/features/full_threats.h` were changed. 
- Searched source with `rg -n "SFNNv10|SFNNv11|nn-3dd094f3dfcf|nn-37f18f62d772" src` to verify the new net names appear in the codebase. 
- Built the project with `make -j$(nproc) build` which completed successfully. 
- Executed the engine bench via `./src/Revolution-4.70-010226 bench` which loaded `nn-3dd094f3dfcf.nnue` and `nn-37f18f62d772.nnue` and produced no NNUE compatibility error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de8fd30708327b2a17004a9458c08)