### PR TITLE
REVOLUTION-P0N: bridge trace eval to single net

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -442,9 +442,9 @@ void Engine::trace_eval() const {
     Position     p;
     p.set(pos.fen(), options["UCI_Chess960"], &trace_states->back());
 
-    verify_networks();
+    verify_network();
 
-    sync_cout << "\n" << Eval::trace(p, *networks) << sync_endl;
+    sync_cout << "\n" << Eval::trace(p, networks->big) << sync_endl;
 }
 
 const OptionsMap& Engine::get_options() const { return options; }


### PR DESCRIPTION
### Motivation
- Route the diagnostic `trace_eval` utility to the single verified big NNUE network instead of the multi-network verification path to simplify tracing and avoid dereferencing the composite `networks` object.

### Description
- In `Engine::trace_eval()` (src/engine.cpp) replaced `verify_networks()` with `verify_network()` and changed the `Eval::trace` call from `Eval::trace(p, *networks)` to `Eval::trace(p, networks->big)`.

### Testing
- Built the engine (`make -C src ...`) and ran UCI/eval/runtime smoke checks invoking `uci`, `isready`, `eval`, and a `position startpos`/`go depth 1` probe, which completed successfully (build STATUS=0 and logs contained `uciok`, `readyok`, and `bestmove`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a136d9046c083278d94127024dba291)