### PR TITLE
Fix unresolved verify-pgo merge conflict in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1060,68 +1060,49 @@ profile-build: net config-sanity objclean profileclean
 
 verify-pgo:
 	@echo "Checking link lines for PGO flags ..."
-	@grep -E -- '-fprofile-(instr-)?generate' pgo_gen_build.log >/dev/null || (echo "ERROR: GEN link/compile line missing profile generate flags."; exit 1)
-	@grep -E -- '-fprofile-(instr-)?use=default\.profdata' pgo_use_build.log >/dev/null || (echo "ERROR: USE link/compile line missing profile use flag."; exit 1)
-	@if grep -E -- '-fprofile-(instr-)?generate|libclang_rt\.profile' pgo_use_build.log >/dev/null; then \
+	@grep -E -- "-fprofile-(instr-)?generate" pgo_gen_build.log >/dev/null || (echo "ERROR: GEN link/compile line missing profile generate flags."; exit 1)
+	@grep -E -- "-fprofile-(instr-)?use=default\.profdata" pgo_use_build.log >/dev/null || (echo "ERROR: USE link/compile line missing profile use flag."; exit 1)
+	@if grep -E -- "-fprofile-(instr-)?generate|libclang_rt\.profile" pgo_use_build.log >/dev/null; then \
 		echo "ERROR: Final binary is instrumented (phantom PGO). Aborting."; \
 		exit 1; \
 	fi
 	@rm -f __pgo_use_test_*.profraw __pgo_gen_test_*.profraw "$(PROFRAW_VERIFY)"
 	@LLVM_PROFILE_FILE=./__pgo_use_test_%p.profraw $(WINE_PATH) ./$(EXE_USE) bench >/dev/null 2>&1 || true
-	@if find . -maxdepth 1 -name '__pgo_use_test_*.profraw' -type f -size +0c | grep -q .; then \
+	@if find . -maxdepth 1 -name "__pgo_use_test_*.profraw" -type f -size +0c | grep -q .; then \
 		echo "ERROR: Final binary is instrumented (phantom PGO). Aborting."; \
 		exit 1; \
 	fi
 	@if [ "$(comp)" = "clang" ]; then \
-	  rm -f "$(PROFRAW_VERIFY)" verify_pgo.out; \
-codex/fix-verify-pgo-for-missing-exe_gen-in-msys2-m0emr0
-	  if [ -x "./$(EXE_GEN)" ]; then \
-	    printf 'verify-pgo runner: %s\n' "./$(EXE_GEN)" > verify_pgo.out 2>&1; \
-	    ls -la "./$(EXE_GEN)" >> verify_pgo.out 2>&1; \
-	    if [ "$(target_windows)" = "yes" ]; then \
-	      echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY_WIN)\" \"./$(EXE_GEN)\" bench" >> verify_pgo.out 2>&1; \
-	      LLVM_PROFILE_FILE="$(PROFRAW_VERIFY_WIN)" "./$(EXE_GEN)" bench >> verify_pgo.out 2>&1 || true; \
-	    else \
-	      echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY)\" \"./$(EXE_GEN)\" bench" >> verify_pgo.out 2>&1; \
-	      LLVM_PROFILE_FILE="$(PROFRAW_VERIFY)" "./$(EXE_GEN)" bench >> verify_pgo.out 2>&1 || true; \
-	    fi; \
-	    if [ ! -s "$(PROFRAW_VERIFY)" ]; then \
-	      echo "ERROR: PGO failed: no .profraw produced at $(PROFRAW_VERIFY). Aborting to prevent phantom PGO."; \
-	      tail -n 80 verify_pgo.out; \
-	      exit 1; \
-	    fi; \
-	  else \
-	    echo "verify-pgo: EXE_GEN missing; skip GEN verify run; require $(PROFRAW_PATH)" > verify_pgo.out 2>&1; \
-	    if [ ! -s "$(PROFRAW_PATH)" ]; then \
-	      echo "ERROR: missing/empty $(PROFRAW_PATH)"; \
-	      exit 1; \
-	    fi; \
-=======
-	  GEN="./$(EXE_GEN)"; \
-	  if [ ! -x "$$GEN" ]; then GEN="./$(EXE_USE)"; fi; \
-	  printf 'verify-pgo runner: %s\n' "$$GEN" > verify_pgo.out 2>&1; \
-	  ls -la "$$GEN" >> verify_pgo.out 2>&1; \
-	  if [ "$(target_windows)" = "yes" ]; then \
-	    echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY_WIN)\" \"$$GEN\" bench" >> verify_pgo.out 2>&1; \
-	    LLVM_PROFILE_FILE="$(PROFRAW_VERIFY_WIN)" "$$GEN" bench >> verify_pgo.out 2>&1 || true; \
-	  else \
-	    echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY)\" \"$$GEN\" bench" >> verify_pgo.out 2>&1; \
-	    LLVM_PROFILE_FILE="$(PROFRAW_VERIFY)" "$$GEN" bench >> verify_pgo.out 2>&1 || true; \
-	  fi; \
-	  if [ ! -s "$(PROFRAW_VERIFY)" ]; then \
-	    echo "ERROR: PGO failed: no .profraw produced at $(PROFRAW_VERIFY). Aborting to prevent phantom PGO."; \
-	    tail -n 80 verify_pgo.out; \
-	    exit 1; \
- main
-	  fi; \
+		rm -f "$(PROFRAW_VERIFY)" verify_pgo.out; \
+		if [ -x "./$(EXE_GEN)" ]; then \
+			printf "verify-pgo runner: %s\n" "./$(EXE_GEN)" > verify_pgo.out 2>&1; \
+			ls -la "./$(EXE_GEN)" >> verify_pgo.out 2>&1; \
+			if [ "$(target_windows)" = "yes" ]; then \
+				echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY_WIN)\" \"./$(EXE_GEN)\" bench" >> verify_pgo.out 2>&1; \
+				LLVM_PROFILE_FILE="$(PROFRAW_VERIFY_WIN)" "./$(EXE_GEN)" bench >> verify_pgo.out 2>&1 || true; \
+			else \
+				echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY)\" \"./$(EXE_GEN)\" bench" >> verify_pgo.out 2>&1; \
+				LLVM_PROFILE_FILE="$(PROFRAW_VERIFY)" "./$(EXE_GEN)" bench >> verify_pgo.out 2>&1 || true; \
+			fi; \
+			if [ ! -s "$(PROFRAW_VERIFY)" ]; then \
+				echo "ERROR: PGO failed: no .profraw produced at $(PROFRAW_VERIFY)."; \
+				tail -n 80 verify_pgo.out; \
+				exit 1; \
+			fi; \
+		else \
+			echo "verify-pgo: EXE_GEN missing; skip GEN verify run; require $(PROFRAW_PATH)" > verify_pgo.out 2>&1; \
+			if [ ! -s "$(PROFRAW_PATH)" ]; then \
+				echo "ERROR: missing/empty $(PROFRAW_PATH)"; \
+				exit 1; \
+			fi; \
+		fi; \
 	else \
