### PR TITLE
REVOLUTION-P0P: switch worker evaluate to single net bridge

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1812,8 +1812,8 @@ Search::Worker::big_cache() {
 }
 
 Value Search::Worker::evaluate(const Position& pos) {
-    return Eval::evaluate(networks[numaAccessToken], pos, accumulatorStack, refreshTable,
-                          optimism[pos.side_to_move()]);
+    return evaluate_with_big_network_bridge(big_network(), pos, accumulatorStack, big_cache(),
+                                            optimism[pos.side_to_move()]);
 }
 
 namespace {


### PR DESCRIPTION
### Motivation
- Move the active search evaluation callsite from the dual-net container path to the single-big-net bridge so search uses the new single-net accessors and bridge while preserving dual-net compatibility surfaces for later purge.
- Use the already-present helpers `Search::evaluate_with_big_network_bridge`, `Worker::big_network()` and `Worker::big_cache()` without changing other search behavior or public APIs.

### Description
- Modified `src/search.cpp` to replace the active call in `Search::Worker::evaluate()` from `Eval::evaluate(networks[numaAccessToken], ...)` to `evaluate_with_big_network_bridge(big_network(), pos, accumulatorStack, big_cache(), optimism[pos.side_to_move()])`.
- The change touches only `src/search.cpp` and keeps `EvalFileSmall`, `Eval::NNUE::Networks`, `networks.small`, `caches.small`, and all dual-net APIs intact.
- No other search logic, qsearch, TT, UCI options, Engine surfaces, NNUE internals or Makefile were modified.

### Testing
- Performed a clean build (`make -C src clean; make -C src ...`) which completed successfully with zero warnings and zero errors.
- Ran UCI smoke which returned `id name`, `uciok`, `readyok`, and the options `EvalFile` and `EvalFileSmall`, with both default NNUE filenames present.
- Executed eval trace smoke (`eval`) which produced evaluation output and no crash/assert.
- Performed runtime smokes: `go depth 1` and `go depth 4` both returned a `bestmove` with no crash/assert.
- Verified `MultiPV` (3) and threaded (`Threads=4`) runs produced `bestmove` outputs with no crash/assert.
- Verified via source grep that prior bridge phases and dual-net compatibility surfaces remain present after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1372e26e148327965cd80889835593)