### PR TITLE
REVOLUTION-P0-SFDEV20260609: apply wasm, mate PV and relaxed atomic block

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Adrian Petrescu (apetresc)
 Adrian (AdrianGHUB15)
 Ahmed Kerimov (wcdbmv)
 Ajith Chandy Jose (ajithcj)
+AK-Khan02
 Alain Savard (Rocky640)
 Alayan Feh (Alayan-stk-2)
 Alexander Kure

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,6 +47,8 @@ endif
 ### Executable name
 ifeq ($(target_windows),yes)
 	EXESUF = .exe
+else ifneq (,$(findstring wasm,$(ARCH)))
+	EXESUF = .js
 else
 	EXESUF =
 endif
@@ -128,7 +130,9 @@ VPATH = syzygy:nnue:nnue/features
 # neon = yes/no       --- -DUSE_NEON         --- Use ARM SIMD architecture
 # dotprod = yes/no    --- -DUSE_NEON_DOTPROD --- Use ARM advanced SIMD Int8 dot product instructions
 # lsx = yes/no        --- -mlsx              --- Use Loongson SIMD eXtension
-# lasx = yes/no       --- -mlasx             --- use Loongson Advanced SIMD eXtension
+# lasx = yes/no       --- -mlasx             --- Use Loongson Advanced SIMD eXtension
+# relaxedsimd = y/n   --- -mrelaxed-simd     --- Use WebAssembly relaxed SIMD extension
+# syzygy = yes/no     --- -DNO_TABLEBASES    --- Support Syzygy tablebase probing
 #
 # Note that Makefile is space sensitive, so when adding new architectures
 # or modifying existing flags, you have to make sure there are no extra spaces
@@ -189,7 +193,7 @@ ifeq ($(ARCH), $(filter $(ARCH), \
                  x86-64-fma3 x86-64-bmi2 x86-64-avx2 x86-64-sse41-popcnt x86-64-modern x86-64-ssse3 x86-64-sse3-popcnt \
                  x86-64 x86-32-sse41-popcnt x86-32-sse2 x86-32 ppc-64 ppc-64-altivec ppc-64-vsx ppc-32 e2k \
                  armv7 armv7-neon armv8 armv8-dotprod apple-silicon general-64 general-32 riscv64 \
-                 loongarch64 loongarch64-lsx loongarch64-lasx))
+                 loongarch64 loongarch64-lsx loongarch64-lasx wasm32 wasm32-relaxed-simd))
    SUPPORTED_ARCH=true
 else
    SUPPORTED_ARCH=false
@@ -221,6 +225,8 @@ dotprod = no
 arm_version = 0
 lsx = no
 lasx = no
+relaxedsimd = no
+syzygy = yes
 STRIP = strip
 
 ifneq ($(shell which clang-format-20 2> /dev/null),)
@@ -438,6 +444,27 @@ ifeq ($(ARCH),apple-silicon)
 	arm_version = 8
 endif
 
+# WASM is largely compiled using emcc's x86 compatibility layer, with occasional
+# WASM-specific intrinsics.
+ifeq ($(ARCH),wasm32)
+	arch = wasm32
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	syzygy = no
+endif
+
+ifeq ($(ARCH),wasm32-relaxed-simd)
+	arch = wasm32
+	sse = yes
+	sse2 = yes
+	ssse3 = yes
+	sse41 = yes
+	relaxedsimd = yes
+	syzygy = no
+endif
+
 ifeq ($(ARCH),ppc-32)
 	arch = ppc
 	bits = 32
@@ -529,7 +556,7 @@ ifeq ($(COMP),gcc)
 		endif
 	else ifeq ($(arch),loongarch64)
 		CXXFLAGS += -latomic
-	else
+	else ifneq ($(arch),wasm32)
 		CXXFLAGS += -m$(bits)
 		LDFLAGS += -m$(bits)
 	endif
@@ -539,7 +566,9 @@ ifeq ($(COMP),gcc)
 	endif
 
 	ifneq ($(KERNEL),Darwin)
