### PR TITLE
Rebrand release to Revolution-5.60-100526 across build and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Revolution-5.50-260426
+# Revolution-5.60-100526
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.50-260426** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.60-100526** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
 ## Technical note
 
-This release is **Revolution-5.50-260426**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
+This release is **Revolution-5.60-100526**. It includes the already-ported official Stockfish SFNNv14 NNUE architecture update while preserving Revolution identity and custom code.
 
 Technical highlights:
 
@@ -196,12 +196,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Nombre UCI esperado | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution-5.50-260426-sse41popcnt` | `Revolution-5.50-260426-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution-5.50-260426-avx2` | `Revolution-5.50-260426-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution-5.50-260426-bmi2` | `Revolution-5.50-260426-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution-5.50-260426-FMA3` | `Revolution-5.50-260426-FMA3[.exe]` |
-| `x86-64-avx512` | `Revolution-5.50-260426-avx512` | `Revolution-5.50-260426-avx512[.exe]` |
-| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.50-260426-avx512cl` | `Revolution-5.50-260426-avx512cl[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-5.60-100526-sse41popcnt` | `Revolution-5.60-100526-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-5.60-100526-avx2` | `Revolution-5.60-100526-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-5.60-100526-bmi2` | `Revolution-5.60-100526-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-5.60-100526-fma3` | `Revolution-5.60-100526-fma3[.exe]` |
+| `x86-64-avx512` | `Revolution-5.60-100526-avx512` | `Revolution-5.60-100526-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.60-100526-avx512cl` | `Revolution-5.60-100526-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.50-260426
+RELEASE_TAG ?= 5.60-100526
 
 NNUE_BIG = nn-fcf986aea78a.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue
@@ -175,7 +175,7 @@ ifeq ($(ARCH),x86-64-FMA3)
    ARCH := x86-64-fma3
 endif
 ifeq ($(ARCH),x86-64-fma3)
-   ARCH_TAG := FMA3
+   ARCH_TAG := fma3
 endif
 
 EXE ?= $(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)$(EXESUF)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "5.50-260426";
+constexpr std::string_view version = "5.60-100526";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and


### PR DESCRIPTION
### Motivation
- Update the shipped release identifier so generated binaries and UCI names reflect the new brand `Revolution-5.60-100526`.
- Ensure architecture suffixes used in UCI/executable names are consistent and appear correctly in GUIs (e.g., `fma3` in lowercase).
- Keep the fallback internal version string in code aligned with the documented release tag to avoid mismatches for non-Makefile builds.

### Description
- Changed the default `RELEASE_TAG` in `src/Makefile` from `5.50-260426` to `5.60-100526` so built binaries and UCI names use the new version.
- Normalized the FMA3 architecture tag by setting `ARCH_TAG := fma3` for `x86-64-fma3` targets to produce `Revolution-5.60-100526-fma3` consistently.
- Updated the fallback version constant in `src/misc.cpp` from `5.50-260426` to `5.60-100526` for non-Makefile/embedded builds.
- Refreshed `README.md` headings and the architecture/executable table to document the new release name and expected UCI/executable identifiers for `sse41popcnt`, `avx2`, `bmi2`, `fma3`, `avx512`, and `avx512cl`.

### Testing
- Ran `make -C src help` to validate the Makefile and confirm the help output can be generated correctly, and the command completed successfully.
- Verified textual replacements and version references with `rg -n` against `README.md`, `src/Makefile`, and `src/misc.cpp`, and all expected occurrences were found and updated.
- Inspected `make help` tail output to ensure build targets remain listed and no syntax errors were introduced, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0052cd0d28832780e0657ef5d1d91b)