### PR TITLE
REVOLUTION-P0Z: collapse active network storage to single NetworkBig

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -77,7 +77,7 @@ Engine::Engine(std::optional<std::string> path) :
     numaContext(NumaConfig::from_system(DefaultNumaPolicy)),
     states(new std::deque<StateInfo>(1)),
     threads(),
-    networks(numaContext, get_default_networks()) {
+    networks(numaContext, get_default_network()) {
 
     pos.set(StartFEN, false, &states->back());
 
@@ -320,7 +320,7 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 // network related
 
 void Engine::verify_networks() const {
-    networks->big.verify(options["EvalFile"], onVerifyNetworks);
+    networks->verify(options["EvalFile"], onVerifyNetworks);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -356,7 +356,7 @@ void Engine::verify_networks() const {
 void Engine::verify_network() const {
     const auto report = onVerifyNetworks ? onVerifyNetworks : [](std::string_view) {};
 
-    networks->big.verify(options["EvalFile"], report);
+    networks->verify(options["EvalFile"], report);
 
     auto statuses = networks.get_status_and_errors();
 
@@ -392,16 +392,6 @@ void Engine::verify_network() const {
     }
 }
 
-std::unique_ptr<Eval::NNUE::Networks> Engine::get_default_networks() const {
-    auto networks_ =
-      std::make_unique<NN::Networks>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
-                                     NN::EvalFile{"", "None", ""});
-
-    networks_->big = *make_default_big_network(binaryDirectory);
-
-    return networks_;
-}
-
 std::unique_ptr<Eval::NNUE::NetworkBig> Engine::get_default_network() const {
     return make_default_big_network(binaryDirectory);
 }
@@ -410,14 +400,14 @@ void Engine::load_network(const std::string& file) { load_big_network(file); }
 
 void Engine::load_big_network(const std::string& file) {
     networks.modify_and_replicate(
-      [this, &file](NN::Networks& networks_) { networks_.big.load(binaryDirectory, file); });
+      [this, &file](NN::NetworkBig& network_) { network_.load(binaryDirectory, file); });
     threads.clear();
     threads.ensure_network_replicated();
 }
 
 void Engine::save_network(const std::pair<std::optional<std::string>, std::string>& file) {
     networks.modify_and_replicate(
-      [&file](NN::Networks& networks_) { networks_.big.save(file.first); });
+      [&file](NN::NetworkBig& network_) { network_.save(file.first); });
 }
 
 // utility functions
@@ -429,7 +419,7 @@ void Engine::trace_eval() const {
 
     verify_network();
 
-    sync_cout << "\n" << Eval::trace(p, networks->big) << sync_endl;
+    sync_cout << "\n" << Eval::trace(p, *networks) << sync_endl;
 }
 
 const OptionsMap& Engine::get_options() const { return options; }

--- a/src/engine.h
+++ b/src/engine.h
@@ -88,7 +88,6 @@ class Engine {
     // network related
 
     std::unique_ptr<Eval::NNUE::NetworkBig> get_default_network() const;
-    std::unique_ptr<Eval::NNUE::Networks> get_default_networks() const;
     void verify_network() const;
     void verify_networks() const;
     void load_network(const std::string& file);
@@ -124,7 +123,7 @@ class Engine {
     OptionsMap                                         options;
     ThreadPool                                         threads;
     TranspositionTable                                 tt;
-    LazyNumaReplicatedSystemWide<Eval::NNUE::Networks> networks;
+    LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig> networks;
     BookManager                                       bookManager;
 
     Search::SearchManager::UpdateContext  updateContext;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,8 +65,11 @@ using namespace Search;
 
 namespace {
 
-const Eval::NNUE::NetworkBig& big_network_from_networks(const Eval::NNUE::Networks& networks) {
-    return networks.big;
+Eval::NNUE::Networks make_networks_cache_seed_from_big(const Eval::NNUE::NetworkBig& network) {
+    Eval::NNUE::Networks networks_{Eval::NNUE::EvalFile{"", "None", ""},
+                                   Eval::NNUE::EvalFile{"", "None", ""}};
+    networks_.big = network;
+    return networks_;
 }
 
 constexpr int SEARCHEDLIST_CAPACITY = 32;
@@ -174,7 +177,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
     threads(sharedState.threads),
     tt(sharedState.tt),
     networks(sharedState.networks),
-    refreshTable(networks[token]) {
+    refreshTable(make_networks_cache_seed_from_big(networks[token])) {
     clear();
 }
 
@@ -1807,7 +1810,7 @@ TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elaps
 }
 
 const Eval::NNUE::NetworkBig& Search::Worker::big_network() const {
-    return big_network_from_networks(networks[numaAccessToken]);
+    return networks[numaAccessToken];
 }
 
 Eval::NNUE::AccumulatorCaches::Cache<Eval::NNUE::TransformedFeatureDimensionsBig>&

--- a/src/search.h
+++ b/src/search.h
@@ -141,7 +141,7 @@ struct SharedState {
                 ThreadPool&                                               threadPool,
                 TranspositionTable&                                       transpositionTable,
                 std::map<NumaIndex, SharedHistories>&                     sharedHists,
-                const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& nets) :
+                const LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>& nets) :
         options(optionsMap),
         threads(threadPool),
         tt(transpositionTable),
@@ -152,7 +152,7 @@ struct SharedState {
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
     std::map<NumaIndex, SharedHistories>&                     sharedHistories;
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>& networks;
 };
 
 class Worker;
@@ -370,7 +370,7 @@ class Worker {
     const OptionsMap&                                         options;
     ThreadPool&                                               threads;
     TranspositionTable&                                       tt;
-    const LazyNumaReplicatedSystemWide<Eval::NNUE::Networks>& networks;
+    const LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>& networks;
 
     // Used by NNUE
     Eval::NNUE::AccumulatorStack  accumulatorStack;


### PR DESCRIPTION
### Motivation
- Move active Engine/Search replicated NNUE storage from the dual-aggregate `Eval::NNUE::Networks` to the singular `Eval::NNUE::NetworkBig` now that `AccumulatorCaches::clear_big(...)` exists. 
- Reduce Engine/Search dependence on the `.big` extraction bridge while keeping `Worker::evaluate()` semantics unchanged and avoiding NNUE-internal rewrites.

### Description
- Changed the Engine replicated storage type to `LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>` and initialized it with `get_default_network()` instead of `get_default_networks()`; removed the active `get_default_networks()` usage and declaration. (files: `src/engine.h`, `src/engine.cpp`).
- Updated Engine network operations to use `NetworkBig` directly: `verify`, `load`, `save`, and `trace` now operate on the singular `NetworkBig` replica rather than extracting `.big`. (file: `src/engine.cpp`).
- Switched Search-side references to the singular replicated `NetworkBig` in `SharedState` and `Worker`, and made `Search::Worker::big_network()` return `networks[numaAccessToken]` directly; removed the worker-level `.big` extraction helper. (files: `src/search.h`, `src/search.cpp`).
- Added a narrow compatibility helper `make_networks_cache_seed_from_big(const Eval::NNUE::NetworkBig&)` used only to seed `AccumulatorCaches` during `Worker` construction so that `AccumulatorCaches` constructor compatibility is preserved without touching NNUE internals. (file: `src/search.cpp`).

### Testing
- Ran source validations and grep-based checks for removed small-net surfaces and for preservation of single-big evaluation/clear paths; checks passed (no reintroduction of `EvalFileSmall` or `.small` usage in active paths).
- Built the project with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`; build completed successfully with zero warnings/errors in the build log.
- Executed UCI smoke (`uci`/`isready`) and runtime smokes with `EvalFile` set, including `eval`, `export_net`, single-threaded depth-1 `go`, and threaded depth-4 `go`; engine responded (`id name` = `Revolution-5.70-250526`, `uciok`, `readyok`), `option name EvalFile` present, `EvalFileSmall` absent, and `bestmove`/export file observed as expected.
- Verified `Worker::evaluate()` remains the single-big bridge (`evaluate_with_big_network_bridge(big_network(), ..., big_cache(), ...)`) and `Worker::clear()` uses `refreshTable.clear_big(big_network())` after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138c96f624832794763eaf560083ec)