### PR TITLE
Add load_as helper in src/types.h for NNUE compile path

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -38,6 +38,7 @@
 
     #include <cassert>
     #include <cstddef>
+    #include <cstring>
     #include <cstdint>
     #include <type_traits>
     #include "misc.h"
@@ -92,6 +93,17 @@
     #endif
 
 namespace Stockfish {
+
+// --- load_as: strict-aliasing safe typed load from byte pointer ---
+// Used by NNUE layer code paths.
+template<typename T>
+static inline T load_as(const void* p) {
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "load_as requires trivially copyable type");
+    T v;
+    std::memcpy(&v, p, sizeof(T));
+    return v;
+}
 
     #ifdef USE_POPCNT
 constexpr bool HasPopCnt = true;


### PR DESCRIPTION
### Motivation
- Fix a compilation error where NNUE code used an undeclared `load_as` helper by providing a strict-aliasing-safe typed loader in the central types header.

### Description
- Added `#include <cstring>` and a single `Stockfish::load_as<T>(const void*)` template in `src/types.h` (with `static_assert(std::is_trivially_copyable_v<T>)` and `std::memcpy` implementation) and limited edits to `src/types.h` only.

### Testing
- Ran `make -C src objclean`, which succeeded; ran `make -C src -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" lto=no`, which failed, but the first failure occurred after the `load_as` fix during compilation of `nnue/nnue_accumulator.cpp` (compile line: `clang++ ... -c -o nnue_accumulator.o nnue/nnue_accumulator.cpp`) with remaining unrelated errors (missing `ssize`, `sf_unreachable`, etc.).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991038ff8083278296bfadf9964d58)