### PR TITLE
Apply Stockfish late‑May 2026 NNUE & IIR/NUMA updates

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,7 +53,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.70-250526
 
-NNUE_NET = nn-83a0d6daf7e5.nnue
+NNUE_NET = nn-71d6d32cb962.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
+#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,6 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultName "nn-83a0d6daf7e5.nnue"
+#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -30,7 +30,7 @@
 namespace Stockfish::Eval::NNUE::Layers {
 
 // Clipped ReLU
-template<IndexType InDims>
+template<IndexType InDims, int WeightScaleBitsLocal = WeightScaleBits>
 class ClippedReLU {
    public:
     // Input/output type
@@ -49,6 +49,8 @@ class ClippedReLU {
     static constexpr std::uint32_t get_hash_value(std::uint32_t prevHash) {
         std::uint32_t hashValue = 0x538D24C7u;
         hashValue += prevHash;
+        // TODO: consider including WeightScaleBitsLocal in the hash value.
+        // For now omitted on purpose because not written by trainer (yet)
         return hashValue;
     }
 
@@ -79,11 +81,11 @@ class ClippedReLU {
                 const __m256i words0 =
                   _mm256_srli_epi16(_mm256_packus_epi32(_mm256_load_si256(&in[i * 4 + 0]),
                                                         _mm256_load_si256(&in[i * 4 + 1])),
-                                    WeightScaleBits);
+                                    WeightScaleBitsLocal);
                 const __m256i words1 =
                   _mm256_srli_epi16(_mm256_packus_epi32(_mm256_load_si256(&in[i * 4 + 2]),
                                                         _mm256_load_si256(&in[i * 4 + 3])),
-                                    WeightScaleBits);
+                                    WeightScaleBitsLocal);
                 _mm256_store_si256(&out[i], _mm256_permutevar8x32_epi32(
                                               _mm256_packs_epi16(words0, words1), Offsets));
             }
@@ -97,10 +99,10 @@ class ClippedReLU {
             {
                 const __m128i words0 = _mm_srli_epi16(
                   _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
-                  WeightScaleBits);
+                  WeightScaleBitsLocal);
                 const __m128i words1 = _mm_srli_epi16(
                   _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
-                  WeightScaleBits);
+                  WeightScaleBitsLocal);
                 _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
             }
         }
@@ -122,18 +124,18 @@ class ClippedReLU {
     #if defined(USE_SSE41)
             const __m128i words0 = _mm_srli_epi16(
               _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
-              WeightScaleBits);
+              WeightScaleBitsLocal);
             const __m128i words1 = _mm_srli_epi16(
               _mm_packus_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
-              WeightScaleBits);
+              WeightScaleBitsLocal);
             _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
     #else
             const __m128i words0 = _mm_srai_epi16(
               _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 0]), _mm_load_si128(&in[i * 4 + 1])),
-              WeightScaleBits);
+              WeightScaleBitsLocal);
             const __m128i words1 = _mm_srai_epi16(
               _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3])),
-              WeightScaleBits);
+              WeightScaleBitsLocal);
             const __m128i packedbytes = _mm_packs_epi16(words0, words1);
             _mm_store_si128(&out[i], _mm_subs_epi8(_mm_adds_epi8(packedbytes, k0x80s), k0x80s));
     #endif
