### PR TITLE
REVOLUTION-P0AB: remove dual-net Eval evaluate/trace overload fossils

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -50,45 +50,6 @@ bool Eval::use_smallnet(const Position& pos) { return std::abs(simple_eval(pos))
 
 // Evaluate is the evaluator for the outer world. It returns a static evaluation
 // of the position from the point of view of the side to move.
-Value Eval::evaluate(const Eval::NNUE::Networks&    networks,
-                     const Position&                pos,
-                     Eval::NNUE::AccumulatorStack&  accumulators,
-                     Eval::NNUE::AccumulatorCaches& caches,
-                     int                            optimism) {
-
-    assert(!pos.checkers());
-
-    bool smallNet           = use_smallnet(pos);
-    auto [psqt, positional] = smallNet ? networks.small.evaluate(pos, accumulators, caches.small)
-                                       : networks.big.evaluate(pos, accumulators, caches.big);
-
-    Value nnue = (125 * psqt + 131 * positional) / 128;
-
-    // Re-evaluate the position when higher eval accuracy is worth the time spent
-    if (smallNet && (std::abs(nnue) < 277))
-    {
-        std::tie(psqt, positional) = networks.big.evaluate(pos, accumulators, caches.big);
-        nnue                       = (125 * psqt + 131 * positional) / 128;
-        smallNet                   = false;
-    }
-
-    // Blend optimism and eval with nnue complexity
-    int nnueComplexity = std::abs(psqt - positional);
-    optimism += optimism * nnueComplexity / 476;
-    nnue -= nnue * nnueComplexity / 18236;
-
-    int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * (77871 + material) + optimism * (7191 + material)) / 77871;
-
-    // Damp down the evaluation linearly when shuffling
-    v -= v * pos.rule50_count() / 199;
-
-    // Guarantee evaluation does not hit the tablebase range
-    v = std::clamp(v, VALUE_TB_LOSS_IN_MAX_PLY + 1, VALUE_TB_WIN_IN_MAX_PLY - 1);
-
-    return v;
-}
-
 
 Value Eval::evaluate(const Eval::NNUE::NetworkBig& network,
                      const Position&               pos,
@@ -138,34 +99,6 @@ std::string Eval::trace(Position& pos, const Eval::NNUE::NetworkBig& network) {
     ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
 
     v = evaluate(network, pos, *accumulators, *caches, VALUE_ZERO);
-    v = pos.side_to_move() == WHITE ? v : -v;
-    ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
-    ss << " [with scaled NNUE, ...]";
-    ss << "\n";
-
-    return ss.str();
-}
-
-std::string Eval::trace(Position& pos, const Eval::NNUE::Networks& networks) {
-
-    if (pos.checkers())
-        return "Final evaluation: none (in check)";
-
-    auto accumulators = std::make_unique<Eval::NNUE::AccumulatorStack>();
-    auto caches       = std::make_unique<Eval::NNUE::AccumulatorCaches>(networks);
-
-    std::stringstream ss;
-    ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2);
-    ss << '\n' << NNUE::trace(pos, networks, *caches) << '\n';
-
-    ss << std::showpoint << std::showpos << std::fixed << std::setprecision(2) << std::setw(15);
-
-    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, caches->big);
-    Value v                 = psqt + positional;
-    v                       = pos.side_to_move() == WHITE ? v : -v;
-    ss << "NNUE evaluation        " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)\n";
-
-    v = evaluate(networks, pos, *accumulators, *caches, VALUE_ZERO);
     v = pos.side_to_move() == WHITE ? v : -v;
     ss << "Final evaluation       " << 0.01 * UCIEngine::to_cp(v, pos) << " (white side)";
     ss << " [with scaled NNUE, ...]";

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -44,16 +44,10 @@ struct AccumulatorCaches;
 class AccumulatorStack;
 }
 
-std::string trace(Position& pos, const Eval::NNUE::Networks& networks);
 std::string trace(Position& pos, const Eval::NNUE::NetworkBig& network);
 
 int   simple_eval(const Position& pos);
 bool  use_smallnet(const Position& pos);
-Value evaluate(const NNUE::Networks&          networks,
-               const Position&                pos,
-               Eval::NNUE::AccumulatorStack&  accumulators,
-               Eval::NNUE::AccumulatorCaches& caches,
-               int                            optimism);
 Value evaluate(const NNUE::NetworkBig& network,
                const Position&         pos,
                Eval::NNUE::AccumulatorStack& accumulators,


### PR DESCRIPTION
### Motivation
- The runtime has been consolidated to a single big NNUE network and the dual-`NNUE::Networks` evaluation/trace overloads are now inactive fossil surfaces that should be removed.
- Removing unused dual-net `Eval::evaluate`/`Eval::trace` overloads reduces API surface and avoids future regressions while preserving active `NetworkBig` APIs and storage.

### Description
- Deleted the `Eval::evaluate(const Eval::NNUE::Networks&, ...)` declaration from `src/evaluate.h` and its definition from `src/evaluate.cpp`.
- Deleted the `Eval::trace(Position&, const Eval::NNUE::Networks&)` declaration from `src/evaluate.h` and its definition from `src/evaluate.cpp`.
- Preserved all `NetworkBig` overloads and their evaluation/trace implementations and did not change any evaluation formulas or scaling behavior in `src/evaluate.cpp`.
- No Makefile/build-system/ARCH changes were made and Engine/Search storage remains `LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>`.

### Testing
- Ran repository grep/verification checks for storage type, small-net surfaces and API removal and they all passed (dual-net evaluate/trace APIs absent and `NetworkBig` paths intact).
- Built `src` with `make ARCH=x86-64-sse41-popcnt COMP=clang` producing zero warnings and zero errors and the build completed successfully.
- Executed UCI smoke (`uci`/`isready`) and verified `id name Revolution-5.70-250526`, presence of `option name EvalFile`, and absence of `EvalFileSmall`.
- Performed runtime smoke (`go depth 1`), eval trace smoke (`eval`), single-file `export_net` smoke (export file created), and threaded runtime (`Threads=4 go depth 4`), all completing with no crashes and producing expected outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138f8474b483278bd8b3f42f9f9124)