+	ifneq ($(arch),wasm32)
 	   LDFLAGS += -Wl,--no-as-needed
+	endif
 	endif
 endif
 
@@ -690,6 +719,7 @@ ifneq ($(comp),mingw)
 		# Haiku has pthreads in its libroot, so only link it in on other platforms
 		ifneq ($(KERNEL),Haiku)
 			ifneq ($(COMP),ndk)
+			ifneq ($(arch),wasm32)
 				LDFLAGS += -lpthread
 
 				add_lrt = yes
@@ -704,6 +734,7 @@ ifneq ($(comp),mingw)
 				ifeq ($(add_lrt),yes)
 					LDFLAGS += -lrt
 				endif
+			endif
 			endif
 		endif
 	endif
@@ -889,12 +920,25 @@ ifeq ($(lsx),yes)
 	endif
 endif
 
+ifeq ($(arch),wasm32)
+	CXXFLAGS += -pthread -msimd128 -DUSE_POPCNT -DNNUE_EMBEDDING_OFF -DUSE_SLOPPY_ATOMICS
+	LDFLAGS += -pthread -sINITIAL_MEMORY=64MB -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=3MB
+	ifeq ($(relaxedsimd),yes)
+		CXXFLAGS += -mrelaxed-simd
+	endif
+endif
+
 ### 3.7 pext
 ifeq ($(pext),yes)
 	CXXFLAGS += -DUSE_PEXT
 	ifeq ($(comp),$(filter $(comp),gcc clang mingw icx))
 		CXXFLAGS += -mbmi2
 	endif
+endif
+
+### Syzygy tablebases
+ifeq ($(syzygy),no)
+	CXXFLAGS += -DNO_TABLEBASES
 endif
 
 ### 3.8.1 Try to include git commit sha for versioning
@@ -1021,6 +1065,8 @@ help:
 	echo "loongarch64             > LoongArch 64-bit" && \
 	echo "loongarch64-lsx         > LoongArch 64-bit with SIMD eXtension" && \
 	echo "loongarch64-lasx        > LoongArch 64-bit with Advanced SIMD eXtension" && \
+	echo "wasm32                  > WebAssembly 32-bit with SIMD" && \
+	echo "wasm32-relaxed-simd     > WebAssembly 32-bit with relaxed SIMD" && \
 	echo "" && \
 	echo "Supported compilers:" && \
 	echo "" && \
@@ -1221,6 +1267,7 @@ config-sanity: net
 	echo "arm_version: '$(arm_version)'" && \
 	echo "lsx: '$(lsx)'" && \
 	echo "lasx: '$(lasx)'" && \
+	echo "syzygy: '$(syzygy)'" && \
 	echo "target_windows: '$(target_windows)'" && \
 	echo "" && \
 	echo "Flags:" && \
@@ -1237,7 +1284,8 @@ config-sanity: net
 	(test "$(arch)" = "any" || test "$(arch)" = "x86_64" || test "$(arch)" = "i386" || \
 	 test "$(arch)" = "ppc64" || test "$(arch)" = "ppc" || test "$(arch)" = "e2k" || \
 	 test "$(arch)" = "armv7" || test "$(arch)" = "armv8" || test "$(arch)" = "arm64" || \
-	 test "$(arch)" = "riscv64" || test "$(arch)" = "loongarch64") && \
+	 test "$(arch)" = "riscv64" || test "$(arch)" = "loongarch64" || \
+	 test "$(arch)" = "wasm32") && \
 	(test "$(bits)" = "32" || test "$(bits)" = "64") && \
 	(test "$(prefetch)" = "yes" || test "$(prefetch)" = "no") && \
 	(test "$(popcnt)" = "yes" || test "$(popcnt)" = "no") && \
@@ -1256,6 +1304,7 @@ config-sanity: net
 	(test "$(neon)" = "yes" || test "$(neon)" = "no") && \
 	(test "$(lsx)" = "yes" || test "$(lsx)" = "no") && \
 	(test "$(lasx)" = "yes" || test "$(lasx)" = "no") && \
