### PR TITLE
Make PGO pipeline emit release exe names from tag + arch suffix

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -44,9 +44,11 @@ else
 	EXESUF =
 endif
 EXE = revolution$(EXESUF)
-RELEASE_EXE ?= $(EXE)
+RELEASE_TAG ?= 4.90-010326
+BUILD_ARCH_SUFFIX ?= -$(ARCH)
+RELEASE_EXE ?= revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)$(EXESUF)
 EXE_USE ?= $(RELEASE_EXE)
-EXE_GEN ?= $(basename $(RELEASE_EXE))-pgo-gen$(EXESUF)
+EXE_GEN ?= revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)-pgo-gen$(EXESUF)
 
 NNUE_BIG = nn-5227780996d3.nnue
 NNUE_SMALL = nn-37f18f62d772.nnue


### PR DESCRIPTION
### Motivation
- Make the user-facing release executable name automatically include a release tag and the architecture suffix so distributed binaries are unambiguous. 
- Preserve existing PGO semantics so GEN remains instrumented and USE remains a non-instrumented final binary.

### Description
- Added `RELEASE_TAG` (default `4.90-010326`) and `BUILD_ARCH_SUFFIX` (default `-$(ARCH)`) and used them to form the release filename. 
- Set `RELEASE_EXE` to `revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)$(EXESUF)`. 
- Kept `EXE_GEN` as `revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)-pgo-gen$(EXESUF)` and set `EXE_USE` exactly to `$(RELEASE_EXE)`. 
- Did not change the existing `verify-pgo` logic or per-architecture support so config-sanity and PGO invariant checks remain in place.

### Testing
- Ran `make -C src config-sanity ARCH=x86-64-sse41-popcnt` and it completed successfully. 
- Ran `make -C src config-sanity` for `ARCH=x86-64-avx2`, `x86-64-bmi2`, and `x86-64-fma3` and they all completed successfully. 
- Verified variable expansion with `make -s -C src ARCH=x86-64-sse41-popcnt --eval 'print-names: ; echo RELEASE_EXE=$(RELEASE_EXE); echo EXE_GEN=$(EXE_GEN); echo EXE_USE=$(EXE_USE)' print-names` and with `target_windows=yes`, both succeeding and producing the expected names. 
- Final produced filenames for `ARCH=x86-64-sse41-popcnt` are: `RELEASE_EXE=revolution-4.90-010326-x86-64-sse41-popcnt.exe`, `EXE_GEN=revolution-4.90-010326-x86-64-sse41-popcnt-pgo-gen.exe`, and `EXE_USE=revolution-4.90-010326-x86-64-sse41-popcnt.exe`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a48e18bd988327a7def2c63388dc6f)