### PR TITLE
Fix avx512icl update_piece_threats bug

### DIFF
--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -64,6 +64,7 @@ const std::vector<std::string> Defaults = {
   "r3k2r/3nnpbp/q2pp1p1/p7/Pp1PPPP1/4BNN1/1P5P/R2Q1RK1 w kq - 0 16",
   "3Qb1k1/1r2ppb1/pN1n2q1/Pp1Pp1Pr/4P2p/4BP2/4B1R1/1R5K b - - 11 40",
   "4k3/3q1r2/1N2r1b1/3ppN2/2nPP3/1B1R2n1/2R1Q3/3K4 w - - 5 1",
+  "1r6/1P4bk/3qr1p1/N6p/3pp2P/6R1/3Q1PP1/1R4K1 w - - 1 42",
 
   // Positions with high numbers of changed threats
   "k7/2n1n3/1nbNbn2/2NbRBn1/1nbRQR2/2NBRBN1/3N1N2/7K w - - 0 1",

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1134,7 +1134,9 @@ void Position::update_piece_threats(Piece                     pc,
         if constexpr (PutPiece)
         {
             dts->threatenedSqs |= threatened;
-            dts->threateningSqs |= square_bb(s);
+            // A bit may only be set if that square actually produces a threat, so we
+            // must guard setting the square accordingly
+            dts->threateningSqs |= Bitboard(bool(threatened)) << s;
         }
 
         DirtyThreat dt_template{pc, NO_PIECE, s, Square(0), PutPiece};
@@ -1148,7 +1150,7 @@ void Position::update_piece_threats(Piece                     pc,
 
     if constexpr (PutPiece)
     {
-        dts->threatenedSqs |= square_bb(s);
+        dts->threatenedSqs |= Bitboard(bool(all_attackers)) << s;  // same as above
         dts->threateningSqs |= all_attackers;
     }
 


### PR DESCRIPTION
### Motivation
- Fix a subtle AVX-512 ICL-specific bug in `Position::update_piece_threats()` that could set the "to" square unconditionally, producing spurious bench behaviour; also add the upstream sample FEN to the benchmark list to cover the case.

### Description
- In `src/position.cpp` (AVX512ICL path) guard the insertion of the "to" square bit so it is only set when `threatened` (for the threatenedSqs/threateningSqs update) or `all_attackers` (for the later threatenedSqs update) is non-zero, and preserve the explanatory comment from upstream.
- In `src/benchmark.cpp` add the upstream FEN "1r6/1P4bk/3qr1p1/N6p/3pp2P/6R1/3Q1PP1/1R4K1 w - - 1 42" to the default benchmarks.

### Testing
- Built and ran the benchmark suite successfully for the local Makefile architectures `x86-64-sse41-popcnt`, `x86-64-avx512`, `x86-64-avx2`, `x86-64-bmi2`, and `x86-64-fma3`; all builds completed and each generated binary ran `bench` to completion without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef1f1b1848327bb24703a725ccb25)