### PR TITLE
REVOLUTION-P0AE: remove NNUE Networks wrapper fossil

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -248,7 +248,7 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
 }
 
 void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
-    onVerifyNetworks = std::move(f);
+    onVerifyNetwork = std::move(f);
 }
 
 void Engine::set_on_verify_network(std::function<void(std::string_view)>&& f) {
@@ -320,7 +320,7 @@ void Engine::set_ponderhit(bool b) { threads.main_manager()->ponder = b; }
 // network related
 
 void Engine::verify_networks() const {
-    networks->verify(options["EvalFile"], onVerifyNetworks);
+    networks->verify(options["EvalFile"], onVerifyNetwork);
 
     auto statuses = networks.get_status_and_errors();
     for (size_t i = 0; i < statuses.size(); ++i)
@@ -349,12 +349,12 @@ void Engine::verify_networks() const {
             message += " " + *error;
         }
 
-        onVerifyNetworks(message);
+        onVerifyNetwork(message);
     }
 }
 
 void Engine::verify_network() const {
-    const auto report = onVerifyNetworks ? onVerifyNetworks : [](std::string_view) {};
+    const auto report = onVerifyNetwork ? onVerifyNetwork : [](std::string_view) {};
 
     networks->verify(options["EvalFile"], report);
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -127,7 +127,7 @@ class Engine {
     BookManager                                       bookManager;
 
     Search::SearchManager::UpdateContext  updateContext;
-    std::function<void(std::string_view)> onVerifyNetworks;
+    std::function<void(std::string_view)> onVerifyNetwork;
     std::map<NumaIndex, SharedHistories>  sharedHists;
 };
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -122,14 +122,6 @@ using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsB
 using NetworkBig = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 
 
-struct Networks {
-    explicit Networks(EvalFile bigFile) :
-        big(bigFile, EmbeddedNNUEType::BIG) {}
-
-    NetworkBig big;
-};
-
-
 }  // namespace Stockfish
 
 template<typename ArchT, typename FeatureTransformerT>

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -96,7 +96,7 @@ void format_cp_aligned_dot(Value v, std::stringstream& stream, const Position& p
 // Returns a string with the value of each piece on a board,
 // and a table for (PSQT, Layers) values bucket by bucket.
 std::string
-trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::AccumulatorCaches& caches) {
+trace(Position& pos, const Eval::NNUE::NetworkBig& network, Eval::NNUE::AccumulatorCaches& caches) {
 
     std::stringstream ss;
 
@@ -124,7 +124,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
 
     // We estimate the value of each piece by doing a differential evaluation from
     // the current base eval, simulating the removal of the piece from its square.
-    auto [psqt, positional] = networks.big.evaluate(pos, *accumulators, caches.big);
+    auto [psqt, positional] = network.evaluate(pos, *accumulators, caches.big);
     Value base              = psqt + positional;
     base                    = pos.side_to_move() == WHITE ? base : -base;
 
@@ -140,7 +140,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
                 pos.remove_piece(sq);
 
                 accumulators->reset();
-                std::tie(psqt, positional) = networks.big.evaluate(pos, *accumulators, caches.big);
+                std::tie(psqt, positional) = network.evaluate(pos, *accumulators, caches.big);
                 Value eval                 = psqt + positional;
                 eval                       = pos.side_to_move() == WHITE ? eval : -eval;
                 v                          = base - eval;
@@ -157,7 +157,7 @@ trace(Position& pos, const Eval::NNUE::Networks& networks, Eval::NNUE::Accumulat
     ss << '\n';
 
     accumulators->reset();
-    auto t = networks.big.trace_evaluate(pos, *accumulators, caches.big);
+    auto t = network.trace_evaluate(pos, *accumulators, caches.big);
 
     ss << " NNUE network contributions "
        << (pos.side_to_move() == WHITE ? "(White to move)" : "(Black to move)") << std::endl

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -26,6 +26,7 @@
 #include "../misc.h"
 #include "../types.h"
 #include "nnue_architecture.h"
+#include "nnue_feature_transformer.h"
 
 namespace Stockfish {
 
@@ -52,10 +53,14 @@ struct NnueEvalTrace {
     std::size_t correctBucket;
 };
 
-struct Networks;
+template<typename Arch, typename Transformer>
+class Network;
+using BigFeatureTransformer  = FeatureTransformer<TransformedFeatureDimensionsBig>;
+using BigNetworkArchitecture = NetworkArchitecture<TransformedFeatureDimensionsBig, L2Big, L3Big>;
+using NetworkBig             = Network<BigNetworkArchitecture, BigFeatureTransformer>;
 struct AccumulatorCaches;
 
-std::string trace(Position& pos, const Networks& networks, AccumulatorCaches& caches);
+std::string trace(Position& pos, const NetworkBig& network, AccumulatorCaches& caches);
 
 }  // namespace Stockfish::Eval::NNUE
 }  // namespace Stockfish


### PR DESCRIPTION
### Motivation
- Remove the remaining big-only `NNUE::Networks` / `NN::Networks` wrapper fossil now that the codebase is strictly single-net (`NetworkBig`) and avoid any stale wrapper surface in compile-relevant headers. 
- Preserve single-big-net runtime and Engine/Search storage semantics while eliminating wrapper-induced indirections.
- Make a minimal, compile-safe surgical change that does not reintroduce small-net surfaces or change UCI/evaluation semantics.

### Description
- Deleted the `struct Networks { NetworkBig big; };` wrapper from `src/nnue/network.h` and left `NetworkBig` as the direct single-net type surface. 
- Reworked NNUE trace helper API to accept and use a `NetworkBig` directly by updating `src/nnue/nnue_misc.h` and `src/nnue/nnue_misc.cpp` so calls use `network.evaluate(...)` and `network.trace_evaluate(...)` instead of `networks.big.*`, and added the necessary forward/type aliases in the header. 
- Renamed the engine verify callback from `onVerifyNetworks` to `onVerifyNetwork` and updated all sites in `src/engine.h` and `src/engine.cpp` to remove a stale `Networks` token while preserving behavior. 
- No Makefile/build-system/ARCH changes, no reintroduction of small-net types or dual-net APIs, and no changes to evaluation/search semantics.

### Testing
- Ran repository inventory checks to confirm `NetworkSmall` / `EmbeddedNNUEType::SMALL` remain absent and `LazyNumaReplicatedSystemWide<Eval::NNUE::NetworkBig>` remains the active storage (checks passed). 
- Built the project with `make -C src -j2 ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed successfully with zero warnings/errors. 
- Executed automated UCI/runtime smoke sequences including `uci/isready`, setting `EvalFile`, `go depth 1`, `eval`, `export_net` (produced a non-empty big-export), and a threaded search (`Threads=4, go depth 4`); all ran without crash/assert and produced expected `readyok`/`bestmove` responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1394414824832792cb70290e29ccb8)