### PR TITLE
REVOLUTION-P0B: add search/value helper bridge (is_mate + RootMove bound helpers)

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -93,6 +93,9 @@ struct RootMove {
         return m.score != score ? m.score < score : m.previousScore < previousScore;
     }
 
+    bool score_is_bound() const { return scoreLowerbound || scoreUpperbound; }
+    void unset_bound_flags() { scoreLowerbound = scoreUpperbound = false; }
+
     uint64_t          effort           = 0;
     Value             score            = -VALUE_INFINITE;
     Value             previousScore    = -VALUE_INFINITE;

--- a/src/types.h
+++ b/src/types.h
@@ -191,6 +191,18 @@ constexpr bool is_loss(Value value) {
 
 constexpr bool is_decisive(Value value) { return is_win(value) || is_loss(value); }
 
+constexpr bool is_mate(Value value) {
+    assert(is_valid(value));
+    return value >= VALUE_MATE_IN_MAX_PLY;
+}
+
+constexpr bool is_mated(Value value) {
+    assert(is_valid(value));
+    return value <= VALUE_MATED_IN_MAX_PLY;
+}
+
+constexpr bool is_mate_or_mated(Value value) { return is_mate(value) || is_mated(value); }
+
 // In the code, we make the assumption that these values
 // are such that non_pawn_material() can be used to uniquely
 // identify the material on the board.


### PR DESCRIPTION
### Motivation
- Prepare the codebase for a future single-net migration by adding upstream-compatible helper surfaces that are missing, without changing runtime search behaviour.
- Provide small, purely helper-safe APIs for mate classification on `Value` and bound-flag utilities on `RootMove` required by later iterative-deepening/rollback work.
- Restrict changes to only the allowed files to preserve dual-net topology and evaluation semantics.

### Description
- Added `constexpr bool is_mate(Value)`, `constexpr bool is_mated(Value)`, and `constexpr bool is_mate_or_mated(Value)` to `src/types.h` following the existing value-classification helpers. 
- Added `bool score_is_bound() const` and `void unset_bound_flags()` inside `struct RootMove` in `src/search.h` next to `operator<()` to expose RootMove bound semantics. 
- Only `src/types.h` and `src/search.h` were modified and existing symbols/semantics (`VALUE_MATE*`, `is_win`, `is_loss`, `is_decisive`, `scoreLowerbound`, `scoreUpperbound`, `operator<`, and dual-net surfaces) were preserved. 
- Changes are helper-only and do not modify search logic or evaluation code.

### Testing
- Ran repository greps to validate presence of `EvalFileDefaultNameBig`/`EvalFileDefaultNameSmall` and confirm helpers before/after the patch, which matched expectations. 
- Built with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed with zero warnings and zero errors. 
- Performed UCI smoke (`uci` / `isready`) which reported `id name Revolution`, `uciok`, `readyok`, and UCI options `EvalFile` and `EvalFileSmall` with the big/small defaults intact. 
- Performed runtime smoke (`position startpos` + `go depth 1`) which returned `bestmove` without asserts or crashes. Commit created: `70c2475`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13437e26008327babe520ea30462f6)