### PR TITLE
Rebrand to Revolution 5.0-030326 with arch-tagged UCI name and deterministic binaries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,12 +43,8 @@ ifeq ($(target_windows),yes)
 else
 	EXESUF =
 endif
-EXE = revolution$(EXESUF)
-RELEASE_TAG ?= 4.90-020326
-BUILD_ARCH_SUFFIX ?= -$(ARCH)
-RELEASE_EXE ?= revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)$(EXESUF)
-EXE_USE ?= $(RELEASE_EXE)
-EXE_GEN ?= revolution-$(RELEASE_TAG)$(BUILD_ARCH_SUFFIX)-pgo-gen$(EXESUF)
+ENGINE_BASENAME = Revolution
+RELEASE_TAG ?= 5.0-030326
 
 NNUE_BIG = nn-5227780996d3.nnue
 NNUE_SMALL = nn-37f18f62d772.nnue
@@ -145,6 +141,28 @@ ifeq ($(ARCH), native)
    override ARCH := $(shell $(SHELL) ../scripts/get_native_properties.sh | cut -d " " -f 1)
 endif
 
+ARCH_TAG ?= $(ARCH)
+ifeq ($(ARCH),x86-64-sse41-popcnt)
+   ARCH_TAG := sse41popcnt
+endif
+ifeq ($(ARCH),x86-64-avx2)
+   ARCH_TAG := avx2
+endif
+ifeq ($(ARCH),x86-64-bmi2)
+   ARCH_TAG := bmi2
+endif
+ifeq ($(ARCH),x86-64-avx512)
+   ARCH_TAG := avx512
+endif
+ifeq ($(ARCH),x86-64-fma3)
+   ARCH_TAG := FMA3
+endif
+
+EXE ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)$(EXESUF)
+RELEASE_EXE ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)$(EXESUF)
+EXE_USE ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)$(EXESUF)
+EXE_GEN ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)-pgo-gen$(EXESUF)
+
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
@@ -172,6 +190,7 @@ sse2 = no
 ssse3 = no
 sse41 = no
 avx2 = no
+fma3 = no
 avxvnni = no
 avx512 = no
 vnni512 = no
@@ -264,6 +283,7 @@ ifeq ($(findstring -fma3,$(ARCH)),-fma3)
 	ssse3 = yes
 	sse41 = yes
 	avx2 = yes
+	fma3 = yes
 endif
 
 ifeq ($(findstring -avxvnni,$(ARCH)),-avxvnni)
@@ -729,8 +749,13 @@ endif
 ifeq ($(avx2),yes)
 	CXXFLAGS += -DUSE_AVX2
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
-		# Zen4: AVX2+BMI2+FMA3 bench target.
-		CXXFLAGS += -mavx2 -mbmi2 -mfma
+		CXXFLAGS += -mavx2
+	endif
+endif
+
+ifeq ($(fma3),yes)
+	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
+		CXXFLAGS += -mfma
 	endif
 endif
 
@@ -854,6 +879,8 @@ endif
 ifneq ($(ARCH), )
 	CXXFLAGS += -DARCH=$(ARCH)
 endif
+
+CXXFLAGS += -DENGINE_NAME='"$(ENGINE_BASENAME)"' -DENGINE_VERSION='"$(RELEASE_TAG)-$(ARCH_TAG)"'
 
 ### 3.9 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -39,7 +39,13 @@ namespace Stockfish {
 
 namespace {
 
-// Version number or dev.
+// Engine name and version.
+#ifdef ENGINE_NAME
+constexpr std::string_view engineName = ENGINE_NAME;
+#else
+constexpr std::string_view engineName = "Revolution";
+#endif
+
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
@@ -133,7 +139,7 @@ std::string engine_version_info() {
     return ENGINE_ID;
 #else
     std::stringstream ss;
-    ss << "Revolution-" << version << std::setfill('0');
+    ss << engineName << "-" << version << std::setfill('0');
 
     if constexpr (version == "dev")
     {
@@ -165,7 +171,10 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    return engine_version_info() + (to_uci ? "\nid author " : " by ")
+    const std::string name = to_uci ? std::string(engineName) + " " + std::string(version)
+                                    : engine_version_info();
+
+    return name + (to_uci ? "\nid author " : " by ")
          + "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";
 }
 


### PR DESCRIPTION
### Motivation
- Provide a deterministic, architecture-suffixed engine identity for GUIs and build artifacts while preserving existing Makefile/PGO flows.
- Ensure UCI `id name` reports `Revolution <RELEASE_TAG>-<archtag>` so GUIs show exactly the requested strings.
- Provide a new explicit `x86-64-fma3` ARCH that is AVX2 + `-mfma` (without implicitly enabling BMI2).

### Description
- Updated `src/Makefile` to set `ENGINE_BASENAME = Revolution` and default `RELEASE_TAG ?= 5.0-030326` and introduced `ARCH_TAG` mappings for the requested ARCH values (`sse41popcnt`, `avx2`, `bmi2`, `avx512`, `FMA3`) with fallback to `$(ARCH)`.
- Changed produced executable names to deterministic, space-free forms: `$(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)$(EXESUF)` and PGO generator `-pgo-gen` variant, and kept PGO flow variables (`EXE_GEN`, `EXE_USE`) compatible.
- Added `fma3` feature handling so `x86-64-fma3` sets `avx2` + `-mfma` without implying BMI2, and adjusted AVX2 flags to no longer always add `-mbmi2`/`-mfma`.
- Emitted compile-time defines `-DENGINE_NAME="Revolution"` and `-DENGINE_VERSION="$(RELEASE_TAG)-$(ARCH_TAG)"` and updated `src/misc.cpp` so UCI `id name` prints `ENGINE_NAME + " " + ENGINE_VERSION` while preserving non-UCI version text formatting.

### Testing
- Built all requested ARCH targets with clang using non-LTO (in-container LTO failed due to missing `LLVMgold.so`): `make -C src -j4 build ARCH=<arch> COMP=clang lto=no` for `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-avx512`, and `x86-64-fma3`, and those builds completed successfully.
- An attempted LTO build `make -C src -j4 build ARCH=x86-64-sse41-popcnt COMP=clang` failed in this environment due to missing `LLVMgold` plugin, so `lto=no` was used for verification.
- For each produced binary I ran `printf "uci\nquit\n" | ./src/<binary>` and confirmed the exact `id name` output matched expectations (examples: `Revolution-5.0-030326-sse41popcnt` binary prints `id name Revolution 5.0-030326-sse41popcnt`).
- Produced binary names (examples) and their UCI `id name` values are: `Revolution-5.0-030326-sse41popcnt` -> `id name Revolution 5.0-030326-sse41popcnt`, `Revolution-5.0-030326-avx2` -> `id name Revolution 5.0-030326-avx2`, `Revolution-5.0-030326-bmi2` -> `id name Revolution 5.0-030326-bmi2`, `Revolution-5.0-030326-avx512` -> `id name Revolution 5.0-030326-avx512`, and `Revolution-5.0-030326-FMA3` -> `id name Revolution 5.0-030326-FMA3`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a69b9d653c8327be234e9a5c815d36)