### PR TITLE
Unify Windows/Wine PGO handling, refactor engine network init, and update NNUE feature transformer

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,6 +37,13 @@ else ifeq ($(COMP),mingw)
 	endif
 endif
 
+RUN_PREFIX :=
+ifeq ($(target_windows),yes)
+	ifneq ($(OS),Windows_NT)
+		RUN_PREFIX := $(WINE_PATH)
+	endif
+endif
+
 ### Executable name
 ifeq ($(target_windows),yes)
 	EXESUF = .exe
@@ -54,13 +61,17 @@ PREFIX = /usr/local
 BINDIR = $(PREFIX)/bin
 
 ### Built-in benchmark for pgo-builds
-EXE_ABS := $(abspath ./$(EXE))
-EXE_DIR := $(dir $(EXE_ABS))
 PROFRAW_PATH := $(CURDIR)/default.profraw
 PROFRAW_WIN := $(shell cygpath -w "$(PROFRAW_PATH)" 2>/dev/null)
 PROFRAW_VERIFY := $(CURDIR)/__pgo_gen_verify.profraw
 PROFRAW_VERIFY_WIN := $(shell cygpath -w "$(PROFRAW_VERIFY)" 2>/dev/null)
-PGOBENCH = cd "$(EXE_DIR)" && $(WINE_PATH) "$(EXE_ABS)" bench
+PROFRAW_RUN := $(PROFRAW_PATH)
+PROFRAW_VERIFY_RUN := $(PROFRAW_VERIFY)
+ifeq ($(target_windows),yes)
+	PROFRAW_RUN := $(PROFRAW_WIN)
+	PROFRAW_VERIFY_RUN := $(PROFRAW_VERIFY_WIN)
+endif
+PGOBENCH = cd "$(CURDIR)" && $(RUN_PREFIX) "./$(EXE_GEN)" bench
 
 ### Source and object files
 SRCS = benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
@@ -1051,52 +1062,15 @@ profile-build: net config-sanity objclean profileclean
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) EXE=$(EXE_GEN) $(profile_make) | tee pgo_gen_build.log
 	@echo ""
 	@echo "Step 2/4. Running benchmark for pgo-build ..."
