### PR TITLE
REVOLUTION-P0U: remove internal small-net load verify path

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -321,7 +321,6 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 
 void Engine::verify_networks() const {
     networks->big.verify(options["EvalFile"], onVerifyNetworks);
-    networks->small.verify(EvalFileDefaultNameSmall, onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -413,13 +412,6 @@ void Engine::load_network(const std::string& file) { load_big_network(file); }
 void Engine::load_big_network(const std::string& file) {
     networks.modify_and_replicate(
       [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
-    threads.clear();
-    threads.ensure_network_replicated();
-}
-
-void Engine::load_small_network(const std::string& file) {
-    networks.modify_and_replicate(
-      [this, &file](NN::Networks& networks_) { networks_.small.load(binaryDirectory, file); });
     threads.clear();
     threads.ensure_network_replicated();
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -93,7 +93,6 @@ class Engine {
     void verify_networks() const;
     void load_network(const std::string& file);
     void load_big_network(const std::string& file);
-    void load_small_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string>& file);
     void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 


### PR DESCRIPTION
### Motivation
- Remove dead runtime plumbing for the internal small NNUE that is no longer reachable after the prior P0T/P0P changes while preserving dual-net compatibility scaffolding needed for compilation and later phases.

### Description
- Removed the now-unreferenced `Engine::load_small_network(...)` declaration and definition so the engine no longer exposes a public small-net load bridge.
- Modified `Engine::verify_networks()` to verify only the big network by removing the `networks->small.verify(...)` call while preserving the existing status-reporting loop and callbacks.
- Kept internal compatibility artifacts intact including `NetworkSmall`, `NNUE::Networks`, `get_default_networks()`, `save_network(files[2])`, and `EvalFileDefaultNameSmall` so later phases can further purge small-net surfaces safely.
- Changes limited to `src/engine.cpp` and `src/engine.h` only.

### Testing
- Built the engine with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang` and the build completed successfully with zero warnings or errors.
- Verified UCI output via `printf "uci\nisready\nquit\n" | <engine binary>` and confirmed `id name Revolution-5.70-250526`, `uciok`, `readyok`, and that `option name EvalFile` is present while `option name EvalFileSmall` is absent.
- Ran runtime smokes (`setoption name EvalFile`, `isready`, `position startpos`, `go depth 1`) and observed `readyok` and `bestmove` with no crash or assert.
- Ran eval/verify smoke (`eval`) after setting `EvalFile` and observed NNUE evaluation output with no missing-small-net complaint or crash.
- Sent legacy negative test `setoption name EvalFileSmall ...` and observed controlled rejection (`No such option`) with no crash.
- Ran threaded smoke (set `Threads`/`Hash` and `go depth 4`) and observed normal threaded operation with `bestmove` and no crash.
- Static checks and `rg` searches confirm `load_small_network(` is removed from Engine/UCI surfaces and `verify_networks()` no longer references the small net.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13821ae3648327ba4d620684d37737)