### PR TITLE
Penalize TT entries on window-bound mismatch to reduce bad cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -836,6 +836,15 @@ Value Search::Worker::search(
                 return ttData.value;
         }
     }
+    else if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
+             && is_valid(ttData.value) && ttData.bound != BOUND_EXACT
+             && ttData.bound & (ttData.value >= beta ? BOUND_UPPER : BOUND_LOWER)
+             && depth > 5)
+    {
+        // If a window-bound mismatch is the only reason cutoff failed,
+        // penalize the now-useless tte
+        ttWriter.penalize(1);
+    }
 
     // Step 5. Tablebases probe
     if (!rootNode && !excludedMove && tbConfig.cardinality)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -62,6 +62,7 @@ struct TTEntry {
 
    private:
     friend class TranspositionTable;
+    friend struct TTWriter;
 
     uint16_t key16;
     uint8_t  depth8;
@@ -133,6 +134,8 @@ void TTWriter::write(
   Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8) {
     entry->save(k, v, pv, b, d, m, ev, generation8);
 }
+
+void TTWriter::penalize(int penalty) { entry->depth8 -= penalty; }
 
 
 // A TranspositionTable is an array of Cluster, of size clusterCount. Each cluster consists of ClusterSize number

--- a/src/tt.h
+++ b/src/tt.h
@@ -70,6 +70,7 @@ struct TTData {
 struct TTWriter {
    public:
     void write(Key k, Value v, bool pv, Bound b, Depth d, Move m, Value ev, uint8_t generation8);
+    void penalize(int penalty);
 
    private:
     friend class TranspositionTable;


### PR DESCRIPTION
### Motivation
- Reduce the impact of transposition table entries that fail to produce a cutoff only because of a window-bound mismatch, by making such entries less attractive for future lookups.
- Provide a lightweight mechanism in the `TTWriter` to degrade stored entries' effective depth when they are discovered to be misleading during search.

### Description
- Add `TTWriter::penalize(int)` declaration in `tt.h` and implementation in `tt.cpp` which reduces the stored entry's `depth8` by the given penalty.
- Grant `TTWriter` friendship to `TTEntry` so the writer can adjust the packed `depth8` field directly.
- In `search.cpp`, detect the case where a transposition table hit failed to cutoff solely due to a bound/window mismatch and call `ttWriter.penalize(1)` to penalize that entry under the condition `!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta) && is_valid(ttData.value) && ttData.bound != BOUND_EXACT && ttData.bound & (...) && depth > 5`.

### Testing
- Built the project with the usual build system (`make`) successfully.
- Ran the automated unit/regression test suite (`make test` / `ctest`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134b5d1f7483278bdfc265225fa210)