### PR TITLE
REVOLUTION-P0R: rebrand release identity to 5.70-250526

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.60-100526
+RELEASE_TAG ?= 5.70-250526
 
 NNUE_BIG = nn-83a0d6daf7e5.nnue
 NNUE_SMALL = nn-47fc8b7fff06.nnue
@@ -166,7 +166,7 @@ ifeq ($(ARCH),x86-64-avx512)
    ARCH_TAG := avx512
 endif
 ifeq ($(ARCH),x86-64-avx512icl)
-   ARCH_TAG := avx512cl
+   ARCH_TAG := avx512icl
 endif
 ifeq ($(ARCH),x86-64-avx512cl)
    ARCH_TAG := avx512cl
@@ -915,7 +915,7 @@ ifneq ($(ARCH), )
 	CXXFLAGS += -DARCH=$(ARCH)
 endif
 
-CXXFLAGS += -DENGINE_NAME='"$(ENGINE_BASENAME)"' -DENGINE_VERSION='"$(RELEASE_TAG)-$(ARCH_TAG)"'
+CXXFLAGS += -DENGINE_NAME='"$(ENGINE_BASENAME)"' -DENGINE_VERSION='"$(RELEASE_TAG)"'
 
 ### 3.9 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "5.60-100526";
+constexpr std::string_view version = "5.70-250526";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and


### PR DESCRIPTION
### Motivation
- Apply a controlled rebrand to expose the new base release identity `Revolution-5.70-250526` in the build and runtime surfaces while preserving the single-big-net runtime bridge, NNUE filenames/options, and architecture-specific binary naming conventions.

### Description
- Updated `RELEASE_TAG` to `5.70-250526` and adjusted `ARCH_TAG` handling in `src/Makefile`, changed `CXXFLAGS` to define `ENGINE_VERSION` as the base `$(RELEASE_TAG)` (so compile-time `ENGINE_VERSION` no longer appends the arch), and updated the fallback `version` constant in `src/misc.cpp` to `5.70-250526`; files changed: `src/Makefile`, `src/misc.cpp`.

### Testing
- Verified P0P/P0Q surfaces with textual checks (Worker single-big-net evaluate path and `make_default_big_network`/get_default_networks presence), validated NNUE default constants remained unchanged, built the full Linux clang/lld matrix for all required ARCH targets with a clean log gate (no warnings/errors), confirmed produced binaries include `Revolution-5.70-250526` + arch suffix, and ran UCI and runtime smoke (checked `id name Revolution-5.70-250526`, `uciok`/`readyok`, presence of `EvalFile`/`EvalFileSmall`, and that a `bestmove` was returned with no crash).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137be5c9f883278a1caafb4f139a01)