### PR TITLE
Align dual-net big NNUE authority to nn-83a0d6daf7e5.nnue

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.60-100526
 
-NNUE_BIG = nn-fcf986aea78a.nnue
+NNUE_BIG = nn-83a0d6daf7e5.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue
 
 ### Installation dir definitions

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -33,7 +33,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
+#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,7 +4,7 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultNameBig "nn-fcf986aea78a.nnue"
+#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED


### PR DESCRIPTION
### Motivation
- Prepare the dual-net Revolution tree for a later single-net migration by updating the big NNUE default to the modern Stockfish authority while keeping the dual-net runtime untouched. 
- Ensure the build and UCI-exposed defaults match the official Stockfish big network identifier `nn-83a0d6daf7e5.nnue` without renaming or collapsing any dual-net identifiers.

### Description
- Replaced the big NNUE filename `nn-fcf986aea78a.nnue` with `nn-83a0d6daf7e5.nnue` in the authority locations. 
- Modified `src/evaluate.h`, `src/nnue/evaluate.h`, and `src/Makefile` to update `EvalFileDefaultNameBig` and `NNUE_BIG` respectively. 
- Preserved `EvalFileDefaultNameSmall`, `EvalFileSmall`, `NNUE_SMALL`, and all dual-net symbols and runtime surfaces; no identifier renames or topology/runtime changes were made.

### Testing
- Ran scoped greps to validate presence of `#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"` in `src/evaluate.h` and `src/nnue/evaluate.h` and `NNUE_BIG = nn-83a0d6daf7e5.nnue` in `src/Makefile`, and confirmed `nn-fcf986aea78a.nnue` is absent. All checks passed. 
- Executed `make -C src net` to fetch/validate networks and confirmed both `nn-83a0d6daf7e5.nnue` and `nn-47fc8b7fff06.nnue` are available. 
- Performed a clean build with `ARCH=x86-64-sse41-popcnt` and `COMP=clang` (linker `-fuse-ld=lld`), and verified the build completed with zero warnings and zero errors. 
- Ran UCI smoke and runtime smoke (set `EvalFile`/`EvalFileSmall`, `isready`, `go depth 1`) and confirmed presence of `id name Revolution`, `uciok`, `readyok`, `option name EvalFile`, `option name EvalFileSmall`, the updated big/small defaults, and that the engine returned `bestmove` with no crash.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13411ac7d883278548dfcf3ad2b9e9)