### PR TITLE
[CI] Cleanup artifact content (part 2)

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -90,7 +90,9 @@ jobs:
           mv ./stockfish$EXT ../stockfish-$NAME-$BINARY$EXT
 
       - name: Remove non src files
-        run: git clean -fx
+        run: |
+          rm -fR temp_builds
+          git clean -fx
 
       - name: Upload artifact for (pre)-release
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation
- Port upstream CI packaging cleanup so temporary `temp_builds` is removed before `git clean -fx` in the compilation job to avoid including transient build artifacts in uploaded artifacts.

### Description
- Updated `.github/workflows/compilation.yml` in the "Remove non src files" step (which runs with `working-directory: src`) to run `rm -fR temp_builds` and then the existing `git clean -fx`.

### Testing
- No automated tests were executed for this change; only repository inspection, diff and commit verification commands were run successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d692b8a883279c01db706f23856b)