### PR TITLE
Revert Makefile to match integrate-experience-tracking branch

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,8 +44,6 @@ else
 	EXESUF =
 endif
 EXE = revolution$(EXESUF)
-EXE_GEN = revolution-pgo-gen$(EXESUF)
-EXE_USE = revolution-pgo-use$(EXESUF)
 
 NNUE_BIG = nn-5227780996d3.nnue
 NNUE_SMALL = nn-37f18f62d772.nnue
@@ -439,12 +437,6 @@ endif
 CXXFLAGS = $(ENV_CXXFLAGS) -Wall -Wcast-qual -fno-exceptions -std=c++17 $(EXTRACXXFLAGS)
 DEPENDFLAGS = $(ENV_DEPENDFLAGS) -std=c++17
 LDFLAGS = $(ENV_LDFLAGS) $(EXTRALDFLAGS)
-ORIG_EXTRACXXFLAGS := $(EXTRACXXFLAGS)
-ORIG_EXTRALDFLAGS := $(EXTRALDFLAGS)
-PROFILE_BASE_EXTRACXXFLAGS := $(filter-out -fprofile-generate -fprofile-generate=% -fprofile-instr-generate -fprofile-instr-generate=%,$(ORIG_EXTRACXXFLAGS))
-PROFILE_BASE_EXTRALDFLAGS := $(filter-out -fprofile-generate -fprofile-generate=% -fprofile-instr-generate -fprofile-instr-generate=% -lgcov,$(ORIG_EXTRALDFLAGS))
-PROFILE_USE_BASE_EXTRACXXFLAGS := $(filter-out -fprofile-generate -fprofile-generate=% -fprofile-instr-generate -fprofile-instr-generate=% -fprofile-use -fprofile-use=% -fprofile-instr-use -fprofile-instr-use=%,$(ORIG_EXTRACXXFLAGS))
-PROFILE_USE_BASE_EXTRALDFLAGS := $(filter-out -fprofile-generate -fprofile-generate=% -fprofile-instr-generate -fprofile-instr-generate=% -fprofile-use -fprofile-use=% -fprofile-instr-use -fprofile-instr-use=% -lgcov,$(ORIG_EXTRALDFLAGS))
 
 ifeq ($(COMP),)
 	COMP=gcc
@@ -985,78 +977,35 @@ analyze: net config-sanity objclean
 build: net config-sanity
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) all
 
-profile-build: net config-sanity objclean
+profile-build: net config-sanity objclean profileclean
 	@echo ""
-	@echo "Step 1/5. Building instrumented executable ..."
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	ORIG_EXTRACXXFLAGS='$(PROFILE_BASE_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(PROFILE_BASE_EXTRALDFLAGS)' \
-	$(profile_make)
+	@echo "Step 1/4. Building instrumented executable ..."
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_make)
 	@echo ""
