### PR TITLE
REVOLUTION-P0X: add Search-side big-network bridge and remove direct .big access from Worker

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,6 +65,10 @@ using namespace Search;
 
 namespace {
 
+const Eval::NNUE::NetworkBig& big_network_from_networks(const Eval::NNUE::Networks& networks) {
+    return networks.big;
+}
+
 constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
@@ -644,7 +648,7 @@ void Search::Worker::clear() {
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2747 / 128.0 * std::log(i));
 
-    refreshTable.clear(networks[numaAccessToken]);
+    refreshTable.big.clear(big_network());
 }
 
 
@@ -1803,7 +1807,7 @@ TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elaps
 }
 
 const Eval::NNUE::NetworkBig& Search::Worker::big_network() const {
-    return networks[numaAccessToken].big;
+    return big_network_from_networks(networks[numaAccessToken]);
 }
 
 Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>&


### PR DESCRIPTION
### Motivation
- Continue collapsing dual-net `NNUE::Networks` usage toward a single big-net storage without touching NNUE internals by removing direct `.big` member access from active Search/Worker code where compile-safe.
- Provide a minimal, compile-safe bridge so the runtime and public behaviour remain single-big-net while leaving full storage type conversion to a later phase.

### Description
- Added a helper `big_network_from_networks(const Eval::NNUE::Networks&)` to centralize extraction of the `NetworkBig` instance from the existing `NNUE::Networks` aggregate in `src/search.cpp`.
- Updated `Search::Worker::big_network()` to return the big network via the new helper instead of accessing `.big` directly.
- Replaced the accumulator clear call to use the big cache path with `refreshTable.big.clear(big_network())` in `Search::Worker::clear()` so worker initialization uses the singular big-network path.
- Changes are limited to `src/search.cpp` to keep the patch compile-safe and avoid touching NNUE internals or build system files.

### Testing
- Built the engine: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`, and the build completed with zero warnings/errors.
- UCI smoke: ran `uci`/`isready` and verified `id name Revolution-5.70-250526`, `uciok`, `readyok`, and that `option name EvalFile` is present while `EvalFileSmall` is absent; this passed.
- Runtime smoke: started the engine with `EvalFile` set and ran `position startpos` + `go depth 1`, which returned `bestmove` with no crash.
- Eval/verify/export/threaded smokes: ran `eval`, `export_net` (produced a single big `.nnue`), and a threaded `go depth 4` with `Threads=4`; all completed successfully with no crashes.
- Note: a full storage-type replacement was deferred because `AccumulatorCaches` construction/clear paths still expect the `NNUE::Networks` aggregate, so those dependencies remain for a follow-up phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138938fa5083279de922242d31b7a8)