### PR TITLE
Port Stockfish NNUE SFNNv14: update nets, expand FullThreats, add pawn-push threat features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@
 
 Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.10-090326** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
+## Technical note (local patch port, not a new public release)
+
+This tree contains a local manual port of the official Stockfish NNUE architecture update from commit `5eeca7392ee90b7a43da69e647e3d596e42992fd`. It aligns NNUE/FullThreats semantics while preserving current Revolution public identity and release naming.
+
+Technical highlights:
+
+- Ports the official Stockfish SFNNv14 NNUE architecture update.
+- Updates default nets to `nn-7bf13f9655c8.nnue` (big) and `nn-47fc8b7fff06.nnue` (small).
+- Expands FullThreats dimensions from `60144` to `60720`.
+- Adds blocked-pawn threat features via `PawnPushOrAttacks` / `pawn_single_push_bb`.
+- Preserves Revolution branding, UCI identity, and custom experience/release logic while aligning NNUE semantics with the upstream patch.
+
 ## Overview
 
 Revolution is a free and strong UCI chess engine derived from Stockfish that analyzes chess positions and computes optimal moves. The project focuses on experimenting with new ideas and structural changes while retaining compatibility with existing UCI-compliant graphical user interfaces (GUIs).

--- a/src/Makefile
+++ b/src/Makefile
@@ -46,8 +46,8 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.10-090326
 
-NNUE_BIG = nn-5227780996d3.nnue
-NNUE_SMALL = nn-37f18f62d772.nnue
+NNUE_BIG = nn-7bf13f9655c8.nnue
+NNUE_SMALL = nn-47fc8b7fff06.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -155,6 +155,10 @@ constexpr Bitboard pawn_attacks_bb(Bitboard b) {
                       : shift<SOUTH_WEST>(b) | shift<SOUTH_EAST>(b);
 }
 
+constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
+    return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
+}
+
 
 // Returns a bitboard representing an entire line (from board edge
 // to board edge) that intersects the two given squares. If the given squares
@@ -394,6 +398,16 @@ inline constexpr auto PseudoAttacks = []() constexpr {
         attacks[QUEEN][s1] |= attacks[ROOK][s1]  = Bitboards::pseudo_attacks(ROOK, s1);
     }
 
+    return attacks;
+}();
+
+inline constexpr auto PawnPushOrAttacks = []() constexpr {
+    std::array<std::array<Bitboard, SQUARE_NB>, COLOR_NB> attacks{};
+    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
+    {
+        attacks[WHITE][s1] = pawn_single_push_bb(WHITE, square_bb(s1)) | PseudoAttacks[WHITE][s1];
+        attacks[BLACK][s1] = pawn_single_push_bb(BLACK, square_bb(s1)) | PseudoAttacks[BLACK][s1];
+    }
     return attacks;
 }();
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,8 +33,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-5227780996d3.nnue"
-#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameBig "nn-7bf13f9655c8.nnue"
+#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {
 struct Networks;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,7 +4,7 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultNameBig "nn-3dd094f3dfcf.nnue"
