### PR TITLE
Fix clang narrowing in NNUE embeddedDims initializer

### DIFF
--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -329,8 +329,8 @@ bool Network<Arch, Transformer>::load_internal(std::string_view currentName) {
 
     embeddedLoaded = true;
     embeddedBytes  = embedded.size;
-    embeddedDims   = {featureTransformer.TotalInputDimensions,
-                      network[0].TransformedFeatureDimensions,
+    embeddedDims   = {static_cast<int>(featureTransformer.TotalInputDimensions),
+                      static_cast<int>(network[0].TransformedFeatureDimensions),
                       network[0].FC_0_OUTPUTS,
                       network[0].FC_1_OUTPUTS,
                       1};


### PR DESCRIPTION
### Motivation
- Clang reports a C++11 narrowing error when `IndexType` (unsigned) values are used in the `embeddedDims` initializer list, so explicit narrowing is required to satisfy the language rules without changing logic or types.

### Description
- Added `static_cast<int>(...)` to `featureTransformer.TotalInputDimensions` and `network[0].TransformedFeatureDimensions` in the `embeddedDims` initializer inside `Network::load_internal` in `src/nnue/network.cpp`, keeping all other elements and logic unchanged.

### Testing
- Built the single translation unit with `make -B network.o COMP=clang`, which compiled successfully; a full `make -j profile-build COMP=clang` run reached compilation of `nnue/network.cpp` with no narrowing diagnostics but linking failed due to environment profile/LLVM tooling missing in this runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698def94c4d08327bfce5a742d23c0da)