### PR TITLE
Rebrand release to Revolution-5.40-190426 across build and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Revolution-5.20-040426
+# Revolution-5.40-190426
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.20-040426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.40-190426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Technical note
 
-This release is **Revolution-5.20-040426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
+This release is **Revolution-5.40-190426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
 
 Technical highlights:
 
@@ -194,12 +194,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Nombre UCI esperado | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution-5.20-040426-sse41popcnt` | `Revolution-5.20-040426-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution-5.20-040426-avx2` | `Revolution-5.20-040426-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution-5.20-040426-bmi2` | `Revolution-5.20-040426-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution-5.20-040426-FMA3` | `Revolution-5.20-040426-FMA3[.exe]` |
-| `x86-64-avx512` | `Revolution-5.20-040426-avx512` | `Revolution-5.20-040426-avx512[.exe]` |
-| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.20-040426-avx512cl` | `Revolution-5.20-040426-avx512cl[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-5.40-190426-sse41popcnt` | `Revolution-5.40-190426-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-5.40-190426-avx2` | `Revolution-5.40-190426-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-5.40-190426-bmi2` | `Revolution-5.40-190426-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-5.40-190426-FMA3` | `Revolution-5.40-190426-FMA3[.exe]` |
+| `x86-64-avx512` | `Revolution-5.40-190426-avx512` | `Revolution-5.40-190426-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.40-190426-avx512cl` | `Revolution-5.40-190426-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.30-090426
+RELEASE_TAG ?= 5.40-190426
 
 NNUE_BIG = nn-7bf13f9655c8.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue


### PR DESCRIPTION
### Motivation
- Update the engine release tag so generated UCI `id name` strings and produced executable names reflect the new branding `Revolution-5.40-190426` for all architecture targets.
- Keep documentation consistent with the build output so GUIs (Fritz, CuteChess, etc.) and users see matching expected names for platform-specific binaries.

### Description
- Changed the release tag in `src/Makefile` from `5.30-090426` to `5.40-190426` so `EXE`/`ENGINE_VERSION` and related targets use the new tag.
- Updated `README.md` headings, release references, and the architecture naming table from the previous `Revolution-5.20-040426`/`-5.30-090426` strings to `Revolution-5.40-190426`.
- Left existing architecture-to-`ARCH_TAG` mappings intact so output names include the correct suffixes (e.g. `sse41popcnt`, `avx2`, `bmi2`, `FMA3`, `avx512`).

### Testing
- Verified presence of the new release tag with `rg` to confirm `RELEASE_TAG ?= 5.40-190426` and unchanged `ARCH_TAG` mappings in `src/Makefile` (succeeded).
- Inspected a dry-run build with `make -C src -n build ARCH=x86-64-avx2` and confirmed the compiler/linker flags include `-DENGINE_VERSION="5.40-190426-avx2"`, showing the runtime/executable name will use the new branding (succeeded).
- Ran `make -C src help` to ensure the build subsystem responds and prints help as expected (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d84e59b88327a76bb2ab53a577f6)