-#define EvalFileDefaultNameSmall "nn-37f18f62d772.nnue"
+#define EvalFileDefaultNameBig "nn-7bf13f9655c8.nnue"
+#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -21,6 +21,7 @@
 #include "full_threats.h"
 
 #include <array>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -72,7 +73,7 @@ constexpr auto make_piece_indices_piece() {
 
     for (Square from = SQ_A1; from <= SQ_H8; ++from)
     {
-        Bitboard attacks = PseudoAttacks[C][from];
+        Bitboard attacks = PawnPushOrAttacks[C][from];
 
         for (Square to = SQ_A1; to <= SQ_H8; ++to)
         {
@@ -135,8 +136,8 @@ constexpr auto init_threat_offsets() {
 
             else if (from >= SQ_A2 && from <= SQ_H7)
             {
-                Bitboard attacks = (pieceIdx < 8) ? pawn_attacks_bb<WHITE>(square_bb(from))
-                                                  : pawn_attacks_bb<BLACK>(square_bb(from));
+                Bitboard attacks =
+                  (pieceIdx < 8) ? PawnPushOrAttacks[WHITE][from] : PawnPushOrAttacks[BLACK][from];
                 cumulativePieceOffset += constexpr_popcount(attacks);
             }
         }
@@ -209,6 +210,7 @@ inline sf_always_inline IndexType FullThreats::make_index(
 void FullThreats::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
     Square   ksq      = pos.square<KING>(perspective);
     Bitboard occupied = pos.pieces();
+    Bitboard pawns    = pos.pieces(PAWN);
 
     for (Color color : {WHITE, BLACK})
     {
@@ -245,6 +247,20 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                     Piece     attacked = pos.piece_on(to);
                     IndexType index    = make_index(perspective, attacker, from, to, attacked, ksq);
 
+                    if (index < Dimensions)
+                        active.push_back(index);
+                }
+
+                // Set of pawns which are prevented from movement by a pawn in front of them
+                Bitboard pushers = pawn_single_push_bb(~c, pawns) & pos.pieces(c, PAWN);
+                while (pushers)
+                {
+                    Square from     = pop_lsb(pushers);
+                    Square to       = from + pawn_push(c);
+                    Piece  attacked = pos.piece_on(to);
+                    assert(type_of(attacked) == PAWN);
+
+                    IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
                     if (index < Dimensions)
                         active.push_back(index);
                 }

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -42,7 +42,7 @@ class FullThreats {
     static constexpr std::uint32_t HashValue = 0x8f234cb8u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = 60144;
+    static constexpr IndexType Dimensions = 60720;
 
     // clang-format off
     // Orient a square according to perspective (rotates by 180 for black)

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1125,8 +1125,23 @@ void Position::update_piece_threats(Piece                     pc,
     Bitboard threatened = attacks_bb(pc, s, occupied) & occupied;
     Bitboard sliders    = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
     Bitboard incoming_threats =
-      (PseudoAttacks[KNIGHT][s] & knights) | (attacks_bb<PAWN>(s, WHITE) & blackPawns)
-      | (attacks_bb<PAWN>(s, BLACK) & whitePawns) | (PseudoAttacks[KING][s] & kings);
+      (PseudoAttacks[KNIGHT][s] & knights) | (PseudoAttacks[KING][s] & kings);
+
+    if (type_of(pc) == PAWN)
+    {
+        Bitboard whiteAttacks = PawnPushOrAttacks[WHITE][s];
+        Bitboard blackAttacks = PawnPushOrAttacks[BLACK][s];
+
+        threatened |= (color_of(pc) == WHITE ? whiteAttacks : blackAttacks) & pieces(PAWN);
+
+        incoming_threats |= whiteAttacks & blackPawns;
+        incoming_threats |= blackAttacks & whitePawns;
+    }
+    else
+    {
+        incoming_threats |=
+          (attacks_bb<PAWN>(s, WHITE) & blackPawns) | (attacks_bb<PAWN>(s, BLACK) & whitePawns);
+    }
 
 #ifdef USE_AVX512ICL
     if (threatened)


### PR DESCRIPTION
### Motivation

- Align Revolution NNUE semantics with the official Stockfish NNUE architecture update (SFNNv14) while preserving the local release identity and naming. 
- Ensure threat-features include blocked-pawn (pawn-push) information so NNUE nets trained with the upstream semantics will index features consistently. 

### Description

- Updated default NNUE filenames in `src/Makefile`, `src/evaluate.h`, and `src/nnue/evaluate.h` to `nn-7bf13f9655c8.nnue` (big) and `nn-47fc8b7fff06.nnue` (small). 
- Added `pawn_single_push_bb` and a combined `PawnPushOrAttacks` lookup in `src/bitboard.h`, and switched full-threats feature generation to use these combined pawn push-or-attack bitboards in `src/nnue/features/full_threats.cpp/.h`. 
- Expanded `FullThreats::Dimensions` from `60144` to `60720` in `src/nnue/features/full_threats.h` and added logic to append blocked-pawn (push-prevented) features to active indices in `full_threats.cpp`. 
- Updated `src/position.cpp` threat bookkeeping to consider pawn single-push threats via `PawnPushOrAttacks` for correct `threatened` and `incoming_threats` computation, and added a small include (`<cassert>`) used by the new code. 
- Documented the change in `README.md` with a technical note describing the port, highlights, and intent to preserve Revolution branding while aligning NNUE semantics with upstream. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12721e3008327802bb8389975dad9)