### PR TITLE
Fix MinGW Clang PGO link by adding libclang profile runtime

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -582,6 +582,8 @@ ifdef COMPCXX
 endif
 
 LLVM_PROFDATA ?= llvm-profdata
+CLANG_RESOURCE_DIR := $(shell $(CXX) -print-resource-dir 2>/dev/null)
+CLANG_PROFILE_RT_WIN := $(CLANG_RESOURCE_DIR)/lib/windows/libclang_rt.profile-x86_64.a
 
 ifeq ($(comp),icx)
 	profile_make = icx-profile-make
@@ -1121,17 +1123,25 @@ FORCE:
 
 clang-profile-make:
 	@command -v $(LLVM_PROFDATA) >/dev/null 2>&1 || (echo "ERROR: $(LLVM_PROFDATA) not found"; exit 1)
+	@if [ "$(target_windows)" = "yes" ] && [ ! -f "$(CLANG_PROFILE_RT_WIN)" ]; then \
+		echo "ERROR: missing Clang profile runtime: $(CLANG_PROFILE_RT_WIN)"; \
+		exit 1; \
+	fi
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-generate' \
-	EXTRALDFLAGS='-fprofile-instr-generate' \
+	EXTRALDFLAGS='-fprofile-instr-generate $(if $(filter yes,$(target_windows)),$(CLANG_PROFILE_RT_WIN))' \
 	all
 
 clang-profile-use:
 	@command -v $(LLVM_PROFDATA) >/dev/null 2>&1 || (echo "ERROR: $(LLVM_PROFDATA) not found"; exit 1)
+	@if [ "$(target_windows)" = "yes" ] && [ ! -f "$(CLANG_PROFILE_RT_WIN)" ]; then \
+		echo "ERROR: missing Clang profile runtime: $(CLANG_PROFILE_RT_WIN)"; \
+		exit 1; \
+	fi
 	$(XCRUN) $(LLVM_PROFDATA) merge -output=default.profdata default.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
 	EXTRACXXFLAGS='-fprofile-instr-use=default.profdata' \
-	EXTRALDFLAGS='-fprofile-instr-use=default.profdata' \
+	EXTRALDFLAGS='-fprofile-instr-use=default.profdata $(if $(filter yes,$(target_windows)),$(CLANG_PROFILE_RT_WIN))' \
 	all
 
 gcc-profile-make:


### PR DESCRIPTION
### Motivation
- On MinGW/CLANG64 PGO builds the linker can miss `__llvm_profile_runtime` because the Clang Windows profile runtime archive isn't passed to the link step.

### Description
- Add `CLANG_RESOURCE_DIR := $(shell $(CXX) -print-resource-dir 2>/dev/null)` and `CLANG_PROFILE_RT_WIN := $(CLANG_RESOURCE_DIR)/lib/windows/libclang_rt.profile-x86_64.a` to `src/Makefile` to locate the Clang profile runtime.
- In `clang-profile-make` and `clang-profile-use` fail fast when `target_windows=yes` and `$(CLANG_PROFILE_RT_WIN)` is missing, printing a clear error.
- Append `$(CLANG_PROFILE_RT_WIN)` to `EXTRALDFLAGS` for the two Clang PGO targets when `target_windows=yes` so the runtime archive is linked into the final executable.

### Testing
- Ran `make -C src objclean` and it completed successfully. (passed)
- Ran `make -C src -j profile-build ARCH=x86-64-sse41-popcnt COMP=clang lto=no EXTRALDFLAGS="-fuse-ld=lld"` and the full profile-build sequence completed successfully, producing the instrumented and optimized builds. (passed)
- Ran a Windows dry-run `make -C src -n clang-profile-use OS=Windows_NT COMP=clang ARCH=x86-64-sse41-popcnt CLANG_RESOURCE_DIR='C:/tools/msys64/clang64/lib/clang/21'` which printed the final link invocation containing `C:/tools/msys64/clang64/lib/clang/21/lib/windows/libclang_rt.profile-x86_64.a`, confirming the runtime archive is appended to the link line. (dry-run output as expected)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c9582174832780c646b685c92a6f)