-	@src="$(abspath $(NNUE_BIG))";   dst="$(EXE_DIR)$(NNUE_BIG)";   [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
-	@src="$(abspath $(NNUE_SMALL))"; dst="$(EXE_DIR)$(NNUE_SMALL)"; [ "$$src" = "$$dst" ] || cp -f "$$src" "$$dst"
-	@(echo "=== PGOBENCH preflight ==="; \
-	  pwd; \
-	  ls -lh "./$(EXE_GEN)" "$(NNUE_BIG)" "$(NNUE_SMALL)") > PGOBENCH.out 2>&1
 	@if [ "$(comp)" = "clang" ]; then \
 	  rm -f "$(PROFRAW_PATH)"; \
-	  echo "PGO bench executable: $(EXE_GEN)" >> PGOBENCH.out 2>&1; \
-	  ls -la "./$(EXE_GEN)" >> PGOBENCH.out 2>&1; \
-	  if [ "$(target_windows)" = "yes" ]; then \
-	    BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-	    SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-	    if command -v winepath >/dev/null 2>&1; then \
-	      BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-	      SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-	    else \
-	      BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-	      SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-	    fi; \
-	    printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | LLVM_PROFILE_FILE="$(PROFRAW_WIN)" $(WINE_PATH) "./$(EXE_GEN)" >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
-	  else \
-	    LLVM_PROFILE_FILE="$(CURDIR)/default.profraw" "./$(EXE_GEN)" bench >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
-	  fi; \
-	  ls -la "$(CURDIR)/default.profraw" >> PGOBENCH.out 2>&1 || true; \
-	  find "$(CURDIR)" -maxdepth 1 -name '*.profraw' -type f -size +0c -ls >> PGOBENCH.out 2>&1 || true; \
+	  LLVM_PROFILE_FILE="$(PROFRAW_RUN)" $(PGOBENCH) > PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
 	  if [ ! -s "$(CURDIR)/default.profraw" ]; then \
 	    echo "ERROR: PGO failed loudly: clang bench did not produce a non-empty $(CURDIR)/default.profraw."; \
-	    echo "ERROR: See PGOBENCH.out diagnostics above for executable path/listing and profraw scan."; \
-	    tail -n 80 PGOBENCH.out; \
 	    exit 1; \
 	  fi; \
 	else \
-	  BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-	  SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-	  BIG_WIN="$$BIG_UNIX"; \
-	  SMALL_WIN="$$SMALL_UNIX"; \
-	  if [ "$(target_windows)" = "yes" ]; then \
-	    if command -v winepath >/dev/null 2>&1; then \
-	      BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-	      SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-	    else \
-	      BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-	      SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-	    fi; \
-	  fi; \
-	  printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | LLVM_PROFILE_FILE="./pgo_%p.profraw" $(WINE_PATH) "./$(EXE_GEN)" >> PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
+	  LLVM_PROFILE_FILE="./pgo_%p.profraw" $(PGOBENCH) > PGOBENCH.out 2>&1 || (echo ""; echo "PGOBENCH FAILED. Last 80 lines:"; tail -n 80 PGOBENCH.out; exit 1); \
 	fi
 	@if [ "$(comp)" = "clang" ]; then \
 	  if [ ! -s "$(CURDIR)/default.profraw" ]; then \
@@ -1130,20 +1104,7 @@ verify-pgo:
 		exit 1; \
 	fi
 	@rm -f __pgo_use_test_*.profraw __pgo_gen_test_*.profraw "$(PROFRAW_VERIFY)"
-	@BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-	SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-	BIG_WIN="$$BIG_UNIX"; \
-	SMALL_WIN="$$SMALL_UNIX"; \
-	if [ "$(target_windows)" = "yes" ]; then \
-	  if command -v winepath >/dev/null 2>&1; then \
-	    BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-	    SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-	  else \
-	    BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-	    SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-	  fi; \
-	fi; \
-	printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | LLVM_PROFILE_FILE=./__pgo_use_test_%p.profraw $(WINE_PATH) ./$(EXE_USE) >/dev/null 2>&1 || true
+	@cd "$(CURDIR)" && LLVM_PROFILE_FILE=./__pgo_use_test_%p.profraw $(RUN_PREFIX) "./$(EXE_USE)" bench >/dev/null 2>&1 || true
 	@if find . -maxdepth 1 -name "__pgo_use_test_*.profraw" -type f -size +0c | grep -q .; then \
 		echo "ERROR: Final binary is instrumented (phantom PGO). Aborting."; \
 		exit 1; \
@@ -1151,27 +1112,9 @@ verify-pgo:
 	@if [ "$(comp)" = "clang" ]; then \
 		rm -f "$(PROFRAW_VERIFY)" verify_pgo.out; \
 		if [ -x "./$(EXE_GEN)" ]; then \
-			printf "verify-pgo runner: %s\n" "./$(EXE_GEN)" > verify_pgo.out 2>&1; \
-			ls -la "./$(EXE_GEN)" >> verify_pgo.out 2>&1; \
-			if [ "$(target_windows)" = "yes" ]; then \
-				BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-				SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-				if command -v winepath >/dev/null 2>&1; then \
-					BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-					SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-				else \
-					BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-					SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-				fi; \
-				printf "verify-pgo command: LLVM_PROFILE_FILE=\"%s\" ./$(EXE_GEN) [uci bench]\n" "$(PROFRAW_VERIFY_WIN)" >> verify_pgo.out 2>&1; \
-				printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | LLVM_PROFILE_FILE="$(PROFRAW_VERIFY_WIN)" $(WINE_PATH) "./$(EXE_GEN)" >> verify_pgo.out 2>&1 || true; \
-			else \
-				echo "LLVM_PROFILE_FILE=\"$(PROFRAW_VERIFY)\" \"./$(EXE_GEN)\" bench" >> verify_pgo.out 2>&1; \
-				LLVM_PROFILE_FILE="$(PROFRAW_VERIFY)" "./$(EXE_GEN)" bench >> verify_pgo.out 2>&1 || true; \
-			fi; \
+			LLVM_PROFILE_FILE="$(PROFRAW_VERIFY_RUN)" $(PGOBENCH) > verify_pgo.out 2>&1 || true; \
 			if [ ! -s "$(PROFRAW_VERIFY)" ]; then \
 				echo "ERROR: PGO failed: no .profraw produced at $(PROFRAW_VERIFY)."; \
-				tail -n 80 verify_pgo.out; \
 				exit 1; \
 			fi; \
 		else \
@@ -1182,20 +1125,7 @@ verify-pgo:
 			fi; \
 		fi; \
 	else \
-		BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-		SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-		BIG_WIN="$$BIG_UNIX"; \
-		SMALL_WIN="$$SMALL_UNIX"; \
-		if [ "$(target_windows)" = "yes" ]; then \
-			if command -v winepath >/dev/null 2>&1; then \
-				BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-				SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-			else \
-				BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-				SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-			fi; \
-		fi; \
-		printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | LLVM_PROFILE_FILE=./__pgo_gen_test_%p.profraw $(WINE_PATH) ./$(EXE_GEN) >/dev/null 2>&1 || true; \
+		cd "$(CURDIR)" && LLVM_PROFILE_FILE=./__pgo_gen_test_%p.profraw $(RUN_PREFIX) "./$(EXE_GEN)" bench >/dev/null 2>&1 || true; \
 		if ! find . -maxdepth 1 -name "__pgo_gen_test_*.profraw" -type f -size +0c | grep -q .; then \
 			echo "ERROR: PGO failed: no .profraw produced. Aborting to prevent phantom PGO."; \
 			exit 1; \
@@ -1208,24 +1138,10 @@ bench-compare: net config-sanity
 	@echo "Building PGO binary ($(EXE_USE)) ..."
 	@$(MAKE) ARCH=$(ARCH) COMP=$(COMP) profile-build
 	@echo "Collecting bench NPS ..."
-	@BIG_UNIX="$(abspath $(NNUE_BIG))"; \
-	SMALL_UNIX="$(abspath $(NNUE_SMALL))"; \
-	BIG_WIN="$$BIG_UNIX"; \
-	SMALL_WIN="$$SMALL_UNIX"; \
-	if [ "$(target_windows)" = "yes" ]; then \
-	  if command -v winepath >/dev/null 2>&1; then \
-	    BIG_WIN="$$(winepath -w "$$BIG_UNIX")"; \
-	    SMALL_WIN="$$(winepath -w "$$SMALL_UNIX")"; \
-	  else \
-	    BIG_WIN="Z:$$(printf '%s' "$$BIG_UNIX" | sed 's#/#\\\\#g')"; \
-	    SMALL_WIN="Z:$$(printf '%s' "$$SMALL_UNIX" | sed 's#/#\\\\#g')"; \
-	  fi; \
-	fi; \
-	echo "Non-PGO:"; \
-	printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | $(WINE_PATH) ./$(RELEASE_EXE) | tee bench_non_pgo.out | tail -n 5; \
+	@echo "Non-PGO:"; \
+	cd "$(CURDIR)" && $(RUN_PREFIX) "./$(RELEASE_EXE)" bench | tee bench_non_pgo.out | tail -n 5; \
 	echo "PGO:"; \
-	printf "uci\nsetoption name EvalFile value %s\nsetoption name EvalFileSmall value %s\nisready\nbench\nquit\n" "$$BIG_WIN" "$$SMALL_WIN" | $(WINE_PATH) ./$(EXE_USE) | tee bench_pgo.out | tail -n 5
-
+	cd "$(CURDIR)" && $(RUN_PREFIX) "./$(EXE_USE)" bench | tee bench_pgo.out | tail -n 5
 strip:
 	$(STRIP) $(EXE)
 

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -64,10 +64,7 @@ Engine::Engine(std::optional<std::string> path) :
     numaContext(NumaConfig::from_system(DefaultNumaPolicy)),
     states(new std::deque<StateInfo>(1)),
     threads(),
-    networks(numaContext,
-             // Heap-allocate because sizeof(NN::Networks) is large
-             std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                            NN::EvalFile{EvalFileDefaultNameSmall, "None", ""})) {
+    networks(numaContext, get_default_networks()) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -184,7 +181,8 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    load_networks();
+    threads.clear();
+    threads.ensure_network_replicated();
     resize_threads();
     bookManager.init(options);
     Experience::update_settings(options);
@@ -345,13 +343,15 @@ void Engine::verify_networks() const {
     }
 }
 
