### PR TITLE
Use absolute executable for PGO bench and stage NNUE nets in profile-build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,9 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-PGOBENCH = $(WINE_PATH) ./$(EXE) bench
+EXE_ABS := $(abspath ./$(EXE))
+EXE_DIR := $(dir $(EXE_ABS))
+PGOBENCH = $(WINE_PATH) "$(EXE_ABS)" bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
@@ -987,6 +989,8 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
+	@src="$(abspath $(NNUE_BIG))";   dst="$(EXE_DIR)$(NNUE_BIG)";   [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
+	@src="$(abspath $(NNUE_SMALL))"; dst="$(EXE_DIR)$(NNUE_SMALL)"; [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
 	$(PGOBENCH) > PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1)
 	tail -n 4 PGOBENCH.out
 	@echo ""


### PR DESCRIPTION
### Motivation
- Ensure the built-in PGO benchmark is invoked reliably when the engine is referenced via an absolute path so it runs regardless of current working directory.
- Ensure the NNUE network files are discoverable by the benchmark when the binary is executed by absolute path by staging them next to the executable.

### Description
- Add `EXE_ABS := $(abspath ./$(EXE))` and `EXE_DIR := $(dir $(EXE_ABS))` to derive an absolute executable path and its directory.
- Change `PGOBENCH` to call the quoted absolute path via `$(WINE_PATH) "$(EXE_ABS)" bench` to avoid relative-path issues.
- In the `profile-build` recipe, copy `NNUE_BIG` and `NNUE_SMALL` into `$(EXE_DIR)` (unless already present) before running the `bench` step.

### Testing
- Ran `make -C src -n profile-build ARCH=native COMP=gcc` to validate recipe expansion and confirm the new `EXE_ABS`/`EXE_DIR` usage and the NNUE staging commands were emitted.
- The dry-run printed the new staging commands but the overall make invocation failed with linker errors in this environment due to missing object files, so the staging lines were verified while a full build was not produced in this test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982ae61c1c8327b1ef695ca0eca5cc)