### PR TITLE
REVOLUTION-P0L: bridge UCI export_net single-file save

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -180,15 +180,23 @@ void UCIEngine::loop() {
             sync_cout << compiler_info() << sync_endl;
         else if (token == "export_net")
         {
-            std::pair<std::optional<std::string>, std::string> files[2];
+            std::pair<std::optional<std::string>, std::string> file;
 
-            if (is >> std::skipws >> files[0].second)
-                files[0].first = files[0].second;
+            if (is >> std::skipws >> file.second)
+                file.first = file.second;
 
-            if (is >> std::skipws >> files[1].second)
-                files[1].first = files[1].second;
+            if (!(is >> std::skipws).eof())
+            {
+                std::pair<std::optional<std::string>, std::string> files[2];
+                files[0] = file;
 
-            engine.save_network(files);
+                if (is >> files[1].second)
+                    files[1].first = files[1].second;
+
+                engine.save_network(files);
+            }
+            else
+                engine.save_network(file);
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout


### PR DESCRIPTION
### Motivation
- Add a UCI-side bridge so `export_net` can call the new singular `Engine::save_network(file)` big-net export path while preserving the existing dual-net export behavior.
- Ensure the UCI command remains backward compatible with two-argument dual-net usage and does not alter NNUE runtime/option surfaces.

### Description
- Modified `export_net` handling in `src/uci.cpp` to parse the first filename into a single `file` and call `engine.save_network(file)` when only one filename is provided. 
- If a second filename is present, the code now constructs `files[2]` and calls the existing dual overload `engine.save_network(files)`, preserving previous behavior. 
- Change is limited to `src/uci.cpp` and does not alter any Engine/Search/Eval/NNUE APIs or remove `EvalFileSmall`/dual-net surfaces. 

### Testing
- Built with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build passed with zero warnings and zero errors. 
- UCI smoke with `uci`/`isready` confirmed `uciok`, `readyok`, `EvalFile`, and `EvalFileSmall` options are present. 
- Runtime smoke (`position startpos` + `go depth 1`) returned `bestmove` and exhibited no crashes. 
- `export_net <big-file>` smoke wrote the big NNUE via the singular save path and `export_net <big-file> <small-file>` smoke wrote both big and small NNUE files via the dual path. 
- Threaded smoke (`Threads=4`, `go depth 4`) returned `bestmove` with no crashes, and grep checks confirm prior P0A..P0K bridges/constants remain intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135f61a7408327894ca2e926c1a52d)