-	  LLVM_PROFILE_FILE=./__pgo_gen_test_%p.profraw $(WINE_PATH) ./$(EXE_GEN) bench >/dev/null 2>&1 || true; \
-	  if ! find . -maxdepth 1 -name '__pgo_gen_test_*.profraw' -type f -size +0c | grep -q .; then \
-	    echo "ERROR: PGO failed: no .profraw produced. Aborting to prevent phantom PGO."; \
-	    exit 1; \
-	  fi; \
+		LLVM_PROFILE_FILE=./__pgo_gen_test_%p.profraw $(WINE_PATH) ./$(EXE_GEN) bench >/dev/null 2>&1 || true; \
+		if ! find . -maxdepth 1 -name "__pgo_gen_test_*.profraw" -type f -size +0c | grep -q .; then \
+			echo "ERROR: PGO failed: no .profraw produced. Aborting to prevent phantom PGO."; \
+			exit 1; \
+		fi; \
 	fi
-
 bench-compare: net config-sanity
 	@echo "Building non-PGO binary ($(RELEASE_EXE)) ..."
 	@$(MAKE) ARCH=$(ARCH) COMP=$(COMP) objclean


### PR DESCRIPTION
### Motivation
- The `verify-pgo` Makefile recipe contained unresolved merge-conflict artifacts (stray branch-name line and conflict markers) that caused a shell/Make syntax error during `verify-pgo` execution.
- The goal was to remove all conflict remnants and restore a single, syntactically valid `verify-pgo` recipe with correct TAB indentation and safe line continuations.

### Description
- Removed all merge-conflict artifacts and stray branch-name lines from the `verify-pgo` recipe in `src/Makefile` and replaced the recipe body with a single coherent clang / non-clang implementation.
- Normalized quoting and escape sequences so the recipe uses proper TAB-indented recipe lines and `\` continuations without trailing spaces.
- Ensured the `PROFRAW_VERIFY` and `PROFRAW_VERIFY_WIN` variables are present near `PROFRAW_PATH` / `PROFRAW_WIN` so the recipe references valid paths for verification.
- Cleaned up leftover tokens (including the stray `codex/...` line and any conflict markers) that previously produced a `missing separator` / shell syntax error.

### Testing
- Ran the conflict-marker scan `grep -nE "(<<<<<<<|=======|>>>>>>>|^codex/)" src/Makefile` and an anchored variant `grep -nE "^(<<<<<<<|=======|>>>>>>>|codex/)" src/Makefile` to confirm no actual merge markers or branch-marker lines remain; the anchored scan returned no matches (no conflict markers found).
- Ran `make -C src verify-pgo ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` to validate the recipe executes to the first guard; `verify-pgo` started but failed with `ERROR: GEN link/compile line missing profile generate flags.` due to missing `pgo_gen_build.log` in this environment, which is expected in a partial CI/dev environment and is the first-failure stop requested.
- Per the instructions to stop at the first failure, `make -C src -j profile-build ...` was not executed after the `verify-pgo` guard failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d74bd14c8327b667e22ce8ef24bd)