### PR TITLE
Rebrand engine release identifiers to 5.30-090426

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.20-040426
+RELEASE_TAG ?= 5.30-090426
 
 NNUE_BIG = nn-7bf13f9655c8.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "5.20-040426";
+constexpr std::string_view version = "5.30-090426";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and


### PR DESCRIPTION
### Motivation
- Update the default release tag so generated executables and UCI engine IDs use the new branding `5.30-090426`.
- Ensure GUIs (Fritz/CuteChess) show builds with architecture suffixes like `-avx2`, `-bmi2`, `-FMA3`, and `-avx512` according to the compiled ARCH.

### Description
- Changed the default `RELEASE_TAG` in `src/Makefile` from `5.20-040426` to `5.30-090426`, which updates generated executable names via `EXE = $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)`.
- Updated the fallback `version` string in `src/misc.cpp` to `"5.30-090426"` so builds that don't inject `ENGINE_VERSION` also report the new version.

### Testing
- Verified Makefile expansion using `make -C src ARCH=<arch> -s --eval 'print: ; @echo $(EXE)' print` for `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-fma3`, and `x86-64-avx512`, which produced `Revolution-5.30-090426-sse41popcnt`, `Revolution-5.30-090426-avx2`, `Revolution-5.30-090426-bmi2`, `Revolution-5.30-090426-FMA3`, and `Revolution-5.30-090426-avx512` respectively (success).
- Attempted a dry-run build with `make -C src -n build ARCH=x86-64-sse41-popcnt` which returned a truncated output (broken pipe) but was not required to validate the naming changes (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7eb27c624832787ece1e165f96c63)