### PR TITLE
REVOLUTION-P0K: add engine single-net accessor bridge

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -354,6 +354,18 @@ std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
     return networks_;
 }
 
+std::unique_ptr<Eval::NNUE::NetworkBig> Engine::get_default_network() const {
+    auto network =
+      std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                       NN::EmbeddedNNUEType::BIG);
+
+    network->load(binaryDirectory, "");
+
+    return network;
+}
+
+void Engine::load_network(const std::string& file) { load_big_network(file); }
+
 void Engine::load_big_network(const std::string& file) {
     networks.modify_and_replicate(
       [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
@@ -373,6 +385,11 @@ void Engine::save_network(const std::pair<std::optional<std::string>, std::strin
         networks_.big.save(files[0].first);
         networks_.small.save(files[1].first);
     });
+}
+
+void Engine::save_network(const std::pair<std::optional<std::string>, std::string>& file) {
+    networks.modify_and_replicate(
+      [&file](NN::Networks& networks_) { networks_.big.save(file.first); });
 }
 
 // utility functions

--- a/src/engine.h
+++ b/src/engine.h
@@ -86,10 +86,13 @@ class Engine {
 
     // network related
 
+    std::unique_ptr<Eval::NNUE::NetworkBig> get_default_network() const;
     std::unique_ptr<Eval::NNUE::Networks> get_default_networks() const;
     void verify_networks() const;
+    void load_network(const std::string& file);
     void load_big_network(const std::string& file);
     void load_small_network(const std::string& file);
+    void save_network(const std::pair<std::optional<std::string>, std::string>& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     // utility functions


### PR DESCRIPTION
### Motivation
- Provide a Stockfish-like single-net Engine surface that operates on the existing big NNUE only while preserving the current dual-net runtime and public APIs.

### Description
- Added declarations in `src/engine.h` and implementations in `src/engine.cpp` for `std::unique_ptr<Eval::NNUE::NetworkBig> Engine::get_default_network() const`, `void Engine::load_network(const std::string& file)` (which delegates to `load_big_network`), and `void Engine::save_network(const std::pair<std::optional<std::string>, std::string>& file)` (which saves only `networks_.big`).
- Kept all dual-net surfaces intact (`get_default_networks`, `verify_networks`, `load_big_network`, `load_small_network`, `save_network(files[2])`) and avoided any small-net dependency in the new bridges.

### Testing
- Built the project with `make -C src -j2 ...` and the build completed with `STATUS=0` and zero `warning:`/`error:` log matches (pass).
- Ran automated UCI smoke (`uci`/`isready`) which returned `id name`, `uciok`, `readyok`, and the `EvalFile`/`EvalFileSmall` options (pass).
- Executed runtime smoke (`position startpos` + `go depth 1`) and threaded smoke (`Threads=4, go depth 4`), both returned `bestmove` with no crashes (pass).
- Verified diffs were limited to `src/engine.h` and `src/engine.cpp` and greps confirmed the new bridges do not reference small-net symbols (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135ddfeaf483278c3f464d901a33bc)