@@ -149,8 +151,8 @@ class ClippedReLU {
         {
             int16x8_t  shifted;
             const auto pack = reinterpret_cast<int16x4_t*>(&shifted);
-            pack[0]         = vqshrn_n_s32(in[i * 2 + 0], WeightScaleBits);
-            pack[1]         = vqshrn_n_s32(in[i * 2 + 1], WeightScaleBits);
+            pack[0]         = vqshrn_n_s32(in[i * 2 + 0], WeightScaleBitsLocal);
+            pack[1]         = vqshrn_n_s32(in[i * 2 + 1], WeightScaleBitsLocal);
             out[i]          = vmax_s8(vqmovn_s16(shifted), Zero);
         }
         constexpr IndexType Start = NumChunks * (SimdWidth / 2);
@@ -160,7 +162,7 @@ class ClippedReLU {
 
         for (IndexType i = Start; i < InputDimensions; ++i)
         {
-            output[i] = static_cast<OutputType>(std::clamp(input[i] >> WeightScaleBits, 0, 127));
+            output[i] = static_cast<OutputType>(std::clamp(input[i] >> WeightScaleBitsLocal, 0, 127));
         }
     }
 };

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -30,7 +30,7 @@
 namespace Stockfish::Eval::NNUE::Layers {
 
 // Clipped ReLU
-template<IndexType InDims>
+template<IndexType InDims, int WeightScaleBitsLocal = WeightScaleBits>
 class SqrClippedReLU {
    public:
     // Input/output type
@@ -49,6 +49,8 @@ class SqrClippedReLU {
     static constexpr std::uint32_t get_hash_value(std::uint32_t prevHash) {
         std::uint32_t hashValue = 0x538D24C7u;
         hashValue += prevHash;
+        // TODO: consider including WeightScaleBitsLocal in the hash value.
+        // For now omitted on purpose because not written by trainer (yet)
         return hashValue;
     }
 
@@ -66,11 +68,15 @@ class SqrClippedReLU {
 
     // Forward propagation
     void propagate(const InputType* input, OutputType* output) const {
+        static_assert(WeightScaleBitsLocal >= 5 && WeightScaleBitsLocal <= 8,
+                      "SqrClippedReLU only support WeightScaleBitsLocal between 5 and 8");
+        // After squaring we need to shift by WeightScaleBitsLocal * 2 + 7.
+        // MulHi strips the lower 16 bits (i.e. shift by 16), so shift out the remaining bits.
+        [[maybe_unused]] constexpr int SimdShiftAmount = WeightScaleBitsLocal * 2 + 7 - 16;
 
 #if defined(USE_SSE2)
         constexpr IndexType NumChunks = InputDimensions / 16;
 
-        static_assert(WeightScaleBits == 6);
         const auto in  = reinterpret_cast<const __m128i*>(input);
         const auto out = reinterpret_cast<__m128i*>(output);
         for (IndexType i = 0; i < NumChunks; ++i)
@@ -80,11 +86,8 @@ class SqrClippedReLU {
             __m128i words1 =
               _mm_packs_epi32(_mm_load_si128(&in[i * 4 + 2]), _mm_load_si128(&in[i * 4 + 3]));
 
-            // We shift by WeightScaleBits * 2 = 12 and divide by 128
-            // which is an additional shift-right of 7, meaning 19 in total.
-            // MulHi strips the lower 16 bits so we need to shift out 3 more to match.
-            words0 = _mm_srli_epi16(_mm_mulhi_epi16(words0, words0), 3);
-            words1 = _mm_srli_epi16(_mm_mulhi_epi16(words1, words1), 3);
+            words0 = _mm_srli_epi16(_mm_mulhi_epi16(words0, words0), SimdShiftAmount);
+            words1 = _mm_srli_epi16(_mm_mulhi_epi16(words1, words1), SimdShiftAmount);
 
             _mm_store_si128(&out[i], _mm_packs_epi16(words0, words1));
         }
@@ -99,7 +102,7 @@ class SqrClippedReLU {
             output[i] = static_cast<OutputType>(
               // Really should be /127 but we need to make it fast so we right-shift
               // by an extra 7 bits instead. Needs to be accounted for in the trainer.
-              std::min(127ll, ((long long) (input[i]) * input[i]) >> (2 * WeightScaleBits + 7)));
+              std::min(127ll, ((long long) (input[i]) * input[i]) >> (2 * WeightScaleBitsLocal + 7)));
         }
     }
 };

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -60,10 +60,10 @@ struct NetworkArchitecture {
     static constexpr int       FC_1_OUTPUTS                 = L3;
 
     Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS + 1> fc_0;
-    Layers::SqrClippedReLU<FC_0_OUTPUTS + 1>                                           ac_sqr_0;
-    Layers::ClippedReLU<FC_0_OUTPUTS + 1>                                              ac_0;
+    Layers::SqrClippedReLU<FC_0_OUTPUTS + 1, WeightScaleBits + 1>                      ac_sqr_0;
+    Layers::ClippedReLU<FC_0_OUTPUTS + 1, WeightScaleBits + 1>                         ac_0;
     Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS>                            fc_1;
-    Layers::ClippedReLU<FC_1_OUTPUTS>                                                  ac_1;
+    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                                 ac_1;
     Layers::AffineTransform<FC_1_OUTPUTS, 1>                                           fc_2;
 
     // Hash value embedded in the evaluation file
@@ -73,6 +73,8 @@ struct NetworkArchitecture {
         hashValue ^= TransformedFeatureDimensions * 2;
 
         hashValue = decltype(fc_0)::get_hash_value(hashValue);
+        // TODO: consider including hash value of ac_sqr_0 in the overall hash value.
+        // For now omitted on purpose because hash value is not written by trainer yet.
         hashValue = decltype(ac_0)::get_hash_value(hashValue);
         hashValue = decltype(fc_1)::get_hash_value(hashValue);
         hashValue = decltype(ac_1)::get_hash_value(hashValue);
@@ -126,11 +128,21 @@ struct NetworkArchitecture {
         ac_1.propagate(buffer.fc_1_out, buffer.ac_1_out);
         fc_2.propagate(buffer.ac_1_out, buffer.fc_2_out);
 
-        // buffer.fc_0_out[FC_0_OUTPUTS] is such that 1.0 is equal to 127*(1<<WeightScaleBits) in
-        // quantized form, but we want 1.0 to be equal to 600*OutputScale
-        std::int32_t fwdOut =
-          (buffer.fc_0_out[FC_0_OUTPUTS]) * (600 * OutputScale) / (127 * (1 << WeightScaleBits));
-        std::int32_t outputValue = buffer.fc_2_out[0] + fwdOut;
+        // max value for fwdOut is (L1 + L3) * HiddenMaxVal * WeightMaxVal
+        // for int8 activations and weights this is (L1 + L3) * 16129 making
+        // fwdOut safe from overflow until (L1 + L3) > 133,144
+        // first layer and last layer use WeightScaleBits + 1
+        std::int32_t fwdOut = buffer.fc_2_out[0] + buffer.fc_0_out[FC_0_OUTPUTS];
+
+        // fwdOut is such that 1.0 is equal to HiddenOneVal*(1<<WeightScaleBits)*2 in
+        // quantized form, but we want 1.0 to be equal to 600*OutputScale.
+        // To make overflow impossible, cast to int64_t.
+        constexpr std::int64_t multiplier  = 600 * OutputScale;
+        constexpr std::int64_t denominator = static_cast<std::int64_t>(HiddenOneVal)
+                                           * static_cast<std::int64_t>(1U << WeightScaleBits) * 2;
+
+        std::int32_t outputValue =
+          static_cast<std::int32_t>((static_cast<std::int64_t>(fwdOut) * multiplier) / denominator);
 
         return outputValue;
     }

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -55,11 +55,15 @@ using PSQTWeightType   = std::int32_t;
 using IndexType        = std::uint32_t;
 
 // Version of the evaluation file
-constexpr std::uint32_t Version = 0x7AF32F20u;
+constexpr std::uint32_t Version = 0x6A448AFAu;
 
 // Constant used in evaluation value calculation
 constexpr int OutputScale     = 16;
 constexpr int WeightScaleBits = 6;
+constexpr int FtOneVal        = 256;
+constexpr int FtMaxVal        = 255;
+constexpr int HiddenOneVal    = 128;
+constexpr int HiddenMaxVal    = 127;
 
 // Size of cache line (in bytes)
 constexpr std::size_t CacheLineSize = 64;

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -163,9 +163,10 @@ class FeatureTransformer {
         {
             read_little_endian<ThreatWeightType>(stream, threatWeights.data(),
                                                  ThreatInputDimensions * HalfDimensions);
-            read_leb_128(stream, weights);
+            read_leb_128(stream, threatPsqtWeights);
 
-            read_leb_128(stream, threatPsqtWeights, psqtWeights);
+            read_leb_128(stream, weights);
+            read_leb_128(stream, psqtWeights);
         }
         else
         {
@@ -190,20 +191,10 @@ class FeatureTransformer {
         {
             write_little_endian<ThreatWeightType>(stream, copy->threatWeights.data(),
                                                   ThreatInputDimensions * HalfDimensions);
+            write_leb_128<PSQTWeightType>(stream, copy->threatPsqtWeights);
+
             write_leb_128<WeightType>(stream, copy->weights);
-
-            auto combinedPsqtWeights =
-              std::make_unique<std::array<PSQTWeightType, TotalInputDimensions * PSQTBuckets>>();
-
-            std::copy(std::begin(copy->threatPsqtWeights),
-                      std::begin(copy->threatPsqtWeights) + ThreatInputDimensions * PSQTBuckets,
-                      combinedPsqtWeights->begin());
-
-            std::copy(std::begin(copy->psqtWeights),
-                      std::begin(copy->psqtWeights) + InputDimensions * PSQTBuckets,
-                      combinedPsqtWeights->begin() + ThreatInputDimensions * PSQTBuckets);
-
-            write_leb_128<PSQTWeightType>(stream, *combinedPsqtWeights);
+            write_leb_128<PSQTWeightType>(stream, copy->psqtWeights);
         }
         else
         {
@@ -274,8 +265,11 @@ class FeatureTransformer {
             static_assert((HalfDimensions / 2) % OutputChunkSize == 0);
             constexpr IndexType NumOutputChunks = HalfDimensions / 2 / OutputChunkSize;
 
-            const vec_t Zero = vec_zero();
-            const vec_t One  = vec_set_16(255);
+#if !defined(USE_NEON)
+            const vec_t   Zero  = vec_zero();
+            const vec_t   FtMax = vec_set_16(FtMaxVal);
+            constexpr int shift = 7;
+#endif
 
             const vec_t* in0 = reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][0]));
             const vec_t* in1 =
@@ -329,18 +323,6 @@ class FeatureTransformer {
             // 8 bits. Shifting it by 7 bits left will no longer occupy the
             // signed bit, so we are safe.
 
-            // Note that on NEON processors, we shift left by 6 instead
-            // because the instruction "vqdmulhq_s16" also doubles the
-            // return value after the multiplication, adding an extra shift
-            // to the left by 1, so we compensate by shifting less before
-            // the multiplication.
-
-            constexpr int shift =
-    #if defined(USE_SSE2)
-              7;
-    #else
-              6;
-    #endif
             if constexpr (UseThreats)
             {
                 const vec_t* tin0 =
@@ -354,34 +336,62 @@ class FeatureTransformer {
                     const vec_t acc1a = vec_add_16(in1[j * 2 + 0], tin1[j * 2 + 0]);
                     const vec_t acc1b = vec_add_16(in1[j * 2 + 1], tin1[j * 2 + 1]);
 
+#if defined(USE_NEON)
+                    // The NEON path relies on unsigned saturation for crelu.
+                    static_assert(FtMaxVal == 255);
+
+                    const uint16x8_t mul0 = vmull_u8(vqmovun_s16(acc0a), vqmovun_s16(acc1a));
+                    const uint16x8_t mul1 = vmull_u8(vqmovun_s16(acc0b), vqmovun_s16(acc1b));
+
+                    const uint8x16x2_t uzp =
+                      vuzpq_u8(vreinterpretq_u8_u16(mul0), vreinterpretq_u8_u16(mul1));
+                    const uint8x16_t pab = vshrq_n_u8(uzp.val[1], 1);
+                    out[j] = reinterpret_cast<vec_t>(pab);
+#else
                     const vec_t sum0a =
-                      vec_slli_16(vec_max_16(vec_min_16(acc0a, One), Zero), shift);
+                      vec_slli_16(vec_max_16(vec_min_16(acc0a, FtMax), Zero), shift);
                     const vec_t sum0b =
-                      vec_slli_16(vec_max_16(vec_min_16(acc0b, One), Zero), shift);
-                    const vec_t sum1a = vec_min_16(acc1a, One);
-                    const vec_t sum1b = vec_min_16(acc1b, One);
+                      vec_slli_16(vec_max_16(vec_min_16(acc0b, FtMax), Zero), shift);
+                    const vec_t sum1a = vec_min_16(acc1a, FtMax);
+                    const vec_t sum1b = vec_min_16(acc1b, FtMax);
 
                     const vec_t pa = vec_mulhi_16(sum0a, sum1a);
                     const vec_t pb = vec_mulhi_16(sum0b, sum1b);
 
                     out[j] = vec_packus_16(pa, pb);
+#endif
                 }
             }
             else
             {
                 for (IndexType j = 0; j < NumOutputChunks; ++j)
                 {
+#if defined(USE_NEON)
+                    // The NEON path relies on unsigned saturation for crelu.
+                    static_assert(FtMaxVal == 255);
+
+                    const uint16x8_t mul0 =
+                      vmull_u8(vqmovun_s16(in0[j * 2 + 0]), vqmovun_s16(in1[j * 2 + 0]));
+                    const uint16x8_t mul1 =
+                      vmull_u8(vqmovun_s16(in0[j * 2 + 1]), vqmovun_s16(in1[j * 2 + 1]));
+
+                    const uint8x16x2_t uzp =
+                      vuzpq_u8(vreinterpretq_u8_u16(mul0), vreinterpretq_u8_u16(mul1));
+                    const uint8x16_t pab = vshrq_n_u8(uzp.val[1], 1);
+                    out[j] = reinterpret_cast<vec_t>(pab);
+#else
                     const vec_t sum0a =
-                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 0], One), Zero), shift);
+                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 0], FtMax), Zero), shift);
                     const vec_t sum0b =
-                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 1], One), Zero), shift);
-                    const vec_t sum1a = vec_min_16(in1[j * 2 + 0], One);
-                    const vec_t sum1b = vec_min_16(in1[j * 2 + 1], One);
+                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 1], FtMax), Zero), shift);
+                    const vec_t sum1a = vec_min_16(in1[j * 2 + 0], FtMax);
+                    const vec_t sum1b = vec_min_16(in1[j * 2 + 1], FtMax);
 
                     const vec_t pa = vec_mulhi_16(sum0a, sum1a);
                     const vec_t pb = vec_mulhi_16(sum0b, sum1b);
 
                     out[j] = vec_packus_16(pa, pb);