-	@echo "Step 2/5. Running benchmark for pgo-build ..."
+	@echo "Step 2/4. Running benchmark for pgo-build ..."
 	@src="$(abspath $(NNUE_BIG))";   dst="$(EXE_DIR)$(NNUE_BIG)";   [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
 	@src="$(abspath $(NNUE_SMALL))"; dst="$(EXE_DIR)$(NNUE_SMALL)"; [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
 	@(echo "=== PGOBENCH preflight ==="; \
 	  pwd; \
-	  ls -lh "./$(EXE_GEN)" "$(NNUE_BIG)" "$(NNUE_SMALL)") > PGOBENCH.out 2>&1
-	@rm -f .pgo_step2_start.stamp
-	@touch .pgo_step2_start.stamp
+	  ls -lh "./$(EXE)" "$(NNUE_BIG)" "$(NNUE_SMALL)") > PGOBENCH.out 2>&1
 	@if [ "$(comp)" = "clang" ]; then \
-	  export LLVM_PROFILE_FILE=./pgo_%p.profraw; \
-	  $(WINE_PATH) "./$(EXE_GEN)" bench >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
-	  if ! find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c -newer .pgo_step2_start.stamp | grep -q .; then \
-	    echo "ERROR: Instrumented run did not produce any non-empty pgo_*.profraw files."; \
-	    exit 1; \
-	  fi; \
+	  LLVM_PROFILE_FILE="default.profraw" $(WINE_PATH) "./$(EXE)" bench >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
 	else \
 	  BIG="$(abspath $(NNUE_BIG))"; SMALL="$(abspath $(NNUE_SMALL))"; \
 	  if [ "$(target_windows)" = "yes" ] && command -v cygpath > /dev/null 2>&1; then \
 	    BIG="$$(cygpath -w "$(abspath $(NNUE_BIG))")"; \
 	    SMALL="$$(cygpath -w "$(abspath $(NNUE_SMALL))")"; \
 	  fi; \
-	  printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG" "$$SMALL" | $(WINE_PATH) "./$(EXE_GEN)" >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
+	  printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG" "$$SMALL" | $(WINE_PATH) "./$(EXE)" >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
 	fi
-	@if ! find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c -newer .pgo_step2_start.stamp | grep -q .; then \
-	  echo "ERROR: Step 2 did not produce new non-empty pgo_*.profraw files."; \
-	  exit 1; \
-	fi
-	@rm -f .pgo_step2_start.stamp
 	tail -n 4 PGOBENCH.out
 	@echo ""
-	@echo "Step 3/5. Building optimized executable ..."
+	@echo "Step 3/4. Building optimized executable ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean
-	@rm -f .pgo_step3_build.log
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	ORIG_EXTRACXXFLAGS='$(PROFILE_BASE_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(PROFILE_BASE_EXTRALDFLAGS)' \
-	$(profile_use) | tee .pgo_step3_build.log
-	@if grep -E -q -- 'fprofile-generate|fprofile-instr-generate' .pgo_step3_build.log; then \
-		echo "ERROR: Step 3 build log contains forbidden profile-generate flags."; \
-		exit 1; \
-	fi
-	@if [ ! -s stockfish.profdata ]; then \
-	  echo "ERROR: stockfish.profdata is missing or empty."; \
-	  exit 1; \
-	fi
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) $(profile_use)
 	@echo ""
-	@echo "Step 4/5. Validating binary instrumentation invariants ..."
-	@rm -f pgo_*.profraw
-	@export LLVM_PROFILE_FILE=./pgo_%p.profraw; \
-	$(WINE_PATH) "./$(EXE_GEN)" bench > /dev/null 2>&1 || (echo "ERROR: EXE_GEN invariant run failed."; exit 1)
-	@if ! find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c | grep -q .; then \
-	  echo "ERROR: EXE_GEN did not produce profiling data during invariant check."; \
-	  exit 1; \
-	fi
-	@rm -f pgo_*.profraw
-	@export LLVM_PROFILE_FILE=./pgo_%p.profraw; \
-	$(WINE_PATH) "./$(EXE_USE)" bench > /dev/null 2>&1 || (echo "ERROR: EXE_USE invariant run failed."; exit 1)
-	@if find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c | grep -q .; then \
-	  echo "ERROR: Final binary is instrumented (phantom PGO). Aborting."; \
-	  exit 1; \
-	fi
-	@echo ""
-	@echo "Step 5/5. Deleting profile data ..."
+	@echo "Step 4/4. Deleting profile data ..."
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profileclean
-	@echo ""
-	@echo "PGO pipeline completed: $(EXE_GEN) (gen) and $(EXE_USE) (use)."
 
 strip:
 	$(STRIP) $(EXE)
@@ -1072,14 +1021,13 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f stockfish stockfish.exe $(EXE)
-	@find . -type f \( -name '*.o' -o -name '*.d' \) -delete
+	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f stockfish.profdata default.profdata default.profraw *.profraw .pgo_step2_start.stamp
+	@rm -f stockfish.profdata default.profdata default.profraw *.profraw
 	@rm -f stockfish.*args*
 	@rm -f stockfish.*lt*
 	@rm -f stockfish.res
