### PR TITLE
Increase default Experience Book Min Depth to 27 and remove unused variable

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -165,7 +165,7 @@ Engine::Engine(std::optional<std::string> path) :
     options.add("Experience Book Eval Importance", Option(5, 0, 10, [this](const Option&) {
                     return Experience::update_settings(options);
                 }));
-    options.add("Experience Book Min Depth", Option(4, 4, 64, [this](const Option&) {
+    options.add("Experience Book Min Depth", Option(27, 4, 64, [this](const Option&) {
                     return Experience::update_settings(options);
                 }));
     options.add("Experience Book Max Moves", Option(16, 1, 100, [this](const Option&) {
@@ -202,7 +202,6 @@ void Engine::go(Search::LimitsType& limits) {
 
     if (limits.perft == 0)
     {
-        const int  bookPly  = pos.game_ply();
         const Move bookMove = bookManager.probe(pos, options);
         if (bookMove != Move::none())
         {


### PR DESCRIPTION
### Motivation

- Adjust the default search depth used when building the experience book to a much higher value to improve quality of stored positions.
- Remove an unused local variable in `Engine::go` to clean up the code and avoid compiler warnings.

### Description

- Change the default value for `"Experience Book Min Depth"` from `4` to `27` in `Engine::Engine` initialization to make experience entries use deeper plies by default.
- Remove the unused declaration `const int bookPly = pos.game_ply();` from `Engine::go` since it was never used.

### Testing

- Performed a full project build with `make` (or equivalent) and compilation completed successfully. 
- Ran the automated test suite via `ctest` and a small smoke `perft` check; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b0d66d848327bccc42b446fd27db)