### PR TITLE
Set default NNUE filenames and produce revolution.exe

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,10 +39,14 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-	EXE = stockfish.exe
+	EXESUF = .exe
 else
-	EXE = stockfish
+	EXESUF =
 endif
+EXE = revolution$(EXESUF)
+
+NNUE_BIG = nn-5227780996d3.nnue
+NNUE_SMALL = nn-37f18f62d772.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -1021,7 +1025,7 @@ profileclean:
 
 # evaluation network (nnue)
 net:
-	@$(SHELL) ../scripts/net.sh
+	@NNUE_BIG=$(NNUE_BIG) NNUE_SMALL=$(NNUE_SMALL) $(SHELL) ../scripts/net.sh
 
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-49c1193b131c.nnue"
+#define EvalFileDefaultNameBig "nn-5227780996d3.nnue"
 #define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
 
 namespace NNUE {


### PR DESCRIPTION
### Motivation
- Ensure the build downloads/embeds the intended SFNNv13 networks and that Windows builds produce `revolution.exe` rather than the stockfish binary. 
- The repository previously defaulted the big NNUE filename to `nn-49c1193b131c.nnue` and the Makefile produced `stockfish(.exe)`, causing mismatched downloads and output name.

### Description
- Change the big default NNUE name in `src/evaluate.h` to `"nn-5227780996d3.nnue"` and keep the small net as `"nn-37f18f62d772.nnue"` without touching architecture constants. 
- Modify `src/Makefile` to set `EXESUF` and `EXE = revolution$(EXESUF)` so Windows builds emit `revolution.exe`. 
- Add `NNUE_BIG` and `NNUE_SMALL` variables in `src/Makefile` and pass them into the `net` target invocation (`NNUE_BIG=$(NNUE_BIG) NNUE_SMALL=$(NNUE_SMALL) ...`) so the downloader uses the same filenames as the code defaults. 
- No other source logic or files were changed.

### Testing
- Ran `cd src && make net`, which completed successfully (exit code 0) and exercised the downloader. 
- Ran `cd src && ls nn-*.nnue` and confirmed both `nn-5227780996d3.nnue` and `nn-37f18f62d772.nnue` are present. 
- No full builds/profile-builds were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69981d42b51c8327bde3e72f115d64f6)