### PR TITLE
REVOLUTION-P0AC: remove inactive NNUE Networks fossils

### DIFF
--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -62,11 +62,6 @@ struct AccumulatorCaches {
 
     AccumulatorCaches() = default;
 
-    template<typename Networks>
-    AccumulatorCaches(const Networks& networks) {
-        clear(networks);
-    }
-
     template<typename Network>
     void init_big(const Network& network) {
         clear_big(network);
@@ -107,14 +102,7 @@ struct AccumulatorCaches {
         big.clear(network);
     }
 
-    template<typename Networks>
-    void clear(const Networks& networks) {
-        clear_big(networks.big);
-        small.clear(networks.small);
-    }
-
-    Cache<TransformedFeatureDimensionsBig>   big;
-    Cache<TransformedFeatureDimensionsSmall> small;
+    Cache<TransformedFeatureDimensionsBig> big;
 };
 
 


### PR DESCRIPTION
### Motivation
- Remove inactive dual-net compatibility surfaces in `AccumulatorCaches` now that the runtime is single big-net and the small-net paths are unused.

### Description
- Deleted the templated `AccumulatorCaches(const Networks&)` constructor, removed `AccumulatorCaches::clear(const Networks&)`, and removed the `Cache<TransformedFeatureDimensionsSmall> small` member and related small-cache usage from `src/nnue/nnue_accumulator.h`, while preserving `init_big`, `clear_big`, and the `big` cache.

### Testing
- Built the project with `make -C src` (ARCH=x86-64-sse41-popcnt COMP=clang) with zero warnings/errors and ran UCI/runtime/eval/export/threaded smoke tests (`uci`/`isready`, depth search, `eval`, `export_net`, threaded depth run) which all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1390feb8ac8327a11c2169d0f71ae9)