@@ -1169,12 +1117,6 @@ config-sanity: net
 	 test "$(comp)" = "aarch64-linux-android21-clang")
 
 $(EXE): $(OBJS)
-	@if [ "$@" = "$(EXE_USE)" ]; then \
-		if printf '%s\0' $(OBJS) | xargs -0 nm -g 2>/dev/null | grep -E -q '__llvm_profile|__llvm_profile_runtime|__llvm_profile_instrument'; then \
-			echo "ERROR: Final binary is instrumented (phantom PGO). Aborting."; \
-			exit 1; \
-		fi; \
-	fi
 	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
 
 # Force recompilation to ensure version info is up-to-date
@@ -1183,53 +1125,53 @@ FORCE:
 
 clang-profile-make:
 	@command -v $(LLVM_PROFDATA) >/dev/null 2>&1 || (echo "ERROR: $(LLVM_PROFDATA) not found"; exit 1)
-	@if [ "$(target_windows)" = "yes" ] && [ ! -f "$(CLANG_PROFILE_RT_WIN)" ]; then echo "ERROR: missing Clang profile runtime: $(CLANG_PROFILE_RT_WIN)"; exit 1; fi
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_GEN)' ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS) -fprofile-generate' EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS) -fprofile-generate $(if $(filter yes,$(target_windows)),$(CLANG_PROFILE_RT_WIN))' all
+	@if [ "$(target_windows)" = "yes" ] && [ ! -f "$(CLANG_PROFILE_RT_WIN)" ]; then \
+		echo "ERROR: missing Clang profile runtime: $(CLANG_PROFILE_RT_WIN)"; \
+		exit 1; \
+	fi
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-generate' \
+	EXTRALDFLAGS='-fprofile-instr-generate $(if $(filter yes,$(target_windows)),$(CLANG_PROFILE_RT_WIN))' \
+	all
 
 clang-profile-use:
 	@command -v $(LLVM_PROFDATA) >/dev/null 2>&1 || (echo "ERROR: $(LLVM_PROFDATA) not found"; exit 1)
-	@if ! find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c | grep -q .; then echo "ERROR: no non-empty pgo_*.profraw files found for llvm-profdata merge"; exit 1; fi
-	@if printf '%s\n' '$(PROFILE_USE_BASE_EXTRACXXFLAGS) $(PROFILE_USE_BASE_EXTRALDFLAGS)' | grep -E -q 'fprofile-generate|fprofile-instr-generate|libclang_rt\.profile'; then echo "ERROR: clang-profile-use contains forbidden instrumentation/runtime flags"; exit 1; fi
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata pgo_*.profraw
-	@if [ ! -s stockfish.profdata ]; then echo "ERROR: stockfish.profdata is missing or empty."; exit 1; fi
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_USE)' ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' EXTRACXXFLAGS='$(PROFILE_USE_BASE_EXTRACXXFLAGS) -fprofile-use=stockfish.profdata' EXTRALDFLAGS='$(PROFILE_USE_BASE_EXTRALDFLAGS) -fprofile-use=stockfish.profdata' all
+	@if [ "$(target_windows)" = "yes" ] && [ ! -f "$(CLANG_PROFILE_RT_WIN)" ]; then \
+		echo "ERROR: missing Clang profile runtime: $(CLANG_PROFILE_RT_WIN)"; \
+		exit 1; \
+	fi
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=default.profdata default.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-use=default.profdata' \
+	EXTRALDFLAGS='-fprofile-instr-use=default.profdata $(if $(filter yes,$(target_windows)),$(CLANG_PROFILE_RT_WIN))' \
+	all
 
 gcc-profile-make:
 	@mkdir -p profdir
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_GEN)' \
-	ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' \
-	EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS) -fprofile-generate=profdir $(EXTRAPROFILEFLAGS)' \
-	EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS) -fprofile-generate=profdir' \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-generate=profdir' \
+	EXTRACXXFLAGS+=$(EXTRAPROFILEFLAGS) \
+	EXTRALDFLAGS='-lgcov' \
 	all
 
 gcc-profile-use:
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_USE)' \
-	ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' \
-	EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS) -fprofile-use=profdir -fno-peel-loops -fno-tracer $(EXTRAPROFILEFLAGS)' \
-	EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-use=profdir -fno-peel-loops -fno-tracer' \
+	EXTRACXXFLAGS+=$(EXTRAPROFILEFLAGS) \
+	EXTRALDFLAGS='-lgcov' \
 	all
 
 icx-profile-make:
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_GEN)' \
-	ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' \
-	EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS) -fprofile-generate' \
-	EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS) -fprofile-generate' \
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-generate ' \
+	EXTRALDFLAGS=' -fprofile-instr-generate' \
 	all
 
 icx-profile-use:
