### PR TITLE
REVOLUTION-P0J: add search single-net evaluation bridge

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1793,6 +1793,15 @@ TimePoint Search::Worker::elapsed() const {
 
 TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elapsed_time(); }
 
+[[maybe_unused]] Value Search::evaluate_with_big_network_bridge(
+  const Eval::NNUE::NetworkBig&                                                         network,
+  const Position&                                                                        pos,
+  Eval::NNUE::AccumulatorStack&                                                          accumulators,
+  Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>& cache,
+  Value                                                                                  optimism) {
+    return Eval::evaluate(network, pos, accumulators, cache, optimism);
+}
+
 Value Search::Worker::evaluate(const Position& pos) {
     return Eval::evaluate(networks[numaAccessToken], pos, accumulatorStack, refreshTable,
                           optimism[pos.side_to_move()]);

--- a/src/search.h
+++ b/src/search.h
@@ -157,6 +157,13 @@ struct SharedState {
 
 class Worker;
 
+[[maybe_unused]] Value evaluate_with_big_network_bridge(
+  const Eval::NNUE::NetworkBig&                                                         network,
+  const Position&                                                                        pos,
+  Eval::NNUE::AccumulatorStack&                                                          accumulators,
+  Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>& cache,
+  Value                                                                                  optimism);
+
 // Null Object Pattern, implement a common interface for the SearchManagers.
 // A Null Object will be given to non-mainthread workers.
 class ISearchManager {


### PR DESCRIPTION
### Motivation
- Prepare a minimal, compile-valid search-side call path that can invoke the single-big-network evaluation overload added in P0I without changing the current dual-net runtime behavior.
- Provide a narrow bridge so future phases can migrate search evaluation plumbing to single-net callsites one step at a time.

### Description
- Added a declaration `evaluate_with_big_network_bridge(...)` in `src/search.h` (Search namespace scope) with the big-network, accumulator stack, big-cache, and `optimism` signature and marked it `[[maybe_unused]]`.
- Implemented `Search::evaluate_with_big_network_bridge(...)` in `src/search.cpp` to call the P0I overload directly: `return Eval::evaluate(network, pos, accumulators, cache, optimism);`.
- Left all active search call sites unchanged; `Search::Worker::evaluate(const Position&)` still uses the dual-net path `Eval::evaluate(networks[numaAccessToken], ...)` so runtime behavior is preserved.
- Changes are limited to `src/search.h` and `src/search.cpp` only and do not touch NNUE internals, engine/UCI surfaces, or other forbidden files.

### Testing
- Performed a clean clang build (`make -C src ... COMP=clang`) which completed with `STATUS=0` and the build log reported zero `warning:` and zero `error:`.
- Ran UCI smoke which returned `id name Revolution`, `uciok`, `readyok`, and showed `EvalFile` and `EvalFileSmall` options with the expected default net names; runtime smoke (`go depth 1`) and threaded smoke (`Threads=4, go depth 4`) both produced `bestmove` and no crashes.
- Verified repository checks/greps for P0A/P0B/P0C/P0E/P0F/P0G/P0I markers and confirmed no forbidden-file diffs outside `src/search.h` and `src/search.cpp` were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135c0a2238832788d501a026a8948f)