-void Engine::load_networks() {
-    networks.modify_and_replicate([this](NN::Networks& networks_) {
-        networks_.big.load(binaryDirectory, options["EvalFile"]);
-        networks_.small.load(binaryDirectory, options["EvalFileSmall"]);
-    });
-    threads.clear();
-    threads.ensure_network_replicated();
+std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
+    auto networks_ =
+      std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""});
+
+    networks_->big.load(binaryDirectory, "");
+    networks_->small.load(binaryDirectory, "");
+
+    return networks_;
 }
 
 void Engine::load_big_network(const std::string& file) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -86,8 +86,8 @@ class Engine {
 
     // network related
 
+    std::unique_ptr<Eval::NNUE::Networks> get_default_networks() const;
     void verify_networks() const;
-    void load_networks();
     void load_big_network(const std::string& file);
     void load_small_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -122,9 +122,20 @@ class FeatureTransformer {
 
     static constexpr auto InversePackusEpi16Order = invert_permutation(PackusEpi16Order);
 
+    static constexpr std::uint32_t combine_hash(std::initializer_list<std::uint32_t> hashes) {
+        std::uint32_t hash = 0;
+        for (const auto component_hash : hashes)
+        {
+            hash = (hash << 1) | (hash >> 31);
+            hash ^= component_hash;
+        }
+        return hash;
+    }
+
     // Hash value embedded in the evaluation file
     static constexpr std::uint32_t get_hash_value() {
-        return (UseThreats ? ThreatFeatureSet::HashValue : PSQFeatureSet::HashValue)
+        return (UseThreats ? combine_hash({ThreatFeatureSet::HashValue, PSQFeatureSet::HashValue})
+                           : PSQFeatureSet::HashValue)
              ^ (OutputDimensions * 2);
     }
 
@@ -142,13 +153,6 @@ class FeatureTransformer {
 
         if constexpr (UseThreats)
             permute<8>(threatWeights, InversePackusEpi16Order);
-    }
-
-    inline void scale_weights(bool read) {
-        for (auto& w : weights)
-            w = read ? w * 2 : w / 2;
-        for (auto& b : biases)
-            b = read ? b * 2 : b / 2;
     }
 
     // Read network parameters
@@ -171,9 +175,6 @@ class FeatureTransformer {
 
         permute_weights();
 
-        if constexpr (!UseThreats)
-            scale_weights(true);
-
         return !stream.fail();
     }
 
@@ -182,9 +183,6 @@ class FeatureTransformer {
         std::unique_ptr<FeatureTransformer> copy = std::make_unique<FeatureTransformer>(*this);
 
         copy->unpermute_weights();
-
-        if constexpr (!UseThreats)
-            copy->scale_weights(false);
 
         write_leb_128<BiasType>(stream, copy->biases);
 
@@ -277,7 +275,7 @@ class FeatureTransformer {
             constexpr IndexType NumOutputChunks = HalfDimensions / 2 / OutputChunkSize;
 
             const vec_t Zero = vec_zero();
-            const vec_t One  = vec_set_16(UseThreats ? 255 : 127 * 2);
+            const vec_t One  = vec_set_16(255);
 
             const vec_t* in0 = reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][0]));
             const vec_t* in1 =
@@ -397,17 +395,13 @@ class FeatureTransformer {
 
                 if constexpr (UseThreats)
                 {
-                    BiasType sum0t = threatAccumulation[static_cast<int>(perspectives[p])][j + 0];
-                    BiasType sum1t =
+                    sum0 += threatAccumulation[static_cast<int>(perspectives[p])][j + 0];
+                    sum1 +=
                       threatAccumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
-                    sum0 = std::clamp<BiasType>(sum0 + sum0t, 0, 255);
-                    sum1 = std::clamp<BiasType>(sum1 + sum1t, 0, 255);
                 }
-                else
-                {
-                    sum0 = std::clamp<BiasType>(sum0, 0, 127 * 2);
-                    sum1 = std::clamp<BiasType>(sum1, 0, 127 * 2);
-                }
+
+                sum0 = std::clamp<BiasType>(sum0, 0, 255);
+                sum1 = std::clamp<BiasType>(sum1, 0, 255);
 
                 output[offset + j] = static_cast<OutputType>(unsigned(sum0 * sum1) / 512);
             }


### PR DESCRIPTION
### Motivation
- Simplify and unify how the Makefile invokes Windows executables under Wine and streamline PGO/profraw handling across platforms.
- Improve initialization and loading of NNUE networks in `Engine` to avoid duplicated logic and make default network construction explicit.
- Fix and modernize parts of the NNUE `FeatureTransformer` by combining hash values, removing legacy weight scaling, and normalizing clipping/packing behavior for correctness and consistency.

### Description
- Makefile: introduce `RUN_PREFIX` and `PGOBENCH` variables and use `PROFRAW_RUN`/`PROFRAW_VERIFY_RUN` to unify profiler file paths; replace ad-hoc `wine`/`winepath` handling with a single prefix and simplify many PGO/bench/verify invocations to `cd $(CURDIR)` then `$(RUN_PREFIX) "./$(EXE)" bench` style calls; remove unused `EXE_ABS`/`EXE_DIR` usage.
- Engine: replace previous `load_networks()` flow with a new `get_default_networks()` that constructs and preloads default `NN::Networks` and uses it in the `Engine` constructor; update constructor to call `threads.clear()` and `threads.ensure_network_replicated()` after networks are set; add declaration of `get_default_networks()` to `engine.h` and remove `load_networks()` declaration.
- NNUE `FeatureTransformer`: add `combine_hash` to combine multiple feature-set hashes when `UseThreats` is enabled and use it in `get_hash_value()`; remove legacy `scale_weights` logic for read/write and instead rely on permutation/unpermutation without additional scaling; unify clipping/packing semantics by setting the `One` vector to `255` and clamping scalar accumulation to `0..255` with adjusted final scaling in the transform path.

### Testing
- Performed a local non-PGO build with `make` on Linux and the build completed successfully.
- Exercised the PGO workflow with `make profile-build` and `make verify-pgo`, which produced profiler `.profraw` files and passed the verification checks.
- Ran `make bench-compare` to confirm the unified `RUN_PREFIX` invocation works for both non-PGO and PGO executables and observed expected bench output; these runs completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d142a36a708327a620a374f40cf909)