### PR TITLE
REVOLUTION-P0C: bridge iterative deepening mate rollback

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -270,9 +270,9 @@ void Search::Worker::iterative_deepening() {
 
     Move pv[MAX_PLY + 1];
 
-    Depth lastBestMoveDepth = 0;
-    Value lastBestScore     = -VALUE_INFINITE;
-    auto  lastBestPV        = std::vector{Move::none()};
+    Depth            lastBestMoveDepth = 0;
+    Value            lastIterationScore = -VALUE_INFINITE;
+    std::vector<Move> lastIterationPV;
 
     Value  alpha, beta;
     Value  bestValue     = -VALUE_INFINITE;
@@ -427,54 +427,85 @@ void Search::Worker::iterative_deepening() {
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
 
+            // In multiPV analysis we do not let aborted searches spoil mated-in /
+            // TB-loss scores from a completed search in an earlier PV line.
+            // A mated-in/TB-loss from an aborted search for pvIdx > 0 can only become
+            // bestmove in the sorting below if the current bestmove, and therefore the
+            // previously searched pvIdx - 1 line, is already a proven loss.
+            if (threads.stop && pvIdx && is_loss(rootMoves[pvIdx - 1].score)
+                && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+            {
+                rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                  (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
+                   && rootMoves[pvIdx].previousScore < rootMoves[pvIdx - 1].score)
+                    ? rootMoves[pvIdx].previousScore
+                    : rootMoves[pvIdx - 1].score;
+
+                rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                rootMoves[pvIdx].unset_bound_flags();
+                rootMoves[pvIdx].pv.resize(1);
+            }
+
             // Sort the PV lines searched so far and update the GUI
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
-            if (mainThread
-                && (threads.stop || pvIdx + 1 == multiPV || nodes > 10000000)
-                // A thread that aborted search can have mated-in/TB-loss PV and
-                // score that cannot be trusted, i.e. it can be delayed or refuted
-                // if we would have had time to fully search other root-moves. Thus
-                // we suppress this output and below pick a proven score/PV for this
-                // thread (from the previous iteration).
-                && !(threads.abortedSearch && is_loss(rootMoves[0].uciScore)))
+            if (mainThread && !threads.stop && (pvIdx + 1 == multiPV || nodes > 10000000))
                 main_manager()->pv(*this, threads, tt, rootDepth);
 
             if (threads.stop)
                 break;
         }
 
+        const bool forgottenMate = lastIterationScore != -VALUE_INFINITE
+                                && is_mate_or_mated(lastIterationScore)
+                                && (std::abs(rootMoves[0].score) < std::abs(lastIterationScore)
+                                    || rootMoves[0].score_is_bound());
+
         if (!threads.stop)
+        {
             completedDepth = rootDepth;
 
-        // We make sure not to pick an unproven mated-in score,
-        // in case this thread prematurely stopped search (aborted-search).
-        if (threads.abortedSearch && rootMoves[0].score != -VALUE_INFINITE
-            && is_loss(rootMoves[0].score))
-        {
-            // Bring the last best move to the front for best thread selection.
-            Utility::move_to_front(rootMoves, [&lastBestPV = std::as_const(lastBestPV)](
-                                                const auto& rm) { return rm == lastBestPV[0]; });
-            rootMoves[0].pv    = lastBestPV;
-            rootMoves[0].score = rootMoves[0].uciScore = lastBestScore;
+            if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
+                lastBestMoveDepth = rootDepth;
+
+            // Do not replace shorter mate scores from a previous iteration.
+            if (!forgottenMate)
+            {
+                lastIterationPV    = rootMoves[0].pv;
+                lastIterationScore = rootMoves[0].score;
+            }
         }
-        else if (rootMoves[0].pv[0] != lastBestPV[0])
+
+        const bool abortedLossSearch =
+          threads.stop && !pvIdx && rootMoves[0].score != -VALUE_INFINITE
+          && is_loss(rootMoves[0].score) && !rootMoves[0].score_is_bound();
+
+        // An exact mated-in/TB-loss score from an aborted search cannot be trusted:
+        // the loss could be delayed or refuted upon exploring the remaining root moves.
+        // Thus here we roll back to the score from the previous iteration.
+        // We do the same if a search has failed to recover a mate score that was found
+        // in a previous iteration.
+        if (abortedLossSearch || (rootMoves[0].score != -VALUE_INFINITE && forgottenMate))
         {
-            lastBestPV        = rootMoves[0].pv;
-            lastBestScore     = rootMoves[0].score;
-            lastBestMoveDepth = rootDepth;
+            if (!lastIterationPV.empty())
+            {
+                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastIterationPV)](
+                                                    const auto& rm) { return rm == lastPV[0]; });
+
+                rootMoves[0].pv    = lastIterationPV;
+                rootMoves[0].score = rootMoves[0].uciScore = lastIterationScore;
+                rootMoves[0].unset_bound_flags();
+            }
+            else if (abortedLossSearch)
+                rootMoves[0].scoreLowerbound = true;
         }
 
         if (!mainThread)
             continue;
 
