### PR TITLE
REVOLUTION-P0AD: remove inactive NNUE NetworkSmall type surface

### DIFF
--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,7 +39,6 @@ namespace Eval {
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {
-struct Networks;
 struct AccumulatorCaches;
 class AccumulatorStack;
 }

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -45,14 +45,10 @@
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
 INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig);
-INCBIN(EmbeddedNNUESmall, EvalFileDefaultNameSmall);
 #else
-const unsigned char        gEmbeddedNNUEBigData[1]   = {0x0};
-const unsigned char* const gEmbeddedNNUEBigEnd       = &gEmbeddedNNUEBigData[1];
-const unsigned int         gEmbeddedNNUEBigSize      = 1;
-const unsigned char        gEmbeddedNNUESmallData[1] = {0x0};
-const unsigned char* const gEmbeddedNNUESmallEnd     = &gEmbeddedNNUESmallData[1];
-const unsigned int         gEmbeddedNNUESmallSize    = 1;
+const unsigned char        gEmbeddedNNUEBigData[1] = {0x0};
+const unsigned char* const gEmbeddedNNUEBigEnd      = &gEmbeddedNNUEBigData[1];
+const unsigned int         gEmbeddedNNUEBigSize     = 1;
 #endif
 
 namespace {
@@ -72,10 +68,8 @@ struct EmbeddedNNUE {
 using namespace Stockfish::Eval::NNUE;
 
 EmbeddedNNUE get_embedded(EmbeddedNNUEType type) {
-    if (type == EmbeddedNNUEType::BIG)
-        return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
-    else
-        return EmbeddedNNUE(gEmbeddedNNUESmallData, gEmbeddedNNUESmallEnd, gEmbeddedNNUESmallSize);
+    (void) type;
+    return EmbeddedNNUE(gEmbeddedNNUEBigData, gEmbeddedNNUEBigEnd, gEmbeddedNNUEBigSize);
 }
 
 }
@@ -410,7 +404,5 @@ bool Network<Arch, Transformer>::write_parameters(std::ostream&      stream,
 template class Network<NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>,
                        FeatureTransformer<TransformedFeatureDimensionsBig>>;
 
-template class Network<NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>,
-                       FeatureTransformer<TransformedFeatureDimensionsSmall>>;
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -45,7 +45,6 @@ namespace Stockfish::Eval::NNUE {
 
 enum class EmbeddedNNUEType {
     BIG,
-    SMALL,
 };
 
 using NetworkOutput = std::tuple<Value, Value>;
@@ -117,24 +116,17 @@ class Network {
 };
 
 // Definitions of the network types
-using SmallFeatureTransformer = FeatureTransformer<TransformedFeatureDimensionsSmall>;
-using SmallNetworkArchitecture =
-  NetworkArchitecture<TransformedFeatureDimensionsSmall, L2Small, L3Small>;
-
 using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
 using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
 
-using NetworkBig   = Network<BigNetworkArchitecture, BigFeatureTransformer>;
-using NetworkSmall = Network<SmallNetworkArchitecture, SmallFeatureTransformer>;
+using NetworkBig = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 
 
 struct Networks {
-    Networks(EvalFile bigFile, EvalFile smallFile) :
-        big(bigFile, EmbeddedNNUEType::BIG),
-        small(smallFile, EmbeddedNNUEType::SMALL) {}
+    explicit Networks(EvalFile bigFile) :
+        big(bigFile, EmbeddedNNUEType::BIG) {}
 
-    NetworkBig   big;
-    NetworkSmall small;
+    NetworkBig big;
 };
 
 
@@ -148,14 +140,5 @@ struct std::hash<Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>> {
     }
 };
 
-template<>
-struct std::hash<Stockfish::Eval::NNUE::Networks> {
-    std::size_t operator()(const Stockfish::Eval::NNUE::Networks& networks) const noexcept {
-        std::size_t h = 0;
-        Stockfish::hash_combine(h, networks.big);
-        Stockfish::hash_combine(h, networks.small);
-        return h;
-    }
-};
 
 #endif


### PR DESCRIPTION
### Motivation
- Continue the single-big-net fossil purge by eliminating inactive small-net type surfaces from the NNUE layer where they are no longer referenced by active code.
- Reduce type-level clutter and prevent accidental reintroduction of small-net pathways while preserving compile-relevant bridges that still refer to a `Networks` aggregate.

### Description
- Removed the `NetworkSmall` aliases and small-feature architecture aliases and kept only `NetworkBig` in `src/nnue/network.h` so active code remains big-only via `NetworkBig`.
- Collapsed `NNUE::Networks` to a big-only aggregate (`struct Networks { explicit Networks(EvalFile bigFile); NetworkBig big; };`) to preserve compile-relevant call sites without restoring small-net behavior.
- Eliminated `EmbeddedNNUEType::SMALL`, removed small embedded incbin/static buffers, and made `get_embedded()` return the big embedded blob only in `src/nnue/network.cpp`.
- Dropped the explicit small-network template instantiation and removed the now-unnecessary `Networks` forward declaration from `src/evaluate.h`.

### Testing
- Ran static checks/assertions that `NetworkSmall`/small-specific aliases were removed and that big-only surfaces remain (`rg`-based searches); checks passed.
- Built the project with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"`; the build completed successfully with zero warnings/errors.
- Performed automated UCI smoke (`printf "uci\nisready\nquit\n" | ./src/Revolution-*`) and confirmed `id name Revolution-5.70-250526`, `uciok`, `readyok`, and presence of `option name EvalFile` while `EvalFileSmall` was absent.
- Ran automated runtime/eval/export/threaded smokes by scripting `setoption EvalFile` + `go depth 1`, `eval`, `export_net`, and `go depth 4`, and observed successful `bestmove`, no crashes, successful export file, and no small-net errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1392966a0083279b587e73f49e09c4)