### PR TITLE
REVOLUTION-P0Q: consolidate default big network construction

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -59,6 +59,19 @@ int            MaxThreads = std::max(1024, 4 * int(get_hardware_concurrency()));
 // PR#6526). The user can always explicitly override this behavior.
 constexpr NumaAutoPolicy DefaultNumaPolicy = BundledL3Policy{32};
 
+namespace {
+
+std::unique_ptr<NN::NetworkBig> make_default_big_network(const std::string& binaryDirectory) {
+    auto network =
+      std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+                                       NN::EmbeddedNNUEType::BIG);
+
+    network->load(binaryDirectory, "");
+    return network;
+}
+
+}  // namespace
+
 Engine::Engine(std::optional<std::string> path) :
     binaryDirectory(path ? CommandLine::get_binary_directory(*path) : ""),
     numaContext(NumaConfig::from_system(DefaultNumaPolicy)),
@@ -391,20 +404,14 @@ std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
       std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
                                      NN::EvalFile{EvalFileDefaultNameSmall, "None", ""});
 
-    networks_->big.load(binaryDirectory, "");
+    networks_->big = *make_default_big_network(binaryDirectory);
     networks_->small.load(binaryDirectory, "");
 
     return networks_;
 }
 
 std::unique_ptr<Eval::NNUE::NetworkBig> Engine::get_default_network() const {
-    auto network =
-      std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                       NN::EmbeddedNNUEType::BIG);
-
-    network->load(binaryDirectory, "");
-
-    return network;
+    return make_default_big_network(binaryDirectory);
 }
 
 void Engine::load_network(const std::string& file) { load_big_network(file); }


### PR DESCRIPTION
### Motivation
- Remove duplicated big-network construction/loading logic by making the singular big-net authority the source of truth while preserving legacy dual-net surfaces.
- Ensure `get_default_networks()` reuses the consolidated big construction path and keep small-network behavior unchanged.

### Description
- Added an anonymous-namespace helper `make_default_big_network(const std::string&)` in `src/engine.cpp` that constructs and loads the default `NetworkBig` using `EvalFileDefaultNameBig` and `EmbeddedNNUEType::BIG`.
- Rewired `Engine::get_default_network()` to return the helper result via `make_default_big_network`.
- Reused the helper in `Engine::get_default_networks()` for the big side by assigning `networks_->big = *make_default_big_network(binaryDirectory);` while leaving `networks_->small` construction/loading unchanged.
- Only `src/engine.cpp` was modified; dual-net APIs and small-network code paths were preserved.

### Testing
- Performed a full build with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang` which completed with zero warnings/errors (pass).
- Ran UCI smoke (`uci`, `isready`) and observed `EvalFile`/`EvalFileSmall` options and `uciok`/`readyok` (pass).
- Ran eval trace smoke (`eval`) after setting `EvalFile`/`EvalFileSmall` and observed no crash/assert and valid eval output (pass).
- Ran runtime smokes: `go depth 1`, `go depth 4`, and threaded run (Threads=4, Hash=64) and verified `bestmove` and no crashes (all pass).
- Ran repository verification greps for required bridge surfaces and dual-net compatibility points and confirmed they remain present (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13747763488327ac51a85896fbb2bf)