### PR TITLE
REVOLUTION-P0V: remove dual small-net export surface

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -416,13 +416,6 @@ void Engine::load_big_network(const std::string& file) {
     threads.ensure_network_replicated();
 }
 
-void Engine::save_network(const std::pair<std::optional<std::string>, std::string> files[2]) {
-    networks.modify_and_replicate([&files](NN::Networks& networks_) {
-        networks_.big.save(files[0].first);
-        networks_.small.save(files[1].first);
-    });
-}
-
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string>& file) {
     networks.modify_and_replicate(
       [&file](NN::Networks& networks_) { networks_.big.save(file.first); });

--- a/src/engine.h
+++ b/src/engine.h
@@ -94,7 +94,6 @@ class Engine {
     void load_network(const std::string& file);
     void load_big_network(const std::string& file);
     void save_network(const std::pair<std::optional<std::string>, std::string>& file);
-    void save_network(const std::pair<std::optional<std::string>, std::string> files[2]);
 
     // utility functions
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -185,18 +185,7 @@ void UCIEngine::loop() {
             if (is >> std::skipws >> file.second)
                 file.first = file.second;
 
-            if (!(is >> std::skipws).eof())
-            {
-                std::pair<std::optional<std::string>, std::string> files[2];
-                files[0] = file;
-
-                if (is >> files[1].second)
-                    files[1].first = files[1].second;
-
-                engine.save_network(files);
-            }
-            else
-                engine.save_network(file);
+            engine.save_network(file);
         }
         else if (token == "--help" || token == "help" || token == "--license" || token == "license")
             sync_cout


### PR DESCRIPTION
### Motivation
- Remove the legacy dual-file small-net export/save surface so the public export path is strictly single-file big-net while preserving internal NNUE::Networks compatibility for later phases.

### Description
- Simplified UCI `export_net` in `src/uci.cpp` to always parse at most one filename and call `engine.save_network(file)` on the single-file path.
- Removed the dual-file overload declaration from `src/engine.h` and its implementation from `src/engine.cpp` that previously saved both `networks_.big` and `networks_.small`.
- Preserved the single-file `Engine::save_network(const std::pair<std::optional<std::string>, std::string>& file)` and the big-net save path `networks_.big.save(file.first)` so runtime and export semantics for the big network remain unchanged.
- Limited edits to `src/uci.cpp`, `src/engine.h`, and `src/engine.cpp` and avoided any changes to build-system, search, evaluation, or other forbidden areas.

### Testing
- Built the engine with `make -C src build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed successfully with no warnings or errors.
- UCI smoke (`uci` / `isready`) confirmed `id name Revolution-5.70-250526`, `uciok`, `readyok`, and that `option name EvalFile` is present while `option name EvalFileSmall` is absent.
- Single-file export smoke (`export_net <big-file>`) produced a non-empty big export file and completed without crash.
- Dual-file export negative smoke (`export_net <big> <small>`) completed without crash and did not produce the second/small export file.
- Runtime smoke (depth 1) and threaded runtime smoke (depth 4 with `Threads=4` and `Hash=64`) both returned `readyok` and `bestmove` with no crashes.
- Source grep checks confirm removal of dual/small export patterns (`save_network(files[2])`, `engine.save_network(files)`, `networks_.small.save(...)`) and preservation of internal `NetworkSmall` compatibility; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138664b868832786e3b27d460d6f13)