### PR TITLE
make: force EvalFile/EvalFileSmall paths for PGO bench on Windows/MSYS2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ BINDIR = $(PREFIX)/bin
 ### Built-in benchmark for pgo-builds
 EXE_ABS := $(abspath ./$(EXE))
 EXE_DIR := $(dir $(EXE_ABS))
-PGOBENCH = $(WINE_PATH) "$(EXE_ABS)" bench
+PGOBENCH = cd "$(EXE_DIR)" && $(WINE_PATH) "$(EXE_ABS)" bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
@@ -991,7 +991,15 @@ profile-build: net config-sanity objclean profileclean
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
 	@src="$(abspath $(NNUE_BIG))";   dst="$(EXE_DIR)$(NNUE_BIG)";   [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
 	@src="$(abspath $(NNUE_SMALL))"; dst="$(EXE_DIR)$(NNUE_SMALL)"; [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
-	$(PGOBENCH) > PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1)
+	@(echo "=== PGOBENCH preflight ==="; \
+	  pwd; \
+	  ls -lh "./$(EXE)" "$(NNUE_BIG)" "$(NNUE_SMALL)") > PGOBENCH.out 2>&1
+	@BIG="$(abspath $(NNUE_BIG))"; SMALL="$(abspath $(NNUE_SMALL))"; \
+	if [ "$(target_windows)" = "yes" ] && command -v cygpath > /dev/null 2>&1; then \
+	  BIG="$$(cygpath -w "$(abspath $(NNUE_BIG))")"; \
+	  SMALL="$$(cygpath -w "$(abspath $(NNUE_SMALL))")"; \
+	fi; \
+	printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG" "$$SMALL" | $(WINE_PATH) "./$(EXE)" >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1)
 	tail -n 4 PGOBENCH.out
 	@echo ""
 	@echo "Step 3/4. Building optimized executable ..."


### PR DESCRIPTION
### Motivation
- Ensure the PGO benchmark step uses absolute NNUE paths appropriate for a Windows engine run under MSYS2 so the engine can load the intended networks rather than failing due to POSIX/Windows path mismatches. 
- Capture a short preflight header with CWD, executable, and NNUE file listings to make bench failures easier to diagnose.
- Preserve existing failure diagnostics (tail of `PGOBENCH.out`) so actionable logs remain available when bench fails.

### Description
- Replaced the direct `$(PGOBENCH)` call in `profile-build` Step 2/4 with a UCI-driven bench pipeline that sets `EvalFile` and `EvalFileSmall` via stdin and runs the Windows executable under `$(WINE_PATH)` from `./$(EXE)`. 
- Added logic to compute `BIG`/`SMALL` paths: use `cygpath -w "$(abspath ...)"` when `target_windows = yes` and `cygpath` exists, otherwise use POSIX `$(abspath ...)` values. 
- Wrote a preflight header to `PGOBENCH.out` that logs `pwd` and `ls -lh` for `./$(EXE)`, `$(NNUE_BIG)`, and `$(NNUE_SMALL)` before running the bench. 
- Kept the existing failure handling by appending bench stdout/stderr to `PGOBENCH.out` and printing the last 80 lines on failure.

### Testing
- Performed a dry-run build invocation `make -C src -n profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" lto=no`, which exercised Makefile logic but terminated with linker/compiler errors for missing object files in this environment and therefore did not execute the bench step (test failed for unrelated missing objects). 
- Inspected the updated `src/Makefile` content to verify the new preflight and Windows `cygpath` conditional are present and the UCI `printf` pipeline is correctly formed (inspection succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69982fd3bfe88327b1cef57c772f32f3)