### PR TITLE
Rebrand Revolution to 5.80-030625

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.70-250526
+RELEASE_TAG ?= 5.80-030625
 
 NNUE_NET = nn-71d6d32cb962.nnue
 
@@ -914,7 +914,7 @@ ifneq ($(ARCH), )
 	CXXFLAGS += -DARCH=$(ARCH)
 endif
 
-CXXFLAGS += -DENGINE_NAME='"$(ENGINE_BASENAME)"' -DENGINE_VERSION='"$(RELEASE_TAG)"'
+CXXFLAGS += -DENGINE_NAME='"$(ENGINE_BASENAME)"' -DENGINE_VERSION='"$(RELEASE_TAG)"' -DENGINE_ARCH_TAG='"$(ARCH_TAG)"'
 
 ### 3.9 Link Time Optimization
 ### This is a mix of compile and link time options because the lto link phase

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -49,7 +49,7 @@ constexpr std::string_view engineName = "Revolution";
 #ifdef ENGINE_VERSION
 constexpr std::string_view version = ENGINE_VERSION;
 #else
-constexpr std::string_view version = "5.70-250526";
+constexpr std::string_view version = "5.80-030625";
 #endif
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
@@ -170,8 +170,18 @@ std::string engine_version_info() {
 #endif
 }
 
+std::string engine_architecture_info() {
+#ifdef ENGINE_ARCH_TAG
+    constexpr std::string_view archTag = ENGINE_ARCH_TAG;
+    if constexpr (!archTag.empty())
+        return engine_version_info() + "-" + std::string(archTag);
+#endif
+
+    return engine_version_info();
+}
+
 std::string engine_info(bool to_uci) {
-    const std::string name = engine_version_info();
+    const std::string name = to_uci ? engine_version_info() : engine_architecture_info();
 
     return name + (to_uci ? "\nid author " : " by ")
          + "Jorge Ruiz and the Stockfish developers (see AUTHORS file)";

--- a/src/misc.h
+++ b/src/misc.h
@@ -47,6 +47,7 @@
 namespace Stockfish {
 
 std::string engine_version_info();
+std::string engine_architecture_info();
 std::string engine_info(bool to_uci = false);
 std::string compiler_info();
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -456,7 +456,7 @@ void UCIEngine::benchmark(std::istream& args) {
 
     std::cerr << "==========================="
               << "\nVersion                    : "
-              << engine_version_info()
+              << engine_architecture_info()
               // "\nCompiled by                : "
               << compiler_info()
               << "Large pages                : " << (has_large_pages() ? "yes" : "no")


### PR DESCRIPTION
### Motivation
- Perform a strict release-only identity update so the engine and distributed binaries reflect the new release `Revolution-5.80-030625` while preserving existing NNUE and architecture-suffix behavior.
- Keep UCI base identity unchanged (no arch suffix) and expose the compiled-architecture-aware identity only where GUI/bench/analysis surfaces require it.

### Description
- Updated `RELEASE_TAG` in `src/Makefile` to `5.80-030625` and passed the mapped `ARCH_TAG` to the compiler as `ENGINE_ARCH_TAG` so compiled binaries keep the existing `sse41popcnt` style suffixes.
- Replaced the fallback `version` string in `src/misc.cpp` with `5.80-030625` and added `engine_architecture_info()` which appends the compile-time `ENGINE_ARCH_TAG` only for arch-aware surfaces while leaving `engine_version_info()` unchanged for UCI base identity.
- Declared `engine_architecture_info()` in `src/misc.h` and switched benchmark/banner output in `src/uci.cpp` to use the arch-aware identity, while `id name` / UCI output still uses the base identity.
- No changes were made to NNUE filenames/logic or any protected subsystems (search, NNUE internals, experience, Zobrist, book, MCTS, sparsehash, numa, etc.).

### Testing
- Built the SSE41/POPCNT target with `cd src && make clean && make -j$(nproc) build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` and the build completed successfully producing `Revolution-5.80-030625-sse41popcnt` with no compile/link errors.
- Performed a UCI smoke (`uci`, `isready`, `go depth 1`, `quit`) and observed `uciok`, `readyok`, `id name Revolution-5.80-030625`, NNUE default `nn-71d6d32cb962.nnue`, and a legal `bestmove` from `go depth 1`.
- Ran the built bench and recorded a successful run with Total time ~9877 ms, Nodes searched 3,485,290 and Nodes/second ~352,869, and the engine banner/info lines included `Revolution-5.80-030625-sse41popcnt` where appropriate.
- Verified grep/diff gates: no remaining `5.70|250526` hits, `5.80|030625|Revolution-5.80-030625` present, `nn-71d6d32cb962.nnue` preserved, and protected-area diffs are empty.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff700ee548327892c6d2b4a9ef47e)