### PR TITLE
REVOLUTION-P0M: harden singular Engine::verify_network callback bridge

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -348,7 +348,9 @@ void Engine::verify_networks() const {
 }
 
 void Engine::verify_network() const {
-    networks->big.verify(options["EvalFile"], onVerifyNetworks);
+    const auto report = onVerifyNetworks ? onVerifyNetworks : [](std::string_view) {};
+
+    networks->big.verify(options["EvalFile"], report);
 
     auto statuses = networks.get_status_and_errors();
 
@@ -380,7 +382,7 @@ void Engine::verify_network() const {
             message += " " + *error;
         }
 
-        onVerifyNetworks(message);
+        report(message);
     }
 }
 


### PR DESCRIPTION
### Motivation
- Add a safe, Engine-side singular verification bridge that verifies the big network only and cannot fail if the verification callback is unset while preserving the existing dual-net `verify_networks()` path.

### Description
- In `src/engine.cpp` make `Engine::verify_network()` derive a local `report` callable that uses `onVerifyNetworks` when set and falls back to a no-op lambda, call `networks->big.verify(options["EvalFile"], report)`, and emit replica messages via `report` so the singular big-net bridge is robust without touching dual-net surfaces.

### Testing
- Automated validation: built with zero warnings/errors, UCI smoke (`uciok`, `readyok`, options include `EvalFile` and `EvalFileSmall`) passed, runtime smoke (`go depth 1`) returned `bestmove`, eval smoke ran without crash, and threaded smoke (`Threads=4`) returned `bestmove`, and only `src/engine.cpp` was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1369d3353c8327860fe3ad42151ed7)