### PR TITLE
Restore Revolution branding in engine identity output

### DIFF
--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -43,7 +43,7 @@ namespace {
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "dev";
+constexpr std::string_view version = "4.90-210226";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
@@ -117,23 +117,23 @@ class Logger {
 }  // namespace
 
 
-// Returns the full name of the current Stockfish version.
+// Returns the full name of the current Revolution version.
 //
 // For local dev compiles we try to append the commit SHA and
 // commit date from git. If that fails only the local compilation
 // date is set and "nogit" is specified:
-//      Stockfish dev-YYYYMMDD-SHA
+//      Revolution-dev-YYYYMMDD-SHA
 //      or
-//      Stockfish dev-YYYYMMDD-nogit
+//      Revolution-dev-YYYYMMDD-nogit
 //
 // For releases (non-dev builds) we only include the version number:
-//      Stockfish version
+//      Revolution-version
 std::string engine_version_info() {
 #ifdef ENGINE_ID
     return ENGINE_ID;
 #else
     std::stringstream ss;
-    ss << "Stockfish " << version << std::setfill('0');
+    ss << "Revolution-" << version << std::setfill('0');
 
     if constexpr (version == "dev")
     {
@@ -166,7 +166,7 @@ std::string engine_version_info() {
 
 std::string engine_info(bool to_uci) {
     return engine_version_info() + (to_uci ? "\nid author " : " by ")
-         + "the Stockfish developers (see AUTHORS file)";
+         + "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 }
 
 


### PR DESCRIPTION
### Motivation
- Replace Stockfish identity strings with the Revolution branding so the engine reports the requested product/version and author metadata.
- Keep changes strictly limited to branding string literals and comments, without altering any search/eval/nnue/options logic.

### Description
- Updated the default `version` constant from `"dev"` to `"4.90-210226"` in `src/misc.cpp` so the engine prints the release-style version.
- Changed the engine name prefix emitted by `engine_version_info()` from `"Stockfish "` to `"Revolution-"` so headers and UCI reports use `Revolution-4.90-210226`.
- Replaced the generic author text with `"Jorge Ruiz and the Stockfish developers (see AUTHORS file)"` in `engine_info()` so `id author` shows the requested attribution.
- Only `src/misc.cpp` was modified; all other code and logic were left untouched.

### Testing
- Built the engine with `make -C src -j4 build` and the build completed successfully.
- Verified UCI identity with `printf "uci\nquit\n" | ./src/revolution.exe` which printed `id name Revolution-4.90-210226` and `id author Jorge Ruiz and the Stockfish developers (see AUTHORS file)` as expected.
- Ran the built benchmark `./src/revolution.exe bench` and confirmed the startup header begins with `Revolution-4.90-210226 by Jorge Ruiz and the Stockfish developers (see AUTHORS file)`; the benchmark executed and produced normal output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ce9715708327b6b1174f841e29bc)