### PR TITLE
Simplify away main history default (upstream 21b0974f)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -619,7 +619,7 @@ void Search::Worker::undo_null_move(Position& pos) { pos.undo_null_move(); }
 
 // Reset histories, usually before a new game
 void Search::Worker::clear() {
-    mainHistory.fill(68);
+    mainHistory.fill(0);
     captureHistory.fill(-689);
     pawnHistory.fill(-1238);
     pawnCorrectionHistory.fill(5);


### PR DESCRIPTION
### Motivation
- Simplify main history default handling so the main history is zeroed instead of relying on a fixed non-zero default, matching upstream intent to remove the hardcoded default value.

### Description
- Change `Search::Worker::clear()` to call `mainHistory.fill(0);` instead of `mainHistory.fill(68);` in `src/search.cpp`.
- Searched the tree for `mainHistoryDefault` and the iterative-deepening decay pattern and found no matching symbols or code to modify, so no other edits were applied.

### Testing
- Ran `git diff --numstat -- src/search.cpp && git diff -- src/search.cpp` and confirmed only `src/search.cpp` was modified (1 insertion, 1 deletion). 
- Ran `rg -n "mainHistoryDefault"` and confirmed there are no matches in the repository. 
- Executed a full build with `make -C src -j4 build`; the first build failed due to a missing NNUE asset but after providing the missing NNUE file the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698deb71011883278781a80306eb6cfe)