+	(test "$(syzygy)" = "yes" || test "$(syzygy)" = "no") && \
 	(test "$(comp)" = "gcc" || test "$(comp)" = "icx" || test "$(comp)" = "mingw" || \
 	 test "$(comp)" = "clang" || test "$(comp)" = "armv7a-linux-androideabi16-clang" || \
 	 test "$(comp)" = "aarch64-linux-android21-clang")

--- a/src/history.h
+++ b/src/history.h
@@ -52,27 +52,17 @@ static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
 // the entry. The first template parameter T is the base type of the array,
 // and the second template parameter D limits the range of updates in [-D, D]
 // when we update values with the << operator
-template<typename T, int D, bool Atomic = false>
+template<typename T, int D, bool Shared = false>
 struct StatsEntry {
     static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
 
    private:
-    std::conditional_t<Atomic, std::atomic<T>, T> entry;
+    std::conditional_t<Shared, RelaxedAtomic<T>, T> entry;
 
    public:
-    void operator=(const T& v) {
-        if constexpr (Atomic)
-            entry.store(v, std::memory_order_relaxed);
-        else
-            entry = v;
-    }
+    void operator=(const T& v) { entry = v; }
 
-    operator T() const {
-        if constexpr (Atomic)
-            return entry.load(std::memory_order_relaxed);
-        else
-            return entry;
-    }
+    operator T() const { return entry; }
 
     void operator<<(int bonus) {
         // Make sure that bonus is in range [-D, D]

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstddef>
@@ -334,6 +335,89 @@ class MultiArray {
     constexpr void swap(MultiArray<T, Size, Sizes...>& other) noexcept { data_.swap(other.data_); }
 };
 
+// Wrapper around std::atomic<T> which uses relaxed accesses or plain
+// accesses, depending on the config. Intended for performance-sensitive
+// shared statistics where relaxed, non-tearing accesses are sufficient.
+template<typename T>
+class RelaxedAtomic {
+    static constexpr bool UseAtomic =
+#ifdef USE_SLOPPY_ATOMICS
+      !std::atomic<T>::is_always_lock_free || sizeof(T) > sizeof(size_t);
+#else
+      true;
+#endif
+
+   public:
+    RelaxedAtomic() = default;
+    RelaxedAtomic(T val) :
+        inner(val) {}
+    RelaxedAtomic(const RelaxedAtomic& a) :
+        inner(static_cast<T>(a)) {}
+
+    T operator=(T val) {
+        store(val, std::memory_order_relaxed);
+        return val;
+    }
+
+    RelaxedAtomic& operator=(const RelaxedAtomic& a) {
+        store(static_cast<T>(a), std::memory_order_relaxed);
+        return *this;
+    }
+
+    operator T() const { return load(std::memory_order_relaxed); }
+
+    RelaxedAtomic& operator+=(int val) {
+        store(load(std::memory_order_relaxed) + val, std::memory_order_relaxed);
+        return *this;
+    }
+
+    RelaxedAtomic& operator++() {
+        *this += 1;
+        return *this;
+    }
+
+    RelaxedAtomic& operator--() {
+        *this -= 1;
+        return *this;
+    }
+
+    T operator++(int) {
+        T val = load(std::memory_order_relaxed);
+        store(val + 1, std::memory_order_relaxed);
+        return val;
+    }
+
+    T operator--(int) {
+        T val = load(std::memory_order_relaxed);
+        store(val - 1, std::memory_order_relaxed);
+        return val;
+    }
+
+    RelaxedAtomic& operator-=(int val) {
+        store(load(std::memory_order_relaxed) - val, std::memory_order_relaxed);
+        return *this;
+    }
+
+    T load(std::memory_order order) const {
+        assert(order == std::memory_order_relaxed);
+        if constexpr (UseAtomic)
+            return inner.load(order);
+        else
+            return inner;
+    }
+
+    void store(T val, std::memory_order order) {
+        assert(order == std::memory_order_relaxed);
+        if constexpr (UseAtomic)
+            inner.store(val, order);
+        else
+            inner = val;
+    }
+
+   private:
+    std::conditional_t<UseAtomic, std::atomic<T>, T> inner;
+};
+
 
 // xorshift64star Pseudo-Random Number Generator
 // This class is based on original code written and dedicated
@@ -379,13 +463,13 @@ class PRNG {
     }
 };
 
-inline u64 mul_hi64(u64 a, u64 b) {
-#if defined(__GNUC__) && defined(IS_64BIT)
+inline usize mul_hi64(u64 a, usize b) {
+#if defined(__GNUC__) && defined(IS_64BIT) && !defined(__wasm__)
     __extension__ using uint128 = unsigned __int128;
     return (uint128(a) * uint128(b)) >> 64;
 #else
     u64 aL = u32(a), aH = a >> 32;
-    u64 bL = u32(b), bH = b >> 32;
+    u64 bL = u32(b), bH = u64(b) >> 32;
     u64 c1 = (aL * bL) >> 32;
     u64 c2 = aH * bL + c1;
     u64 c3 = aL * bH + u32(c2);

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -550,6 +550,19 @@ Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
     uint8x8_t sameBB  = vshrn_n_u16(vreinterpretq_u16_u8(merged), 4);
 
     return ~vget_lane_u64(vreinterpret_u64_u8(sameBB), 0);
+#elif defined(USE_SSE2)
+    Bitboard sameBB = 0;
+
+    for (int i = 0; i < 64; i += 16)
+    {
+        const __m128i old_v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&oldPieces[i]));
+        const __m128i new_v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(&newPieces[i]));
+        const __m128i same  = _mm_cmpeq_epi8(old_v, new_v);
+
+        sameBB |= static_cast<Bitboard>(_mm_movemask_epi8(same)) << i;
+    }
+
+    return ~sameBB;
 #else
     Bitboard changed = 0;
 

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -163,7 +163,12 @@ inline __m128i _mm_cvtsi64_si128(i64 val) {
     #endif
 
     #ifdef USE_SSE41
-        #define vec_convert_8_16(a) _mm_cvtepi8_epi16(_mm_cvtsi64_si128(static_cast<i64>(a)))
+        #ifdef __wasm__
+            #define vec_convert_8_16(a) wasm_i16x8_load8x8(reinterpret_cast<const void*>(&a))
+        #else
+            #define vec_convert_8_16(a) \
+                _mm_cvtepi8_epi16(_mm_cvtsi64_si128(static_cast<int64_t>(a)))
+        #endif
     #else
 // Credit: Yoshie2000
 inline __m128i vec_convert_8_16(u64 x) {
@@ -340,10 +345,13 @@ fused(const typename VecWrapper::type& in, const T& operand, const Ts&... operan
 }
 
 [[maybe_unused]] static void m128_add_dpbusd_epi32(__m128i& acc, __m128i a, __m128i b) {
-
+    #if defined(__wasm_relaxed_simd__)
+    acc = wasm_i32x4_relaxed_dot_i8x16_i7x16_add(b, a, acc);
+    #else
     __m128i product0 = _mm_maddubs_epi16(a, b);
     product0         = _mm_madd_epi16(product0, _mm_set1_epi16(1));
     acc              = _mm_add_epi32(acc, product0);
+    #endif
 }
 
 #endif

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -337,7 +337,10 @@ void Search::Worker::iterative_deepening() {
         // Save the last iteration's scores before the first PV line is searched and
         // all the move scores except the (new) PV are set to -VALUE_INFINITE.
         for (RootMove& rm : rootMoves)
+        {
             rm.previousScore = rm.score;
+            rm.previousPV    = rm.pv;
+        }
 
         usize pvFirst = 0;
         pvLast         = 0;
@@ -428,23 +431,36 @@ void Search::Worker::iterative_deepening() {
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
 
-            // In multiPV analysis we do not let aborted searches spoil mated-in /
-            // TB-loss scores from a completed search in an earlier PV line.
-            // A mated-in/TB-loss from an aborted search for pvIdx > 0 can only become
-            // bestmove in the sorting below if the current bestmove, and therefore the
-            // previously searched pvIdx - 1 line, is already a proven loss.
-            if (threads.stop && pvIdx && is_loss(rootMoves[pvIdx - 1].score)
-                && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+            // In multiPV analysis we do not let aborted searches spoil mated-in/
+            // TB loss scores from a completed search in an earlier PV line.
+            if (threads.stop && pvIdx
+                && ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+                    || rootMoves[pvIdx].score_is_exact_loss()))
             {
-                rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
-                  (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
-                   && rootMoves[pvIdx].previousScore < rootMoves[pvIdx - 1].score)
-                    ? rootMoves[pvIdx].previousScore
-                    : rootMoves[pvIdx - 1].score;
+                if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
+                    && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
+                {
+                    rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                      rootMoves[pvIdx].previousScore;
+                    rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                    rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
+                    rootMoves[pvIdx].unset_bound_flags();
+                }
+                else
+                {
+                    if (is_loss(rootMoves[pvIdx - 1].score))
+                    {
+                        rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                          rootMoves[pvIdx - 1].score;
+                        rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                        rootMoves[pvIdx].pv.resize(1);
+                        rootMoves[pvIdx].scoreUpperbound = true;
+                    }
+                    else
+                        rootMoves[pvIdx].scoreUpperbound = false;
 
-                rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
-                rootMoves[pvIdx].unset_bound_flags();
-                rootMoves[pvIdx].pv.resize(1);
+                    rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                }
             }
 
             // Sort the PV lines searched so far and update the GUI
@@ -477,9 +493,7 @@ void Search::Worker::iterative_deepening() {
             }
         }
 
-        const bool abortedLossSearch =
-          threads.stop && !pvIdx && rootMoves[0].score != -VALUE_INFINITE
-          && is_loss(rootMoves[0].score) && !rootMoves[0].score_is_bound();
+        const bool abortedLossSearch = threads.stop && !pvIdx && rootMoves[0].score_is_exact_loss();
 
         // An exact mated-in/TB-loss score from an aborted search cannot be trusted:
         // the loss could be delayed or refuted upon exploring the remaining root moves.
@@ -590,8 +604,7 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, Stac
 void Search::Worker::do_move(
   Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss) {
     bool capture = pos.capture_stage(move);
-    // Preferable over fetch_add to avoid locking instructions
-    nodes.store(nodes.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
+    ++nodes;
 
     auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
     pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory);
@@ -864,8 +877,7 @@ Value Search::Worker::search(
 
             if (err != TB::ProbeState::FAIL)
             {
-                // Preferable over fetch_add to avoid locking instructions
-                tbHits.store(tbHits.load(std::memory_order_relaxed) + 1, std::memory_order_relaxed);
+                ++tbHits;
 
                 int drawScore = tbConfig.useRule50 ? 1 : 0;
 
@@ -2188,7 +2200,8 @@ void SearchManager::pv(Search::Worker&           worker,
 
     for (usize i = 0; i < multiPV; ++i)
     {
-        bool updated = rootMoves[i].score != -VALUE_INFINITE;
+        bool updated          = rootMoves[i].score != -VALUE_INFINITE;
+        bool usePreviousScore = !updated;
 
         if (depth == 1 && !updated && i > 0)
             continue;
@@ -2202,15 +2215,16 @@ void SearchManager::pv(Search::Worker&           worker,
         bool tb = worker.tbConfig.rootInTB && std::abs(v) <= VALUE_TB;
         v       = tb ? rootMoves[i].tbScore : v;
 
-        bool isExact = i != pvIdx || tb || !updated;  // tablebase- and previous-scores are exact
+        bool isExact = i != pvIdx || tb || usePreviousScore;
 
         // Potentially correct and extend the PV, and in exceptional cases v
         if (is_decisive(v) && std::abs(v) < VALUE_MATE_IN_MAX_PLY
+            && !usePreviousScore
             && ((!rootMoves[i].scoreLowerbound && !rootMoves[i].scoreUpperbound) || isExact))
             syzygy_extend_pv(worker.options, worker.limits, pos, rootMoves[i], v);
 
         std::string pv;
-        for (Move m : rootMoves[i].pv)
+        for (Move m : usePreviousScore ? rootMoves[i].previousPV : rootMoves[i].pv)
             pv += UCIEngine::move(m, pos.is_chess960()) + " ";
 
         // Remove last whitespace

--- a/src/search.h
+++ b/src/search.h
@@ -94,6 +94,9 @@ struct RootMove {
     }
 
     bool score_is_bound() const { return scoreLowerbound || scoreUpperbound; }
+    bool score_is_exact_loss() const {
+        return score != -VALUE_INFINITE && is_loss(score) && !score_is_bound();
+    }
     void unset_bound_flags() { scoreLowerbound = scoreUpperbound = false; }
 
     u64          effort           = 0;
@@ -107,7 +110,7 @@ struct RootMove {
     int               selDepth         = 0;
     int               tbRank           = 0;
     Value             tbScore;
-    std::vector<Move> pv;
+    std::vector<Move> pv, previousPV;
 };
 
 using RootMoves = std::vector<RootMove>;
@@ -344,9 +347,9 @@ class Worker {
 
     LimitsType limits;
 
-    usize                pvIdx, pvLast;
-    std::atomic<u64> nodes, tbHits, bestMoveChanges;
-    int                   selDepth, nmpMinPly;
+    usize              pvIdx, pvLast;
+    RelaxedAtomic<u64> nodes, tbHits, bestMoveChanges;
+    int                selDepth, nmpMinPly;
 
     Value optimism[COLOR_NB];
 

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -44,6 +44,34 @@
 #include "../types.h"
 #include "../ucioption.h"
 
+#ifdef NO_TABLEBASES
+
+namespace Stockfish::Tablebases {
+
+int MaxCardinality;
+
+void init(const std::string&) {}
+
+WDLScore probe_wdl(Position&, ProbeState* result) {
+    *result = FAIL;
+    return WDLDraw;
+}
+
+int probe_dtz(Position&, ProbeState* result) {
+    *result = FAIL;
+    return 0;
+}
+
+bool root_probe(Position&, Search::RootMoves&, bool, bool) { return false; }
+
+bool root_probe_wdl(Position&, Search::RootMoves&, bool) { return false; }
+
+Config rank_root_moves(const OptionsMap&, Position&, Search::RootMoves&, bool) { return Config{}; }
+
+}  // namespace Stockfish::Tablebases
+
+#else
+
 #ifndef _WIN32
     #include <fcntl.h>
     #include <sys/mman.h>
@@ -1762,3 +1790,5 @@ Config Tablebases::rank_root_moves(const OptionsMap&  options,
     return config;
 }
 }  // namespace Stockfish
+
+#endif  // NO_TABLEBASES

--- a/src/thread.h
+++ b/src/thread.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "memory.h"
+#include "misc.h"
 #include "numa.h"
 #include "position.h"
 #include "search.h"
@@ -167,7 +168,7 @@ class ThreadPool {
     std::vector<std::unique_ptr<Thread>> threads;
     std::vector<NumaIndex>               boundThreadToNumaNode;
 
-    u64 accumulate(std::atomic<u64> Search::Worker::* member) const {
+    u64 accumulate(RelaxedAtomic<u64> Search::Worker::* member) const {
 
         u64 sum = 0;
         for (auto&& th : threads)

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -64,12 +64,12 @@ struct TTEntry {
     friend class TranspositionTable;
     friend struct TTWriter;
 
-    u16 key16;
-    u8  depth8;
-    u8  genBound8;
-    Move     move16;
-    i16  value16;
-    i16  eval16;
+    RelaxedAtomic<u16>  key16;
+    RelaxedAtomic<u8>   depth8;
+    RelaxedAtomic<u8>   genBound8;
+    RelaxedAtomic<Move> move16;
+    RelaxedAtomic<i16>  value16;
+    RelaxedAtomic<i16>  eval16;
 };
 
 // `genBound8` is where most of the details are. We use the following constants to manipulate 5 leading generation bits
@@ -188,7 +188,7 @@ void TranspositionTable::clear(ThreadPool& threads) {
             const usize start  = stride * i;
             const usize len    = i + 1 != threadCount ? stride : clusterCount - start;
 
-            std::memset(&table[start], 0, len * sizeof(Cluster));
+            std::memset(static_cast<void*>(&table[start]), 0, len * sizeof(Cluster));
         });
     }
 

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -6,12 +6,12 @@ import time
 import sys
 import traceback
 import fnmatch
-from functools import wraps
 from contextlib import redirect_stdout
 import io
 import tarfile
 import pathlib
-import concurrent.futures
+import queue
+import threading
 import tempfile
 import shutil
 import urllib.request
@@ -122,29 +122,10 @@ class OrderedClassMembers(type):
 
 
 class TimeoutException(Exception):
-    def __init__(self, message: str, timeout: int):
+    def __init__(self, message: str, timeout: float):
+        super().__init__(message)
         self.message = message
         self.timeout = timeout
-
-
-def timeout_decorator(timeout: float):
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(func, *args, **kwargs)
-                try:
-                    result = future.result(timeout=timeout)
-                except concurrent.futures.TimeoutError:
-                    raise TimeoutException(
-                        f"Function {func.__name__} timed out after {timeout} seconds",
-                        timeout,
-                    )
-            return result
-
-        return wrapper
-
-    return decorator
 
 
 class MiniTestFramework:
@@ -294,6 +275,8 @@ class Stockfish:
         self.cli = cli
         self.prefix = prefix
         self.output = []
+        self.output_queue = queue.Queue()
+        self.reader_thread = None
 
         self.start()
 
@@ -325,6 +308,21 @@ class Stockfish:
             universal_newlines=True,
             bufsize=1,
         )
+        self.reader_thread = threading.Thread(
+            target=self._read_process_output, daemon=True
+        )
+        self.reader_thread.start()
+
+    def _read_process_output(self):
+        try:
+            for line in self.process.stdout:
+                line = line.strip()
+                self.output.append(line)
+                self.output_queue.put(line)
+        except (OSError, ValueError):
+            pass
+        finally:
+            self.output_queue.put(None)
 
     def setoption(self, name: str, value: str):
         self.send_command(f"setoption name {name} value {value}")
@@ -338,31 +336,26 @@ class Stockfish:
         self.process.stdin.write(command + "\n")
         self.process.stdin.flush()
 
-    @timeout_decorator(MAX_TIMEOUT)
     def equals(self, expected_output: str):
         for line in self.readline():
             if line == expected_output:
                 return
 
-    @timeout_decorator(MAX_TIMEOUT)
     def expect(self, expected_output: str):
         for line in self.readline():
             if fnmatch.fnmatch(line, expected_output):
                 return
 
-    @timeout_decorator(MAX_TIMEOUT)
     def contains(self, expected_output: str):
         for line in self.readline():
             if expected_output in line:
                 return
 
-    @timeout_decorator(MAX_TIMEOUT)
     def starts_with(self, expected_output: str):
         for line in self.readline():
             if line.startswith(expected_output):
                 return
 
-    @timeout_decorator(MAX_TIMEOUT)
     def check_output(self, callback):
         if not callback:
             raise ValueError("Callback function is required")
@@ -371,14 +364,33 @@ class Stockfish:
             if callback(line) == True:
                 return
 
-    def readline(self):
+    def readline(self, timeout: float = MAX_TIMEOUT):
         if not self.process:
             raise RuntimeError("Stockfish process is not started")
 
+        deadline = time.monotonic() + timeout
+
         while True:
             self._check_process_alive()
-            line = self.process.stdout.readline().strip()
-            self.output.append(line)
+
+            remaining_time = deadline - time.monotonic()
+            if remaining_time <= 0:
+                raise TimeoutException(
+                    f"No matching output received after {timeout} seconds",
+                    timeout,
+                )
+
+            try:
+                line = self.output_queue.get(timeout=remaining_time)
+            except queue.Empty:
+                raise TimeoutException(
+                    f"No matching output received after {timeout} seconds",
+                    timeout,
+                )
+
+            if line is None:
+                self._check_process_alive()
+                raise RuntimeError("Stockfish process has terminated")
 
             yield line
 


### PR DESCRIPTION
### Motivation

- Bring in the Stockfish dev Jun 9 topology to add WebAssembly build targets, improve MultiPV mate/TB PV correctness, and make relaxed atomics configurable for performance-sensitive targets.
- Preserve Revolution branding, release tag and active NNUE while mapping only the source/build surfaces that cleanly integrate into the local topology.

### Description

- Add `wasm32` and `wasm32-relaxed-simd` build targets and related Makefile flags (`relaxedsimd`, `syzygy`, `USE_SLOPPY_ATOMICS`) while keeping Revolution executable naming and release tag; add optional NO_TABLEBASES compile-time behavior. (files: `src/Makefile`, `src/syzygy/tbprobe.cpp`)
- Introduce `RelaxedAtomic<T>` and use it for performance-sensitive shared counters/storage to allow disabling expensive atomic operations on WASM while preserving native behavior; migrate history/TT/search shared fields to `RelaxedAtomic`. (files: `src/misc.h`, `src/history.h`, `src/tt.cpp`, `src/search.h`, `src/thread.h`)
- Preserve complete PVs for MultiPV output by adding `previousPV` to `RootMove` and propagating previous-PV/previous-score logic and aborted-search guarding in the search manager. (files: `src/search.cpp`, `src/search.h`)
- Add WASM-friendly NNUE/ SIMD small adjustments and SSE2 fallback for changed-piece detection where appropriate. (files: `src/nnue/nnue_accumulator.cpp`, `src/nnue/simd.h`, `src/nnue/nnue_feature_transformer.h`)
- Improve test harness timeout enforcement by draining engine output on a daemon reader thread with a queue and initializing `TimeoutException` properly; add contributor to `AUTHORS`. (files: `tests/testing.py`, `AUTHORS`)
- Kept all Revolution invariants intact: engine name and release tag unchanged, `NNUE_NET = nn-71d6d32cb962.nnue` preserved, no EvalFileSmall/NetworkSmall/nn-83/MCTS/MonteCarlo introduced, and no Jun 10 topology was applied.

### Testing

- Verified authority commits and prerequisites by fetching upstream and inspecting the four Jun 9 commits; started from a clean working tree.
- Ran configuration and build validations: `make -C src config-sanity ARCH=x86-64-sse41-popcnt COMP=clang NNUE_EMBEDDING_OFF=yes` succeeded and `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` completed with build success and zero warnings and zero errors. `make -C src help` lists the new `wasm32` and `wasm32-relaxed-simd` targets.
- Ran source hygiene and invariant checks (`git diff --check`, targeted greps) and confirmed: `RelaxedAtomic`/`USE_SLOPPY_ATOMICS`/`previousPV` are present, Jun 6/Jun 8 endpoints remain, and forbidden identifiers did not appear in `src`.
- Python test harness bytecode check (`python3 -m py_compile tests/testing.py tests/instrumented.py`) could not be fully completed due to unrelated pre-existing malformed content in `tests/instrumented.py` (no Jun 9 changes were made to that file); the `tests/testing.py` runtime changes were applied and validated where possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd544ccd083278d9e52ba29c6656c)