### PR TITLE
Sync Revolution big NNUE filename authority to nn-fcf986aea78a

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.50-260426
 
-NNUE_BIG = nn-f68ec79f0fe3.nnue
+NNUE_BIG = nn-fcf986aea78a.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue
 
 ### Installation dir definitions

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-f68ec79f0fe3.nnue"
+#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,7 +4,7 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultNameBig "nn-f68ec79f0fe3.nnue"
+#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED


### PR DESCRIPTION
### Motivation
- Apply the upstream main NNUE filename update (nn-f68ec79f0fe3.nnue → nn-fcf986aea78a.nnue) so Revolution's build defaults and network tooling point to the new official big-network file.

### Description
- Updated the big-network filename authority only by replacing the big net name with "nn-fcf986aea78a.nnue" in `src/evaluate.h`, `src/nnue/evaluate.h`, and `src/Makefile` (the `EvalFileDefaultNameBig` and `NNUE_BIG` definitions); `EvalFileDefaultNameSmall` and `NNUE_SMALL` remain `nn-47fc8b7fff06.nnue`; this is strictly a filename-authority synchronization only and no NNUE topology, search behavior, UCI option contract, release identity, or Elo claim was changed.

### Testing
- Automated checks performed: repository-wide searches confirmed no remaining `nn-f68ec79f0fe3.nnue` and the new filename appears only in the three updated authority locations; `make -C src -j2 build` succeeded and the network download/validation fetched `nn-fcf986aea78a.nnue` and the small net; and a UCI smoke test (`printf 'uci\nisready\nquit\n' | ./src/Revolution-5.50-260426-avx512`) completed successfully and reported `EvalFile` default `nn-fcf986aea78a.nnue` and `EvalFileSmall` default `nn-47fc8b7fff06.nnue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00507d63d8832784ec3226974f8bef)