-	@if ! find . -maxdepth 1 -name 'pgo_*.profraw' -type f -size +0c | grep -q .; then \
-		echo "ERROR: no non-empty pgo_*.profraw files found for llvm-profdata merge"; \
-		exit 1; \
-	fi
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata pgo_*.profraw
-	@if [ ! -s stockfish.profdata ]; then \
-		echo "ERROR: stockfish.profdata is missing or empty."; \
-		exit 1; \
-	fi
-	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE='$(EXE_USE)' \
-	ORIG_EXTRACXXFLAGS='$(ORIG_EXTRACXXFLAGS)' ORIG_EXTRALDFLAGS='$(ORIG_EXTRALDFLAGS)' \
-	EXTRACXXFLAGS='$(PROFILE_USE_BASE_EXTRACXXFLAGS) -fprofile-use=stockfish.profdata' \
-	EXTRALDFLAGS='$(PROFILE_USE_BASE_EXTRALDFLAGS) -fprofile-use=stockfish.profdata' \
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
+	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
+	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
 .depend: $(SRCS)


### PR DESCRIPTION
### Motivation

- Restore `src/Makefile` to the requested reference state from the `codex/integrate-experience-tracking-in-search-lifecycle` snapshot so the PGO/profile build flow and related targets match that branch. 
- Remove later PGO pipeline additions and phantom-instrumentation invariant checks that were introduced after the referenced point. 
- Keep the build artifact layout simple by using the single `EXE = revolution$(EXESUF)` target and removing auxiliary PGO-only binaries.

### Description

- Replaced the extended PGO flow with the original 4-step `profile-build` flow and updated its internal references to use the primary `$(EXE)` binary. 
- Removed the `EXE_GEN`/`EXE_USE` targets and multiple profile-related guard variables, and simplified the final link rule for `$(EXE)`. 
- Updated the `clang-profile-*`, `gcc-profile-*` and `icx-profile-*` targets to use the expected `-fprofile-instr-generate` / `-fprofile-instr-use` / `-fprofile-generate` / `-fprofile-use` patterns and adjusted linker flags (including `-lgcov`) accordingly. 
- Simplified `objclean` and `profileclean` removal patterns to match the referenced branch and removed transient stamp/validation checks that enforced generation/absence of `.profraw` files.

### Testing

- Verified the `src/Makefile` contents were restored from the target reference and inspected the diff to confirm changes are limited to `src/Makefile` (file stat: 1 file changed, 44 insertions(+), 102 deletions(-)).
- Printed and reviewed relevant `src/Makefile` regions with `nl`/`sed` to confirm the `profile-build`, profile targets, `objclean` and `profileclean` sections match the requested state. 
- Ran repository status and remote-reference checks to ensure the working branch reflects the intended local change and that the reference branch hash was found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f57b5dca88327bb1ef194fb60e08f)