-        // Have we found a "mate in x"?
-        if (limits.mate && rootMoves[0].score == rootMoves[0].uciScore
-            && ((rootMoves[0].score >= VALUE_MATE_IN_MAX_PLY
-                 && VALUE_MATE - rootMoves[0].score <= 2 * limits.mate)
-                || (rootMoves[0].score != -VALUE_INFINITE
-                    && rootMoves[0].score <= VALUE_MATED_IN_MAX_PLY
-                    && VALUE_MATE + rootMoves[0].score <= 2 * limits.mate)))
+        // Have we found a "mate in x" after a completed iteration?
+        if (limits.mate && !threads.stop && is_mate_or_mated(rootMoves[0].score)
+            && VALUE_MATE - std::abs(rootMoves[0].score) <= 2 * limits.mate)
             threads.stop = true;
 
         // If the skill level is enabled and time is up, pick a sub-optimal best move


### PR DESCRIPTION
### Motivation
- Port upstream-compatible iterative_deepening() rollback semantics into Revolution to avoid exposing untrusted exact mated-in / TB-loss PVs from aborted searches and to replace the fragile `lastBestScore/lastBestPV` state with iteration-scoped semantics.  
- Reuse helper surfaces added in the previous phase (mate helpers and RootMove helpers) and preserve all Revolution-specific integration outside this function.

### Description
- Replaced `lastBestScore` / `lastBestPV` with `lastIterationScore` (`Value`) and `lastIterationPV` (`std::vector<Move>`) in `Search::Worker::iterative_deepening()` and kept `lastBestMoveDepth`.  
- Added MultiPV aborted-loss protection immediately after the aspiration re-search loop to avoid letting aborted searches promote mated-in / TB-loss lines, using `previousScore`, `uciScore`, `unset_bound_flags()` and trimming PVs to size 1.  
- Tightened GUI PV emission to `if (mainThread && !threads.stop && (pvIdx + 1 == multiPV || nodes > 10000000))` to prevent publishing PV while `threads.stop` is true.  
- Replaced the completed-iteration rollback with `forgottenMate` and `abortedLossSearch` logic that uses `is_mate_or_mated()`, `score_is_bound()` and `unset_bound_flags()`; rollback restores the previous-iteration PV/score via `Utility::move_to_front(...)` or sets `scoreLowerbound` when no previous PV exists.  
- Simplified the mate-limit stop to use `is_mate_or_mated(rootMoves[0].score)` and `VALUE_MATE - std::abs(rootMoves[0].score) <= 2 * limits.mate`.  
- Scope: only `src/search.cpp` was modified; no changes to `types.h`, `search.h`, NNUE topology, UCI API, TT, MovePicker, Makefile, Book/Experience/Syzygy/MCTS, or other forbidden files.

### Testing
- Static/grep checks: validated presence of P0A/P0B helpers and new symbols (`lastIterationScore|lastIterationPV|forgottenMate|abortedLossSearch|score_is_bound()|unset_bound_flags()|is_mate_or_mated(rootMoves[0].score)`) and absence of `lastBestPV|lastBestScore` and the old `threads.stop || pvIdx + 1 == multiPV` PV-condition in `src/search.cpp`.  
- Build: clean `clang` build completed with `STATUS=0` and log scanned for zero `warning:`/`error:` entries.  
- UCI smoke: engine reported `id name Revolution`, `uciok`, `readyok`, options `EvalFile` and `EvalFileSmall`, and the expected default NNUE filenames.  
- Runtime smoke: `go depth 1` produced `readyok` and `bestmove`; MultiPV smoke (`MultiPV=3 go depth 2`) returned `bestmove`; Mate-limit smoke (`go mate 1`) completed without crash/assert.  
- Scope validation: only `src/search.cpp` changed and no forbidden files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1345ec9bd88327a97825c3334f307a)