### PR TITLE
Use BMI2+FMA3 for AVX2 builds (Zen4 bench target) in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -708,7 +708,8 @@ endif
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		CXXFLAGS += -mavx2 -mbmi
+		# Zen4: AVX2+BMI2+FMA3 bench target.
+		CXXFLAGS += -mavx2 -mbmi2 -mfma
 	endif
 endif
 


### PR DESCRIPTION
### Motivation
- AVX2-targeted builds should leverage BMI2 and FMA3 to match Zen4 microarchitectural capabilities for benchmark/optimized builds.
- The change must be scoped to AVX2-only code paths and must not leak `-mfma` into SSE builds or alter any other flag blocks.

### Description
- Updated the `avx2` compiler block in `src/Makefile` to replace the old `CXXFLAGS += -mavx2 -mbmi` with a commented note and `CXXFLAGS += -mavx2 -mbmi2 -mfma` for the supported compilers (gcc/clang/mingw/icx).
- Added the comment `# Zen4: AVX2+BMI2+FMA3 bench target.` immediately above the new flags to document intent.
- Minimal diff: replaced `CXXFLAGS += -mavx2 -mbmi` with `# Zen4: AVX2+BMI2+FMA3 bench target.` and `CXXFLAGS += -mavx2 -mbmi2 -mfma`.

### Testing
- `apply_patch` ran successfully and updated `src/Makefile` (file patch applied without errors). 
- A pattern search `rg -n -- "Zen4|mavx2|mbmi2|mfma|mbmi" src/Makefile` confirmed the new comment and `-mavx2 -mbmi2 -mfma` are present and the old `-mbmi` occurrence in the AVX2 block is gone.
- Inspecting the affected lines (`sed -n '704,718p' src/Makefile`) verified the AVX2 block contains the new comment and flags and that SSE-related blocks were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999df7e6c7c83279555a2ab2c51b12f)