### PR TITLE
REVOLUTION-P0AH: remove small-NNUE artifacts and finalize single-net fossil closure

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -233,10 +233,6 @@ template void AccumulatorStack::evaluate<TransformedFeatureDimensionsBig>(
   const Position&                                            pos,
   const FeatureTransformer<TransformedFeatureDimensionsBig>& featureTransformer,
   AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>& cache) noexcept;
-template void AccumulatorStack::evaluate<TransformedFeatureDimensionsSmall>(
-  const Position&                                              pos,
-  const FeatureTransformer<TransformedFeatureDimensionsSmall>& featureTransformer,
-  AccumulatorCaches::Cache<TransformedFeatureDimensionsSmall>& cache) noexcept;
 
 
 namespace {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -109,42 +109,31 @@ struct AccumulatorCaches {
 template<typename FeatureSet>
 struct AccumulatorState {
     Accumulator<TransformedFeatureDimensionsBig>   accumulatorBig;
-    Accumulator<TransformedFeatureDimensionsSmall> accumulatorSmall;
     typename FeatureSet::DiffType                  diff;
 
     template<IndexType Size>
     auto& acc() noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig
-                        || Size == TransformedFeatureDimensionsSmall,
-                      "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
 
         if constexpr (Size == TransformedFeatureDimensionsBig)
             return accumulatorBig;
-        else if constexpr (Size == TransformedFeatureDimensionsSmall)
-            return accumulatorSmall;
     }
 
     template<IndexType Size>
     const auto& acc() const noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig
-                        || Size == TransformedFeatureDimensionsSmall,
-                      "Invalid size for accumulator");
+        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
 
         if constexpr (Size == TransformedFeatureDimensionsBig)
             return accumulatorBig;
-        else if constexpr (Size == TransformedFeatureDimensionsSmall)
-            return accumulatorSmall;
     }
 
     void reset(const typename FeatureSet::DiffType& dp) noexcept {
         diff = dp;
         accumulatorBig.computed.fill(false);
-        accumulatorSmall.computed.fill(false);
     }
 
     typename FeatureSet::DiffType& reset() noexcept {
         accumulatorBig.computed.fill(false);
-        accumulatorSmall.computed.fill(false);
         return diff;
     }
 };

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -44,10 +44,6 @@ constexpr IndexType TransformedFeatureDimensionsBig = 1024;
 constexpr int       L2Big                           = 31;
 constexpr int       L3Big                           = 32;
 
-constexpr IndexType TransformedFeatureDimensionsSmall = 128;
-constexpr int       L2Small                           = 15;
-constexpr int       L3Small                           = 32;
-
 constexpr IndexType PSQTBuckets = 8;
 constexpr IndexType LayerStacks = 8;
 


### PR DESCRIPTION
### Motivation
- Finalize the single-net consolidation by removing remaining small-architecture NNUE fossils that still appeared in the local tree and ensure runtime/build authority remains single-file `NNUE_NET`/`EvalFileDefaultName` with `nn-83a0d6daf7e5.nnue`.
- Avoid broad renames of existing `Big`-suffixed types (keep them as historical single-net naming fossils) and only apply strictly local, compile-safe edits in this phase.

### Description
- Removed small-dimension constants from `src/nnue/nnue_architecture.h` by deleting `TransformedFeatureDimensionsSmall`, `L2Small`, and `L3Small` while leaving `Big`-names intact.
- Eliminated the small accumulator member and small-branching code paths from `AccumulatorState` in `src/nnue/nnue_accumulator.h`, and tightened `acc<>()` static assertions to only allow `TransformedFeatureDimensionsBig`.
- Removed the explicit `AccumulatorStack::evaluate<TransformedFeatureDimensionsSmall>` instantiation from `src/nnue/nnue_accumulator.cpp` to avoid residual small-dimension linkage.
- Changes are limited to the allowed NNUE sources (`src/nnue/*`) and do not touch Makefiles, UCI surface, search/eval algorithms, ARCH flags, or other forbidden files.

### Testing
- Final local grep inventory verified all strict dual-net fossils were absent and `NNUE_NET` / `EvalFileDefaultName` remain authoritative (passed).
- `make -C src net` completed and validated only `nn-83a0d6daf7e5.nnue` with no references to `nn-47fc8b7fff06` (passed).
- Build: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` completed with `STATUS=0` and the strict log gate found zero warnings/errors (passed).
- UCI smoke: engine identity `Revolution-5.70-250526`, `uciok`, `readyok`, `option name EvalFile` with `nn-83a0d6daf7e5.nnue` present and `EvalFileSmall` / `nn-47fc8b7fff06.nnue` absent (passed).
- Runtime, eval-trace, single-file `export_net`, and threaded smokes executed against the built binary and produced `readyok` / `bestmove` / export file without crashes or small-net complaints (all passed).
- ARCH target presence grep for required targets passed and `Worker::evaluate` remains single-big-net (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a139bb0b12083279a355cb553f93b25)