### PR TITLE
Rebrand engine identity to Revolution-5.20-040426 with ISA suffixes and FMA3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Revolution-5.10-090326
+# Revolution-5.20-040426
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.10-090326** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.20-040426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
-## Technical note (local patch port, not a new public release)
+## Technical note
 
-This tree contains a local manual port of the official Stockfish NNUE architecture update from commit `5eeca7392ee90b7a43da69e647e3d596e42992fd`. It aligns NNUE/FullThreats semantics while preserving current Revolution public identity and release naming.
+This release is **Revolution-5.20-040426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
 
 Technical highlights:
 
@@ -194,11 +194,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Nombre UCI esperado | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution 5.10-090326-sse41popcnt` | `Revolution-5.10-090326-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution 5.10-090326-avx2` | `Revolution-5.10-090326-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution 5.10-090326-bmi2` | `Revolution-5.10-090326-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution 5.10-090326-FMA3` | `Revolution-5.10-090326-FMA3[.exe]` |
-| `x86-64-avx512` | `Revolution 5.10-090326-avx512` | `Revolution-5.10-090326-avx512[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-5.20-040426-sse41popcnt` | `Revolution-5.20-040426-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-5.20-040426-avx2` | `Revolution-5.20-040426-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-5.20-040426-bmi2` | `Revolution-5.20-040426-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-5.20-040426-FMA3` | `Revolution-5.20-040426-FMA3[.exe]` |
+| `x86-64-avx512` | `Revolution-5.20-040426-avx512` | `Revolution-5.20-040426-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.20-040426-avx512cl` | `Revolution-5.20-040426-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,7 +44,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.10-090326
+RELEASE_TAG ?= 5.20-040426
 
 NNUE_BIG = nn-7bf13f9655c8.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue
@@ -154,6 +154,12 @@ endif
 ifeq ($(ARCH),x86-64-avx512)
    ARCH_TAG := avx512
 endif
+ifeq ($(ARCH),x86-64-avx512icl)
+   ARCH_TAG := avx512cl
+endif
+ifeq ($(ARCH),x86-64-avx512cl)
+   ARCH_TAG := avx512cl
+endif
 ifeq ($(ARCH),x86-64-fma3)
    ARCH_TAG := FMA3
 endif
@@ -166,7 +172,7 @@ EXE_GEN ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)-pgo-gen$(EXESUF)
 # explicitly check for the list of supported architectures (as listed with make help),
 # the user can override with `make ARCH=x86-64-avx512icl SUPPORTED_ARCH=true`
 ifeq ($(ARCH), $(filter $(ARCH), \
-                 x86-64-avx512icl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
+                 x86-64-avx512icl x86-64-avx512cl x86-64-vnni512 x86-64-avx512 x86-64-avxvnni \
                  x86-64-fma3 x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
@@ -328,6 +334,18 @@ ifeq ($(findstring -vnni512,$(ARCH)),-vnni512)
 	pext = yes
 	avx512 = yes
 	vnni512 = yes
+endif
+
+ifeq ($(findstring -avx512cl,$(ARCH)),-avx512cl)
+	popcnt = yes
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	avx2 = yes
+	pext = yes
+	avx512 = yes
+	avx512icl = yes
 endif
 
 ifeq ($(findstring -avx512icl,$(ARCH)),-avx512icl)
@@ -956,6 +974,7 @@ help:
 	echo "" && \
 	echo "native                  > select the best architecture for the host processor (default)" && \
 	echo "x86-64-avx512icl        > x86 64-bit with minimum avx512 support of Intel Ice Lake or AMD Zen 4" && \
+	echo "x86-64-avx512cl         > alias of x86-64-avx512icl with avx512cl release suffix" && \
 	echo "x86-64-vnni512          > x86 64-bit with vnni 512bit support" && \
 	echo "x86-64-avx512           > x86 64-bit with avx512 support" && \
 	echo "x86-64-avxvnni          > x86 64-bit with vnni 256bit support" && \

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "4.90-020326";
+constexpr std::string_view version = "5.20-040426";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
@@ -171,8 +171,7 @@ std::string engine_version_info() {
 }
 
 std::string engine_info(bool to_uci) {
-    const std::string name = to_uci ? std::string(engineName) + " " + std::string(version)
-                                    : engine_version_info();
+    const std::string name = engine_version_info();
 
     return name + (to_uci ? "\nid author " : " by ")
          + "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";


### PR DESCRIPTION
### Motivation
- Update the project release string to `Revolution-5.20-040426` and ensure the final executable name and GUI-visible UCI engine name include the correct ISA suffix for each compiled target. 
- Preserve the already-ported SFNNv14/NNUE semantics and avoid touching search, experience-file, or NNUE logic except where minimally required for naming/compilation.
- Ensure FMA3 is a first-class build target with correct compile flags and explicit `FMA3` identity.

### Description
- Bumped release tag to `5.20-040426` and preserved the per-ISA naming mechanism by updating `src/Makefile` so `EXE`/`ENGINE_VERSION` generate `$(RELEASE_TAG)-$(ARCH_TAG)` and added explicit `ARCH_TAG` mappings for `x86-64-avx512icl -> avx512cl`, `x86-64-avx512cl -> avx512cl`, and kept `x86-64-fma3 -> FMA3`. 
- Added minimal alias support and wiring for `x86-64-avx512cl` in `src/Makefile` (feature flags block, supported-arch list, and `make help` text) so `avx512cl` appears as an alias of `avx512icl` without removing existing targets. 
- Updated `src/misc.cpp` to set the internal fallback version to `5.20-040426` and changed `engine_info()` so the UCI `id name` prints the hyphenated release+ISA identity (e.g., `Revolution-5.20-040426-avx2`) rather than a space-separated name and version. 
- Updated `README.md` to reference `Revolution-5.20-040426`, include the NNUE notes requested (SFNNv14, default nets, FullThreats, blocked-pawn features) and to list the mandatory ISA-suffixed executable/UCI names including `FMA3` and `avx512cl`.

### Testing
- Built the normal target with `make -C src -j2 build ARCH=x86-64-sse41-popcnt` which succeeded and produced `Revolution-5.20-040426-sse41popcnt` with `ENGINE_VERSION='5.20-040426-sse41popcnt'`. 
- Built the FMA3 target with `make -C src -j2 build ARCH=x86-64-fma3`; an initial parallel attempt encountered a transient NNUE download validation error but a subsequent run completed successfully and produced `Revolution-5.20-040426-FMA3` with `-mfma` present in the compile flags and `ENGINE_VERSION='5.20-040426-FMA3'`. 
- Verified GUI-visible UCI identity by running `printf 'uci
quit
' | ./Revolution-5.20-040426-sse41popcnt` and `printf 'uci
quit
' | ./Revolution-5.20-040426-FMA3`, which returned `id name Revolution-5.20-040426-sse41popcnt` and `id name Revolution-5.20-040426-FMA3` respectively. 
- Performed a dry-run check `make -C src -n build ARCH=x86-64-avx512cl` which shows `ENGINE_VERSION='5.20-040426-avx512cl'` and AVX-512 ICL flags, confirming `avx512cl` naming and flag wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d12bfdd3a48327bc951b7e3b485851)