### PR TITLE
Rebrand engine to Revolution-4.80-120226 across build and UCI metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Revolution-4.70-010226
+# Revolution-4.80-120226
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.70-010226** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-4.80-120226** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ ifeq ($(target_windows),yes)
 endif
 
 ### Executable naming
-ENGINE_NAME_BASE = Revolution-4.70-010226
+ENGINE_NAME_BASE = Revolution-4.80-120226
 EXE_BASE = $(ENGINE_NAME_BASE)
 EXE_SUFFIX =
 

--- a/src/bench_prefetch_off.txt
+++ b/src/bench_prefetch_off.txt
@@ -1,4 +1,4 @@
-Revolution-4.70-010226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.80-120226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/bench_prefetch_on.txt
+++ b/src/bench_prefetch_on.txt
@@ -1,4 +1,4 @@
-Revolution-4.70-010226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
+Revolution-4.80-120226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)
 info string NNUE file 'nn-2962dca31855.nnue' missing or incompatible, using zeroed fallback
 info string NNUE file 'nn-37f18f62d772.nnue' missing or incompatible, using zeroed fallback
 info string Using 1 thread

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -44,8 +44,8 @@ namespace {
 #  define BUILD_ARCH_SUFFIX ""
 #endif
 
-constexpr std::string_view engineBaseName = "Revolution-4.70-010226";
-constexpr std::string_view version = "Revolution-4.70-010226";
+constexpr std::string_view engineBaseName = "Revolution-4.80-120226";
+constexpr std::string_view version = "Revolution-4.80-120226";
 constexpr std::string_view archSuffix = BUILD_ARCH_SUFFIX;
 constexpr std::string_view authors = "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 


### PR DESCRIPTION
### Motivation
- Update the engine branding so built binaries and runtime UCI identity report `Revolution-4.80-120226` instead of the previous `Revolution-4.70-010226`.
- Ensure compiled binaries include the architecture suffixes (e.g. `-avx2`, `-bmi2`, `-FMA3`, `-avx512`, `-sse41popcnt`) so GUIs like Fritz and CuteChess list the expected names.

### Description
- Changed `ENGINE_NAME_BASE` in `src/Makefile` to `Revolution-4.80-120226` so produced executables use the new base name and preserved architecture suffix logic. 
- Updated `engineBaseName` and `version` in `src/misc.cpp` to `Revolution-4.80-120226` so `engine_info` / UCI `id name` report the new runtime identity. 
- Replaced documentation and benchmark headers to match the new branding in `README.md`, `src/bench_prefetch_on.txt`, and `src/bench_prefetch_off.txt`. 
- Verified that the existing Makefile architecture-to-suffix mappings continue to produce binary names such as `Revolution-4.80-120226-avx2`, `Revolution-4.80-120226-bmi2`, `Revolution-4.80-120226-FMA3`, `Revolution-4.80-120226-avx512`, and `Revolution-4.80-120226-sse41popcnt`.

### Testing
- Searched repository for old/new branding with `rg -n "Revolution-4\.70-010226|Revolution-4\.80-120226"` to confirm replacements, and the search succeeded. 
- Inspected Makefile name resolution with `make -C src -pn ARCH=<arch>` for `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-fma3`, and `x86-64-avx512` and validated `ENGINE_ARCH_SUFFIX` / `EXE_BASE` / `EXE_SUFFIX` values match expected suffixes. 
- Reviewed modified files (`src/Makefile`, `src/misc.cpp`, `README.md`, `src/bench_prefetch_on.txt`, `src/bench_prefetch_off.txt`) to confirm only branding/version text and Makefile base name were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698decfa77948327bc5e42cdf9ccd23d)