### PR TITLE
REVOLUTION-P0O: add threadpool single-net field alias bridge

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1802,6 +1802,15 @@ TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elaps
     return Eval::evaluate(network, pos, accumulators, cache, optimism);
 }
 
+const Eval::NNUE::NetworkBig& Search::Worker::big_network() const {
+    return networks[numaAccessToken].big;
+}
+
+Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>&
+Search::Worker::big_cache() {
+    return refreshTable.big;
+}
+
 Value Search::Worker::evaluate(const Position& pos) {
     return Eval::evaluate(networks[numaAccessToken], pos, accumulatorStack, refreshTable,
                           optimism[pos.side_to_move()]);

--- a/src/search.h
+++ b/src/search.h
@@ -336,6 +336,10 @@ class Worker {
     TimePoint elapsed() const;
     TimePoint elapsed_time() const;
 
+    const Eval::NNUE::NetworkBig& big_network() const;
+    Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>&
+    big_cache();
+
     Value evaluate(const Position&);
 
     LimitsType limits;


### PR DESCRIPTION
### Motivation
- Provide explicit thread/worker-side accessors for the existing big NNUE network and its big accumulator cache to enable upcoming single-net work while preserving the current dual-net runtime.

### Description
- Add `Search::Worker` declarations in `src/search.h` for `const Eval::NNUE::NetworkBig& big_network() const;` and `Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>& big_cache();`.
- Implement the accessors in `src/search.cpp` so `big_network()` returns `networks[numaAccessToken].big` and `big_cache()` returns `refreshTable.big`.
- Only `src/search.h` and `src/search.cpp` were modified, `Worker::evaluate()` and the active dual-net callsites were left unchanged and no small-net paths were introduced.

### Testing
- Built the project with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang` and the build completed with zero warnings and zero errors.
- UCI smoke (`uci` / `isready`) showed `uciok`, `readyok`, `option name EvalFile`, `option name EvalFileSmall`, and the expected big/small NNUE filenames.
- Runtime smoke (`setoption EvalFile/EvalFileSmall` + `go depth 1`) returned `bestmove` with no crash or assertion.
- Threaded smoke (`Threads=4`, `go depth 4`) returned `bestmove` with no crash or assertion and no small-net usage was introduced as verified by source greps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1370e6f78483279b49431f9f79bf92)