### PR TITLE
REVOLUTION-P0F: add interpolate helper bridge

### DIFF
--- a/src/misc.h
+++ b/src/misc.h
@@ -190,6 +190,12 @@ void sync_cout_end();
 static inline const std::uint16_t Le             = 1;
 static inline const bool          IsLittleEndian = *reinterpret_cast<const char*>(&Le) == 1;
 
+template<typename T1, typename T2>
+inline constexpr T2 interpolate(T1 x, T1 x0, T1 x1, T2 y0, T2 y1) {
+    assert(x0 != x1);
+    return T2(y0 + (y1 - y0) * (x - x0) / (x1 - x0));
+}
+
 
 template<typename T, std::size_t MaxSize>
 class ValueList {


### PR DESCRIPTION
### Motivation
- Provide an upstream-compatible pure-arithmetic `interpolate` helper (Stockfish pattern) needed by later search/topology work while keeping changes minimal and local.

### Description
- Add `template<typename T1, typename T2> inline constexpr T2 interpolate(T1 x, T1 x0, T1 x1, T2 y0, T2 y1)` with `assert(x0 != x1)` and the exact formula to `src/misc.h` and do not modify any call sites or other files.

### Testing
- Audited sources and ran a full clang build (`ARCH=x86-64-sse41-popcnt`), UCI smoke, runtime (depth 1) and threaded (Threads=4 depth 4) smokes; build completed with zero warnings/errors and UCI/runtime/threaded produced the expected outputs (`id name Revolution`, `uciok`, `readyok`, `option EvalFile/EvalFileSmall`, and `bestmove`), and only `src/misc.h` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1352bc11508327a9d6473282e66da2)