### PR TITLE
REVOLUTION-P0Y: add accumulator cache single-net bridge

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -95,9 +95,14 @@ struct AccumulatorCaches {
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
+    template<typename Network>
+    void clear_big(const Network& network) {
+        big.clear(network);
+    }
+
     template<typename Networks>
     void clear(const Networks& networks) {
-        big.clear(networks.big);
+        clear_big(networks.big);
         small.clear(networks.small);
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -648,7 +648,7 @@ void Search::Worker::clear() {
     for (size_t i = 1; i < reductions.size(); ++i)
         reductions[i] = int(2747 / 128.0 * std::log(i));
 
-    refreshTable.big.clear(big_network());
+    refreshTable.clear_big(big_network());
 }
 
 


### PR DESCRIPTION
### Motivation
- Remove the compile blocker that prevents Engine/Search storage collapse by giving the accumulator cache layer a direct big-network-only clear path. 
- Preserve existing dual-network APIs and small-net artifacts for compatibility until the full fossil purge in a later phase. 
- Keep all search/evaluation semantics and UCI surfaces unchanged while enabling P0Z to retry storage collapse safely.

### Description
- Add a narrow big-only API `template<typename Network> void clear_big(const Network& network)` to `AccumulatorCaches` and keep the existing `clear(const Networks&)` overload delegating its big-side work to `clear_big(networks.big)` in `src/nnue/nnue_accumulator.h`.
- Route `Search::Worker::clear()` to use the new bridge via `refreshTable.clear_big(big_network())` instead of directly calling `refreshTable.big.clear(...)` in `src/search.cpp`.
- Only `src/nnue/nnue_accumulator.h` and `src/search.cpp` were modified and all dual-net compatibility surfaces were preserved.

### Testing
- Built with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed with zero warnings/errors according to the strict grep gate. (PASS)
- UCI smoke (`uci`/`isready`) shows `id name Revolution-5.70-250526`, `uciok`, `readyok`, and `option name EvalFile` present while `EvalFileSmall` is absent. (PASS)
- Runtime smoke (`go depth 1`) returned `bestmove` without crash and threaded runtime (`go depth 4`) also completed with `bestmove`. (PASS)
- Eval trace/verify smoke (`eval`) ran with only `EvalFile` set, produced NNUE/final evaluation output, and reported no missing-small-net complaints. (PASS)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138b3c15bc8327b40b9eeef4723680)