### PR TITLE
REVOLUTION-P0AA: collapse accumulator cache seed to single net

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -60,9 +60,16 @@ struct alignas(CacheLineSize) Accumulator {
 // is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
 
+    AccumulatorCaches() = default;
+
     template<typename Networks>
     AccumulatorCaches(const Networks& networks) {
         clear(networks);
+    }
+
+    template<typename Network>
+    void init_big(const Network& network) {
+        clear_big(network);
     }
 
     template<IndexType Size>

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -65,13 +65,6 @@ using namespace Search;
 
 namespace {
 
-Eval::NNUE::Networks make_networks_cache_seed_from_big(const Eval::NNUE::NetworkBig& network) {
-    Eval::NNUE::Networks networks_{Eval::NNUE::EvalFile{"", "None", ""},
-                                   Eval::NNUE::EvalFile{"", "None", ""}};
-    networks_.big = network;
-    return networks_;
-}
-
 constexpr int SEARCHEDLIST_CAPACITY = 32;
 using SearchedList                  = ValueList<Move, SEARCHEDLIST_CAPACITY>;
 
@@ -177,7 +170,8 @@ Search::Worker::Worker(SharedState&                    sharedState,
     threads(sharedState.threads),
     tt(sharedState.tt),
     networks(sharedState.networks),
-    refreshTable(make_networks_cache_seed_from_big(networks[token])) {
+    refreshTable() {
+    refreshTable.init_big(networks[token]);
     clear();
 }
 


### PR DESCRIPTION
### Motivation
- Remove the temporary P0Z compatibility bridge `make_networks_cache_seed_from_big(...)` so AccumulatorCaches no longer requires an `NNUE::Networks` wrapper to initialize big-cache state. 
- Provide a direct NetworkBig-only seeding path for accumulator caches to complete the Storage collapse to `NetworkBig`. 
- Preserve the already-collapsed active Engine/Search storage and Worker big-only semantics while avoiding reintroduction of any small-net public/load/export/verify surfaces.

### Description
- Added a default constructor and a `init_big(const Network& network)` seeding helper to `AccumulatorCaches` in `src/nnue/nnue_accumulator.h` that calls the existing `clear_big(...)` path to initialize big-only cache state. 
- Removed the temporary function `make_networks_cache_seed_from_big(...)` from `src/search.cpp` and eliminated its use. 
- Changed `Search::Worker` construction in `src/search.cpp` to initialize `refreshTable` from the active `NetworkBig` replica by calling `refreshTable.init_big(networks[token]);` and then call `clear()`. 
- Kept all active Engine/Search storage and runtime evaluation APIs as `NetworkBig` only; `Worker::evaluate()` and `Worker::clear()` continue to use the big-only paths (`evaluate_with_big_network_bridge(big_network(), ...)` and `refreshTable.clear_big(big_network())`).

### Testing
- Ran repository scans to confirm active storage remains `NetworkBig` and `make_networks_cache_seed_from_big` is absent; those checks passed. 
- Built the project with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed with no warnings or errors. 
- Executed automated UCI and runtime smokes: `uci`/`isready`, `setoption EvalFile` + `go depth 1`, `eval`, `export_net`, and a threaded `go depth 4`; all ran successfully and returned expected `uciok`/`readyok`/`bestmove` outputs and produced a single big-net export file. 
- Verified that `EvalFile` remains exposed in UCI output and `EvalFileSmall` does not reappear; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138e3e86c88327a61e97c0e1c58aea)