### PR TITLE
REVOLUTION-P0T: remove EvalFileSmall UCI surface

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -188,12 +188,6 @@ Engine::Engine(std::optional<std::string> path) :
           return std::nullopt;
       }));
 
-    options.add(  //
-      "EvalFileSmall", Option(EvalFileDefaultNameSmall, [this](const Option& o) {
-          load_small_network(o);
-          return std::nullopt;
-      }));
-
     threads.clear();
     threads.ensure_network_replicated();
     resize_threads();
@@ -327,7 +321,7 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
-    networks->small.verify(options["EvalFileSmall"], onVerifyNetworks);
+    networks->small.verify(EvalFileDefaultNameSmall, onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)


### PR DESCRIPTION
### Motivation
- Remove the public UCI runtime surface `EvalFileSmall` so the engine no longer advertises a small-net option while preserving internal small-net compatibility and the active single-big-net search evaluation.
- Decouple the small-network verification from a user-facing option while keeping internal loading/embedded small-net artifacts for later-phase purges.

### Description
- Deleted the public UCI option registration for `EvalFileSmall` from the `Engine` options setup by removing the `options.add("EvalFileSmall", ...)` entry in `Engine` constructor in `src/engine.cpp`.
- Changed `Engine::verify_networks()` to call `networks->small.verify(EvalFileDefaultNameSmall, onVerifyNetworks)` instead of using `options["EvalFileSmall"]`, thereby keeping small-net verification but removing its dependency on a public UCI option.
- Preserved internal small-net APIs and functions (`load_small_network`, embedded small-net constant `EvalFileDefaultNameSmall`, `get_default_networks()` etc.) so the dual-net structures remain available for compilation and later purge phases.
- Only source file modified: `src/engine.cpp` (minimal, localized change to remove the public UCI surface).

### Testing
- Built successfully (zero warnings/errors) for `ARCH=x86-64-sse41-popcnt`, `ARCH=x86-64-avx2`, and `ARCH=x86-64-avx512icl` using `make -C src build` with `clang`/`lld`.
- UCI smoke verified that `id name Revolution-5.70-250526` is preserved and that `option name EvalFile` is still exposed while `option name EvalFileSmall` is no longer listed in UCI output.
- Runtime smoke (`setoption name EvalFile ...` + `go depth 1`) returned `bestmove` without crashes and showed both big and embedded small networks present internally in logs.
- Legacy negative smoke (`setoption name EvalFileSmall ...`) is handled safely (engine responded `No such option` and `readyok`) with no crash.
- Threaded smoke (`Threads=4`, `Hash=64`, `go depth 4`) completed and returned `bestmove` with no crashes, preserving threaded runtime behaviour and single-big-net evaluation path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13805960248327959d641b2bc908b5)