### PR TITLE
REVOLUTION-P0M: add engine verify network bridge

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -244,6 +244,10 @@ void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
     onVerifyNetworks = std::move(f);
 }
 
+void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
+    set_on_verify_networks(std::move(f));
+}
+
 void Engine::wait_for_search_finished() { threads.main_thread()->wait_for_search_finished(); }
 
 void Engine::set_position(const std::string& fen, const std::vector<std::string>& moves) {
@@ -317,6 +321,43 @@ void Engine::verify_networks() const {
     {
         const auto [status, error] = statuses[i];
         std::string message        = "Network replica " + std::to_string(i + 1) + ": ";
+        if (status == SystemWideSharedConstantAllocationStatus::NoAllocation)
+        {
+            message += "No allocation.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::LocalMemory)
+        {
+            message += "Local memory.";
+        }
+        else if (status == SystemWideSharedConstantAllocationStatus::SharedMemory)
+        {
+            message += "Shared memory.";
+        }
+        else
+        {
+            message += "Unknown status.";
+        }
+
+        if (error.has_value())
+        {
+            message += " " + *error;
+        }
+
+        onVerifyNetworks(message);
+    }
+}
+
+void Engine::verify_network() const {
+    networks->big.verify(options["EvalFile"], onVerifyNetworks);
+
+    auto statuses = networks.get_status_and_errors();
+
+    for (size_t i = 0; i < statuses.size(); ++i)
+    {
+        const auto [status, error] = statuses[i];
+
+        std::string message = "Network replica " + std::to_string(i + 1) + ": ";
+
         if (status == SystemWideSharedConstantAllocationStatus::NoAllocation)
         {
             message += "No allocation.";

--- a/src/engine.h
+++ b/src/engine.h
@@ -83,11 +83,13 @@ class Engine {
     void set_on_iter(std::function<void(const InfoIter&)>&&);
     void set_on_bestmove(std::function<void(std::string_view, std::string_view)>&&);
     void set_on_verify_networks(std::function<void(std::string_view)>&&);
+    void set_on_verify_network(std::function<void(std::string_view)>&&);
 
     // network related
 
     std::unique_ptr<Eval::NNUE::NetworkBig> get_default_network() const;
     std::unique_ptr<Eval::NNUE::Networks> get_default_networks() const;
+    void verify_network() const;
     void verify_networks() const;
     void load_network(const std::string& file);
     void load_big_network(const std::string& file);


### PR DESCRIPTION
### Motivation
- Provide a singular Engine-side verification bridge that validates the big NNUE only while preserving the existing dual-net verification surface. 
- Maintain backward compatibility with the current dual-net runtime and UCI exposure for `EvalFileSmall`. 
- Mirror Stockfish's singular `set_on_verify_network` / `verify_network` API pattern while reusing Revolution's existing replication and status-reporting mechanisms.

### Description
- Added declarations in `src/engine.h`: `void set_on_verify_network(std::function<void(std::string_view)>&&);` and `void verify_network() const;`. 
- Implemented `Engine::set_on_verify_network(...)` in `src/engine.cpp` to delegate to `set_on_verify_networks(...)` for callback wiring. 
- Implemented `Engine::verify_network() const` to run `networks->big.verify(options["EvalFile"], onVerifyNetworks);`, collect statuses via `networks.get_status_and_errors()`, and emit replica messages through the existing `onVerifyNetworks` callback without referencing the small net. 
- Preserved `verify_networks()` and `set_on_verify_networks()` unchanged so dual-net verification, `EvalFileSmall`, and other NNUE internals remain intact.

### Testing
- Ran repository validation greps for prior phases (P0A..P0L) and API presence, all expected signatures were found. 
- Built the engine with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`, with zero warnings and zero errors in the build log. 
- Performed UCI smoke (`printf "uci\nisready\nquit\n" | ./src/Revolution*`) and runtime smoke (`go depth 1`) which returned `uciok`, `readyok`, and a `bestmove` with no crashes. 
- Ran eval/verification smoke and threaded smoke (`Threads=4, go depth 4`) which produced expected outputs and no crashes, and verified only `src/engine.h` and `src/engine.cpp` changed and that the new `verify_network()` references `options["EvalFile"]` and not `EvalFileSmall`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13662ac03c8327b1dd486729813b9a)