### PR TITLE
Simplify Position::attackers_to_exist logic

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -505,13 +505,11 @@ Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 
 bool Position::attackers_to_exist(Square s, Bitboard occupied, Color c) const {
 
-    return ((attacks_bb<ROOK>(s) & pieces(c, ROOK, QUEEN))
-            && (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN)))
-        || ((attacks_bb<BISHOP>(s) & pieces(c, BISHOP, QUEEN))
-            && (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN)))
-        || (((attacks_bb<PAWN>(s, ~c) & pieces(PAWN)) | (attacks_bb<KNIGHT>(s) & pieces(KNIGHT))
-             | (attacks_bb<KING>(s) & pieces(KING)))
-            & pieces(c));
+    return (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN))
+        || (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN))
+        || (attacks_bb<PAWN>(s, ~c) & pieces(c, PAWN))
+        || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT))
+        || (attacks_bb<KING>(s) & pieces(c, KING));
 }
 
 // Tests whether a pseudo-legal move is legal


### PR DESCRIPTION
### Motivation
- Simplify `Position::attackers_to_exist` by porting the upstream Stockfish change so the function uses direct attacker checks for sliding and non-sliding pieces for clearer and correct attacker detection.

### Description
- Replaced the implementation in `src/position.cpp` so the function now returns the exact expression: `return (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN)) || (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN)) || (attacks_bb<PAWN>(s, ~c) & pieces(c, PAWN)) || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT)) || (attacks_bb<KING>(s) & pieces(c, KING));`, and no other files were modified.

### Testing
- Built the engine with `make -C src -j4 build` (succeeded with no compiler warnings) and ran a UCI smoke test using `printf 'uci\nisready\nposition startpos\ngo depth 10\nquit\n' | ./src/revolution` which completed and produced a `bestmove` response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69577f1f8832782fb9b56000b8d16)