### PR TITLE
Rebrand release to Revolution-5.50-260426 and update build/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Revolution-5.40-190426
+# Revolution-5.50-260426
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.40-190426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.50-260426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Technical note
 
-This release is **Revolution-5.40-190426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
+This release is **Revolution-5.50-260426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
 
 Technical highlights:
 
@@ -175,6 +175,8 @@ This distribution of Revolution consists of the following files:
 
 Revolution supports 32-bit and 64-bit CPUs and the same hardware instruction sets as Stockfish. On Unix-like systems you can compile the engine from the `src` directory with:
 
+The final UCI engine name reported to Fritz/Cute Chess is derived directly from `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` in `src/Makefile`, so each binary announces the architecture-specific suffix shown below.
+
 ```
 cd src
 make -j profile-build
@@ -194,12 +196,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Nombre UCI esperado | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution-5.40-190426-sse41popcnt` | `Revolution-5.40-190426-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution-5.40-190426-avx2` | `Revolution-5.40-190426-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution-5.40-190426-bmi2` | `Revolution-5.40-190426-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution-5.40-190426-FMA3` | `Revolution-5.40-190426-FMA3[.exe]` |
-| `x86-64-avx512` | `Revolution-5.40-190426-avx512` | `Revolution-5.40-190426-avx512[.exe]` |
-| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.40-190426-avx512cl` | `Revolution-5.40-190426-avx512cl[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-5.50-260426-sse41popcnt` | `Revolution-5.50-260426-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-5.50-260426-avx2` | `Revolution-5.50-260426-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-5.50-260426-bmi2` | `Revolution-5.50-260426-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-5.50-260426-FMA3` | `Revolution-5.50-260426-FMA3[.exe]` |
+| `x86-64-avx512` | `Revolution-5.50-260426-avx512` | `Revolution-5.50-260426-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.50-260426-avx512cl` | `Revolution-5.50-260426-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.40-190426
+RELEASE_TAG ?= 5.50-260426
 
 NNUE_BIG = nn-f68ec79f0fe3.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "5.30-090426";
+constexpr std::string_view version = "5.50-260426";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and


### PR DESCRIPTION
### Motivation
- Bump the engine release identifier so compiled binaries and UCI identity reflect the new release `5.50-260426` across the build system and runtime fallback. 
- Ensure architecture-specific UCI names shown by GUIs (Fritz, Cute Chess, etc.) are unambiguous and follow the `ENGINE_BASENAME`/`RELEASE_TAG`/`ARCH_TAG` convention. 
- Update repository documentation to match the new branding and provide a concise, verifiable note about how UCI names are generated from the Makefile.

### Description
- Updated the default release tag in `src/Makefile` from `5.40-190426` to `5.50-260426` so generated executable names use the new release string. 
- Adjusted the fallback compile-time version in `src/misc.cpp` to `5.50-260426` for builds that do not inject `ENGINE_VERSION`. 
- Refreshed `README.md` to replace occurrences of the old release string with `Revolution-5.50-260426` and added a short factual note explaining that the final UCI engine name comes from `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` in `src/Makefile`. 
- Affected files: `src/Makefile`, `src/misc.cpp`, and `README.md`.

### Testing
- Ran a content search with `rg` to confirm all references to the old and new release strings and the `RELEASE_TAG`/`ENGINE_VERSION` settings, which succeeded. 
- Evaluated Makefile name generation with `make -C src -s ARCH=<target> --eval 'print:;@echo $(EXE)'` for `x86-64-sse41-popcnt`, `x86-64-avx2`, `x86-64-bmi2`, `x86-64-fma3`, and `x86-64-avx512`, and verified the produced executable names are `Revolution-5.50-260426-<arch_tag>` as expected. 
- Verified repository state and that the modified files contain the updated version strings, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee38a9a2d083279c3976b40976e8f1)