### PR TITLE
Wire Experience into search lifecycle, flush on UCI events, and lower Book Min Depth to 4

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -165,7 +165,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience Book Eval Importance", Option(5, 0, 10, [this](const Option&) {
                     return Experience::update_settings(options);
                 }));
-    options.add("Experience Book Min Depth", Option(27, 4, 64, [this](const Option&) {
+    options.add("Experience Book Min Depth", Option(4, 4, 64, [this](const Option&) {
                     return Experience::update_settings(options);
                 }));
     options.add("Experience Book Max Moves", Option(16, 1, 100, [this](const Option&) {

--- a/src/experience.cpp
+++ b/src/experience.cpp
@@ -48,7 +48,7 @@ struct Settings {
     bool        bookEnabled        = false;
     int         bookWidth          = 1;
     int         bookEvalImportance = 5;
-    Depth       bookMinDepth       = 27;
+    Depth       bookMinDepth       = 4;
     int         bookMaxMoves       = 16;
     std::string file               = "experience.exp";
     std::size_t maxEntries         = 200000;
@@ -489,7 +489,7 @@ std::optional<std::string> update_settings(const OptionsMap& options) {
     if (options.count("Experience Book Min Depth"))
         newSettings.bookMinDepth = Depth(std::max(0, int(options["Experience Book Min Depth"])));
     else
-        newSettings.bookMinDepth = Depth(27);
+        newSettings.bookMinDepth = Depth(4);
 
     if (options.count("Experience Book Max Moves"))
         newSettings.bookMaxMoves = std::max(1, int(options["Experience Book Max Moves"]));
@@ -646,8 +646,6 @@ void on_search_complete(const Position& pos,
     if (searchedDepth < settings.bookMinDepth)
         return;
 
-    if (std::abs(bestScore) < settings.minScore)
-        return;
 
     if (settings.readonly)
         return;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -49,6 +49,7 @@
 #include "types.h"
 #include "uci.h"
 #include "ucioption.h"
+#include "experience.h"
 
 namespace Stockfish {
 
@@ -193,6 +194,7 @@ void Search::Worker::start_searching() {
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
                             main_manager()->originalTimeAdjust);
     tt.new_search();
+    Experience::on_new_position(rootPos, rootMoves);
 
     if (rootMoves.empty())
     {
@@ -241,6 +243,13 @@ void Search::Worker::start_searching() {
     // Send again PV info if we have a new best thread
     if (bestThread != this)
         main_manager()->pv(*bestThread, threads, tt, bestThread->completedDepth);
+
+    Experience::on_search_complete(bestThread->rootPos,
+                                   bestThread->rootMoves,
+                                   bestThread->rootMoves[0].score,
+                                   bestThread->rootMoves[0].averageScore,
+                                   bestThread->completedDepth,
+                                   limits);
 
     std::string ponder;
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -112,7 +112,11 @@ void UCIEngine::loop() {
         is >> std::skipws >> token;
 
         if (token == "quit" || token == "stop")
+        {
             engine.stop();
+            engine.wait_for_search_finished();
+            Experience::flush();
+        }
 
         // The GUI sends 'ponderhit' to tell that the user has played the expected move.
         // So, 'ponderhit' is sent if pondering was done on the same move that the user
@@ -153,7 +157,10 @@ void UCIEngine::loop() {
         else if (token == "position")
             position(is);
         else if (token == "ucinewgame")
+        {
             engine.search_clear();
+            Experience::new_game();
+        }
         else if (token == "isready")
             sync_cout << "readyok" << sync_endl;
 


### PR DESCRIPTION
### Motivation
- Ensure the Experience module actually learns from searches by invoking its hooks during the search lifecycle and persisting data on stop/quit/ucinewgame events.
- Make defaults practical so the experience file grows in typical analysis (README documents depth >= 4).

### Description
- Hooked Experience into the search lifecycle by adding `#include "experience.h"` and calling `Experience::on_new_position(rootPos, rootMoves)` immediately after `tt.new_search()` in `src/search.cpp`.
- Record learning at search end by calling `Experience::on_search_complete(...)` with the final `bestThread` root results before ponder extraction in `src/search.cpp`.
- Make UCI commands flush/persist experience by changing `stop`/`quit` handling to call `engine.stop(); engine.wait_for_search_finished(); Experience::flush();` and by invoking `Experience::new_game()` on `ucinewgame` in `src/uci.cpp`.
- Lowered the experience book minimum depth default from `27` to `4` in `src/experience.cpp` and updated the UCI option default in `src/engine.cpp` to match.
- Removed the score-magnitude gate (`std::abs(bestScore) < settings.minScore`) in `on_search_complete()` so quiet positions that meet the depth threshold are recorded.
- Files changed: `src/search.cpp`, `src/uci.cpp`, `src/experience.cpp`, `src/engine.cpp`.

### Testing
- Built the project: `make -C src -j4 build`, and compilation completed successfully.
- Acceptance run: piped UCI commands into the engine and exercised a short search: `printf 'uci\nsetoption name Experience Enabled value true\nsetoption name Experience Readonly value false\nsetoption name Experience Book Min Depth value 4\nposition startpos\ngo depth 8\nquit\n' | ./src/revolution`; this produced a `experience.exp` file containing the header and at least one entry.
- Verified status summary after restart with `printf 'uci\nquit\n' | ./src/revolution` showed non-zero moves/positions, confirming the persisted data was loaded and visible.
- All automated steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999e2d7539c8327a30301d9efe901f8)