### PR TITLE
REVOLUTION-P0I: add single-net evaluate/trace overloads for NetworkBig

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -89,10 +89,63 @@ Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
     return v;
 }
 
+
+Value Eval::evaluate(const Eval::NNUE::NetworkBig& network,
+                     const Position&               pos,
+                     Eval::NNUE::AccumulatorStack& accumulators,
+                     Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>&
+                       cache,
+                     int optimism) {
+
+    assert(!pos.checkers());
+
+    auto [psqt, positional] = network.evaluate(pos, accumulators, cache);
+
+    Value nnue = (125 * psqt + 131 * positional) / 128;
+
+    int nnueComplexity = std::abs(psqt - positional);
+    optimism += optimism * nnueComplexity / 476;
+    nnue -= nnue * nnueComplexity / 18236;
+
+    int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
+    int v        = (nnue * (77871 + material) + optimism * (7191 + material)) / 77871;
+
+    v -= v * pos.rule50_count() / 199;
+
+    v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
+
+    return v;
+}
+
 // Like evaluate(), but instead of returning a value, it returns
 // a string (suitable for outputting to stdout) that contains the detailed
 // descriptions and values of each evaluation term. Useful for debugging.
 // Trace scores are from white's point of view
+std::string Eval::trace(Position& pos, const Eval::NNUE::NetworkBig& network) {
+
+    if (pos.checkers())
+        return "Final evaluation: none (in check)";
+
+    auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
+    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>>();
+
+    std::stringstream ss;
+    ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
+
+    auto [psqt, positional] = network.evaluate(pos, *accumulators, *caches);
+    Value v                 = psqt + positional;
+    v                       = pos.side_to_move() == WHITE ? v : -v;
+    ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
+
+    v = evaluate(network, pos, *accumulators, *caches, VALUE_ZERO);
+    v = pos.side_to_move() == WHITE ? v : -v;
+    ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
+    ss << " [with scaled NNUE, ...]";
+    ss << "\n";
+
+    return ss.str();
+}
+
 std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
 
     if (pos.checkers())

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -22,6 +22,8 @@
 #include <string>
 
 #include "types.h"
+#include "nnue/network.h"
+#include "nnue/nnue_accumulator.h"
 
 namespace Stockfish {
 
@@ -43,6 +45,7 @@ class AccumulatorStack;
 }
 
 std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
+std::string trace(Position& pos, const Eval::NNUE::NetworkBig& network);
 
 int   simple_eval(const Position& pos);
 bool  use_smallnet(const Position& pos);
@@ -51,6 +54,11 @@ Value evaluate(const NNUE::Networks&          networks,
                Eval::NNUE::AccumulatorStack&  accumulators,
                Eval::NNUE::AccumulatorCaches& caches,
                int                            optimism);
+Value evaluate(const NNUE::NetworkBig& network,
+               const Position&         pos,
+               Eval::NNUE::AccumulatorStack& accumulators,
+               Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>& cache,
+               int optimism);
 }  // namespace Eval
 
 }  // namespace Stockfish


### PR DESCRIPTION
### Motivation
- Introduce a compile-valid single-network evaluation bridge so `NetworkBig` can be used directly as the future single-net carrier while preserving the existing dual-net runtime and APIs.
- Prepare the codebase for gradual migration to a single-net path without removing `NetworkSmall` or altering runtime behavior.

### Description
- Added new overload declarations in `src/evaluate.h` for `std::string trace(Position& pos, const Eval::NNUE::NetworkBig& network)` and `Value evaluate(const Eval::NNUE::NetworkBig& network, const Position& pos, Eval::NNUE::AccumulatorStack& accumulators, Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>& cache, int optimism)`.
- Implemented the single-big-network `evaluate` in `src/evaluate.cpp` to call `network.evaluate(pos, accumulators, cache)` and then apply the exact same post-NNUE scaling, optimism blending, material/tempo adjustments, rule50 dampening, and clamping logic used by the existing dual-net path.
- Implemented the single-big-network `trace` in `src/evaluate.cpp` that allocates an `AccumulatorStack` and the big-cache only, reports NNUE and final scaled eval, and calls the new single-net `evaluate` overload; this implementation required no changes to `src/nnue/**` internals.
- Preserved the original dual-net `evaluate(const NNUE::Networks& ...)` and `trace(Position&, const NNUE::Networks&)` implementations unchanged and avoided any access to `networks.small`, `caches.small`, or calls to `use_smallnet()` from the new overloads.

### Testing
- Built the project (`make -C src build` with clang+lto) with zero warnings and zero errors and the build completed successfully.
- UCI smoke passed with `uciok`, `readyok`, `EvalFile` and `EvalFileSmall` options present and the expected default NNUE names reported.
- Runtime smoke passed (engine produced `bestmove` for `go depth 1`) and threaded smoke passed (engine produced `bestmove` for `go depth 4` with multiple threads) with no crashes or asserts.
- Regression checks passed confirming only `src/evaluate.h` and `src/evaluate.cpp` changed and previous P0A/P0B/P0C/P0E/P0F/P0G markers and dual-net surfaces remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135a1cafa8832786c485ae73e0320a)