### PR TITLE
REVOLUTION-P0AF: collapse EvalFileDefaultName header surface

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -63,7 +63,7 @@ namespace {
 
 std::unique_ptr<NN::NetworkBig> make_default_big_network(const std::string& binaryDirectory) {
     auto network =
-      std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultNameBig, "None", ""},
+      std::make_unique<NN::NetworkBig>(NN::EvalFile{EvalFileDefaultName, "None", ""},
                                        NN::EmbeddedNNUEType::BIG);
 
     network->load(binaryDirectory, "");
@@ -183,7 +183,7 @@ Engine::Engine(std::optional<std::string> path) :
                 }));
 
     options.add(  //
-      "EvalFile", Option(EvalFileDefaultNameBig, [this](const Option& o) {
+      "EvalFile", Option(EvalFileDefaultName, [this](const Option& o) {
           load_big_network(o);
           return std::nullopt;
       }));

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,6 +35,8 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
+#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
+// Transitional build-script fossils (P0AF): retained for src/Makefile + scripts/net.sh only.
 #define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,8 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
+#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
+// Transitional build-script fossils (P0AF): keep until Makefile/net.sh cleanup phase.
 #define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
 #define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -44,7 +44,7 @@
 //     const unsigned int         gEmbeddedNNUESize;    // the size of the embedded file
 // Note that this does not work in Microsoft Visual Studio.
 #if !defined(_MSC_VER) && !defined(NNUE_EMBEDDING_OFF)
-INCBIN(EmbeddedNNUEBig, EvalFileDefaultNameBig);
+INCBIN(EmbeddedNNUEBig, EvalFileDefaultName);
 #else
 const unsigned char        gEmbeddedNNUEBigData[1] = {0x0};
 const unsigned char* const gEmbeddedNNUEBigEnd      = &gEmbeddedNNUEBigData[1];

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -36,7 +36,7 @@ namespace Eval::NNUE {
 
 // EvalFile uses fixed string types because it's part of the network structure which must be trivial.
 struct EvalFile {
-    // Default net name, will use one of the EvalFileDefaultName* macros defined
+    // Default net name, will use the EvalFileDefaultName macro defined
     // in evaluate.h
     FixedString<256> defaultName;
     // Selected net name, either via uci option or default


### PR DESCRIPTION
### Motivation
- Prepare source headers for strict single-net naming by introducing `EvalFileDefaultName` and removing active uses of `EvalFileDefaultNameBig`/`EvalFileDefaultNameSmall` from runtime code while leaving Makefile/scripts untouched. 
- Align embedded/incbin and Engine default construction to the single active NNUE filename `nn-83a0d6daf7e5.nnue` used at runtime and in the UCI `EvalFile` option. 

### Description
- Added `#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"` to `src/evaluate.h` and `src/nnue/evaluate.h`. 
- Replaced active source uses of `EvalFileDefaultNameBig` with `EvalFileDefaultName` in `src/engine.cpp` (default network construction and UCI `EvalFile` option) and `src/nnue/network.cpp` (incbin embedding). 
- Updated `src/nnue/nnue_misc.h` comment to reference the single `EvalFileDefaultName` macro. 
- Kept transitional `EvalFileDefaultNameBig` and `EvalFileDefaultNameSmall` defines in headers to preserve compatibility with the existing `src/Makefile` and `scripts/net.sh` fetch logic for this phase. 

### Testing
- Built the project with `make -C src clean` and `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed without warnings or errors. 
- UCI smoke: engine responded to `uci`/`isready` with identity `Revolution-5.70-250526`, `uciok`, `readyok`, exposes `option name EvalFile`, and shows `nn-83a0d6daf7e5.nnue` while `EvalFileSmall` and `nn-47fc8b7fff06.nnue` are absent. 
- Runtime smoke: `go depth 1` returned `bestmove` and did not crash. 
- Threaded smoke: `Threads=4, go depth 4` returned `bestmove` and did not crash. 
- Eval/export smoke: `eval` command executed without small-net complaints and `export_net` produced a single exported NNUE file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13965787308327b7266208f5d3389c)