### PR TITLE
REVOLUTION-P0W: remove default small-net construction

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -395,10 +395,9 @@ void Engine::verify_network() const {
 std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
     auto networks_ =
       std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                     NN::EvalFile{EvalFileDefaultNameSmall, "None", ""});
+                                     NN::EvalFile{"", "None", ""});
 
     networks_->big = *make_default_big_network(binaryDirectory);
-    networks_->small.load(binaryDirectory, "");
 
     return networks_;
 }


### PR DESCRIPTION
### Motivation
- Remove the legacy default small-network construction/loading from `Engine::get_default_networks()` so the engine no longer actively constructs/loads the small side while preserving the consolidated big-net path and NNUE compatibility scaffolding.

### Description
- Modified `Engine::get_default_networks()` to pass an empty inert `EvalFile` for the small side and removed the call to `networks_->small.load(...)`, while keeping `networks_->big = *make_default_big_network(binaryDirectory);` and the `NN::Networks` container intact.

### Testing
- Built with `ARCH=x86-64-sse41-popcnt COMP=clang` (zero warnings/errors) and ran UCI, runtime (depth 1), eval, export_net, and threaded (Threads=4, depth 4) smoke tests which all passed; `verify_networks()` remains big-only and `Search::Worker::evaluate()` still uses the single-big-net bridge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1387d49afc8327811fef0aa7b674e7)