+#endif
                 }
             }
 
@@ -400,8 +410,8 @@ class FeatureTransformer {
                       threatAccumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
                 }
 
-                sum0 = std::clamp<BiasType>(sum0, 0, 255);
-                sum1 = std::clamp<BiasType>(sum1, 0, 255);
+                sum0 = std::clamp<BiasType>(sum0, 0, FtMaxVal);
+                sum1 = std::clamp<BiasType>(sum1, 0, FtMaxVal);
 
                 output[offset + j] = static_cast<OutputType>(unsigned(sum0 * sum1) / 512);
             }

--- a/src/numa.h
+++ b/src/numa.h
@@ -1166,23 +1166,18 @@ class NumaConfig {
 #if defined(__linux__) && !defined(__ANDROID__)
 
         std::set<CpuIndex> seenCpus;
-        auto               nextUnseenCpu = [&seenCpus]() {
-            for (CpuIndex i = 0;; ++i)
-                if (!seenCpus.count(i))
-                    return i;
-        };
 
-        while (true)
+        for (const auto& [next, _] : systemConfig.nodeByCpu)
         {
-            CpuIndex next = nextUnseenCpu();
-            auto     siblingsStr =
+            if (seenCpus.count(next))
+                continue;
+
+            auto siblingsStr =
               read_file_to_string("/sys/devices/system/cpu/cpu" + std::to_string(next)
                                   + "/cache/index3/shared_cpu_list");
 
             if (!siblingsStr.has_value() || siblingsStr->empty())
-            {
-                break;  // we have read all available CPUs
-            }
+                continue;
 
             L3Domain domain;
             for (size_t c : indices_from_shortened_string(*siblingsStr))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -977,7 +977,7 @@ Value Search::Worker::search(
     // Step 10. Internal iterative reductions
     // At sufficient depth, reduce depth for PV/Cut nodes without a TTMove.
     // (*Scaler) Making IIR more aggressive scales poorly.
-    if (!allNode && depth >= 6 && !ttData.move && priorReduction <= 3)
+    if (!allNode && depth >= 6 && !ttData.move)
         depth--;
 
     // Step 11. ProbCut


### PR DESCRIPTION
### Motivation
- Bring a small, targeted set of Stockfish changes (2026-05-27..2026-05-29) into Revolution to update NNUE format/authority, fix fragile L3 discovery on Linux, speed NEON feature transform where applicable, and simplify an IIR condition while preserving Revolution-specific behavior and protected subsystems.
- Apply only source changes that map directly to Revolution and avoid importing upstream CI/universal or NNZ/attacks/unrelated subsystems.

### Description
- Replace fragile CPU discovery loop in `src/numa.h` with iteration over `systemConfig.nodeByCpu`, skipping already seen CPUs and continuing when a `shared_cpu_list` is missing/empty (preserves public NUMA/L3 interface).
- Update NNUE filename authority from `nn-83a0d6daf7e5.nnue` to `nn-71d6d32cb962.nnue` in `src/evaluate.h`, `src/nnue/evaluate.h` and `src/Makefile` only.
- Adapt NNUE internals: bump `Version` and add `FtOneVal`, `FtMaxVal`, `HiddenOneVal`, `HiddenMaxVal` in `src/nnue/nnue_common.h`; change first/last activation scaling and final output scaling in `src/nnue/nnue_architecture.h` to use safe int64-based formula; add template-local `WeightScaleBitsLocal` to `ClippedReLU` and `SqrClippedReLU` and compute SIMD shifts from the local bits in `src/nnue/layers/*` while preserving existing SIMD branches.
- Update `src/nnue/nnue_feature_transformer.h` to the new read/write ordering for threat weights/psqt weights, replace 255-clamp literals with `FtMaxVal`, and add an isolated NEON fast path (behind `USE_NEON`) integrated into Revolution’s existing transform loop; do not import upstream NNZ helpers or cursor changes.
- Simplify IIR condition in `src/search.cpp` by removing only the `&& priorReduction <= 3` term, leaving all other search heuristics intact.
- Audit macOS universal / CI work (upstream commit `8cbca11`) and mark it not applicable; no `src/universal/*` or workflow files were imported.

### Testing
- Grep/diff gates: verified changed files are limited to the authorized set and that protected areas (`src/experience.*`, `src/book/`, `src/mcts/`, `src/sparsehash/`, `src/universal/`, `attacks.*`, `nnz_helper.h`) were unchanged; checks for leftover patterns (`priorReduction <= 3`, `nextUnseenCpu`, old NNUE version `0x7AF32F20u`, old NNUE filename) returned no matches.
- `make net` (in `src`) downloaded/validated `nn-71d6d32cb962.nnue` successfully (GitHub fallback used) and returned success.
- `make -j$(nproc) build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` completed successfully and produced the engine binary with no build errors reported in the captured build log.
- UCI smoke: starting the built engine returned `uciok` and `readyok`, `EvalFile` default now reports `nn-71d6d32cb962.nnue`, and `go depth 1` produced a legal `bestmove`.
- `bench` run completed and reported nodes and nodes/sec (example: Total time: 11056 ms, Nodes searched: 3,485,290, NPS: 315,239).
- NEON/ARM cross-compile was not run because an appropriate NEON toolchain was not available: `NEON compile not run: toolchain unavailable`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff2a98d38832786a67b44acd510b2)