### PR TITLE
Restore experience UCI options and startup status output

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -64,7 +64,7 @@ SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
 	nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
 	nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
 	book/book_manager.cpp book/book_utils.cpp \
-	engine.cpp score.cpp memory.cpp
+	experience.cpp engine.cpp score.cpp memory.cpp
 
 HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
@@ -72,7 +72,8 @@ HEADERS = benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
 		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
 		position.h search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
-		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h
+		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h \
+		experience.h experience_compat.h experience_zobrist.h
 
 OBJS = $(SRCS:.cpp=.o)
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "evaluate.h"
+#include "experience.h"
 #include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_common.h"
@@ -146,6 +147,31 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Book 2 Width", Option(1, 1, 100));
     options.add("(CTG) Book 2 Only Green", Option(false));
 
+    options.add("Experience Enabled", Option(true, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience File", Option("experience.exp", [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Readonly", Option(false, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Book", Option(false, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Book Width", Option(1, 1, 20, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Book Eval Importance", Option(5, 0, 10, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Book Min Depth", Option(27, 4, 64, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+    options.add("Experience Book Max Moves", Option(16, 1, 100, [this](const Option&) {
+                    return Experience::update_settings(options);
+                }));
+
     options.add(  //
       "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {
           load_big_network(o);
@@ -161,6 +187,7 @@ Engine::Engine(std::optional<std::string> path) :
     load_networks();
     resize_threads();
     bookManager.init(options);
+    Experience::update_settings(options);
 }
 
 std::uint64_t Engine::perft(const std::string& fen, Depth depth, bool isChess960) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -22,6 +22,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+#include <filesystem>
 #include <iterator>
 #include <optional>
 #include <sstream>
@@ -31,6 +32,7 @@
 
 #include "benchmark.h"
 #include "engine.h"
+#include "experience.h"
 #include "memory.h"
 #include "movegen.h"
 #include "position.h"
@@ -123,6 +125,15 @@ void UCIEngine::loop() {
         {
             print_info_string(UciLogo);
             print_info_string(engine_info());
+
+            if (engine.get_options()["Experience Enabled"])
+            {
+                const std::string experienceFile = std::string(engine.get_options()["Experience File"]);
+                if (!experienceFile.empty() && !std::filesystem::exists(experienceFile))
+                    print_info_string("Experience file not found: " + experienceFile);
+
+                print_info_string(Experience::status_summary());
+            }
 
             sync_cout << "id name " << engine_info(true) << "\n"
                       << engine.get_options() << sync_endl;


### PR DESCRIPTION
### Motivation
- Re-enable the engine's existing self-learning experience subsystem visibility by restoring the UCI options and printing a startup status string so clients can see experience file statistics at `uci` time.
- Reuse the repository's existing experience code and APIs rather than introducing a new format or logic, keeping search/eval/nnue untouched.

### Description
- Added the exact UCI options with the requested names, defaults and ranges: `Experience Enabled` (check, default `true`), `Experience File` (string, default `experience.exp`), `Experience Readonly` (check, default `false`), `Experience Book` (check, default `false`), `Experience Book Width` (spin, default `1`, min `1`, max `20`), `Experience Book Eval Importance` (spin, default `5`, min `0`, max `10`), `Experience Book Min Depth` (spin, default `27`, min `4`, max `64`), and `Experience Book Max Moves` (spin, default `16`, min `1`, max `100`).
- Wired each option change to call the existing experience settings updater via `Experience::update_settings(options)` and invoked `Experience::update_settings(options)` at engine startup to initialise the module.
- Emitted experience startup info during `uci` handling: when enabled the engine prints a missing-file info string if the configured experience file is absent and prints the module summary from `Experience::status_summary()` which matches the required format (e.g. `info string experience.exp -> Total moves: 963. Total positions: 963. Duplicate moves: 0. Fragmentation: 0.00%`).
- Ensured the experience compilation unit and headers are included in the build by adding `experience.cpp` and its headers to `src/Makefile` so the new references link correctly.

### Testing
- Built the engine with `make -C src -j4 build` and the build completed successfully after adding `experience.cpp` to the sources. (Succeeded)
- Ran the UCI validation command `printf "uci\nquit\n" | ./src/revolution | rg -n "Experience|info string"` and observed the startup ASCII logo, a missing-file info string when the file was absent, the exact status summary line produced by `Experience::status_summary()`, and the listing of all Experience options; the output matched the required formatting and option names. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d62e76808327941ac51ea51c4d63)