### PR TITLE
REVOLUTION-P0AG: clean single-net build authority

### DIFF
--- a/scripts/net.sh
+++ b/scripts/net.sh
@@ -74,5 +74,4 @@ fetch_network() {
   return 1
 }
 
-fetch_network EvalFileDefaultNameBig &&
-  fetch_network EvalFileDefaultNameSmall
+fetch_network EvalFileDefaultName

--- a/src/Makefile
+++ b/src/Makefile
@@ -53,8 +53,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.70-250526
 
-NNUE_BIG = nn-83a0d6daf7e5.nnue
-NNUE_SMALL = nn-47fc8b7fff06.nnue
+NNUE_NET = nn-83a0d6daf7e5.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -1179,7 +1178,7 @@ profileclean:
 
 # evaluation network (nnue)
 net:
-	@NNUE_BIG=$(NNUE_BIG) NNUE_SMALL=$(NNUE_SMALL) $(SHELL) ../scripts/net.sh
+	@NNUE_NET=$(NNUE_NET) $(SHELL) ../scripts/net.sh
 
 format:
 	$(CLANG-FORMAT) -i $(SRCS) $(HEADERS) -style=file

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -36,9 +36,6 @@ namespace Eval {
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
 #define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
-// Transitional build-script fossils (P0AF): retained for src/Makefile + scripts/net.sh only.
-#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
-#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -5,8 +5,5 @@
 // Keep these in sync with ../evaluate.h.
 
 #define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
-// Transitional build-script fossils (P0AF): keep until Makefile/net.sh cleanup phase.
-#define EvalFileDefaultNameBig "nn-83a0d6daf7e5.nnue"
-#define EvalFileDefaultNameSmall "nn-47fc8b7fff06.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED

--- a/src/nnue/net.sh
+++ b/src/nnue/net.sh
@@ -87,5 +87,4 @@ fetch_network() {
   return 1
 }
 
-fetch_network EvalFileDefaultNameBig && \
-fetch_network EvalFileDefaultNameSmall
+fetch_network EvalFileDefaultName


### PR DESCRIPTION
### Motivation
- Remove remaining dual-net build and script authority so the tree consistently uses a single NNUE file (`nn-83a0d6daf7e5.nnue`).
- Align Makefile, net-fetch scripts, and header surfaces with the already-migrated single-net runtime surface to eliminate transitional fossils (`EvalFileDefaultNameBig`/`EvalFileDefaultNameSmall`).

### Description
- Replaced dual macros in `src/Makefile` by introducing `NNUE_NET = nn-83a0d6daf7e5.nnue` and updated the `net` target to export only `NNUE_NET` to the net script.
- Updated `scripts/net.sh` and `src/nnue/net.sh` to fetch only `EvalFileDefaultName` instead of `EvalFileDefaultNameBig`/`EvalFileDefaultNameSmall`.
- Removed the transitional `EvalFileDefaultNameBig` and `EvalFileDefaultNameSmall` macros from `src/evaluate.h` and `src/nnue/evaluate.h` while keeping `#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"`.
- Left runtime code and architecture targets intact and verified `INCBIN` and other uses still reference `EvalFileDefaultName` so no runtime dual-net paths were reintroduced.

### Testing
- Ran repository grep/verification checks to confirm removal of `NNUE_BIG`/`NNUE_SMALL` and the transitional macros and to ensure required ARCH target names remain present, all passing.
- Ran `make -C src net` and confirmed it downloads/validates only `nn-83a0d6daf7e5.nnue` with no references to `nn-47fc8b7fff06.nnue`.
- Built `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and verified the build completed with `STATUS=0` and a zero warnings/errors log gate.
- Performed UCI smoke (`uci`, `isready`, `quit`), runtime smoke (`go depth 1`), eval smoke (`eval`), single-file `export_net` smoke, and threaded smoke (`Threads=4`), all of which completed without errors and showed `EvalFile` set to `nn-83a0d6daf7e5.nnue` while `EvalFileSmall` and the old small NNUE filename remained absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1398d5a4a48327ab9d0b27a5706b0f)