### PR TITLE
REVOLUTION-P0-SFDEV20260610-R2: merge HalfKA and Threats accumulators

### DIFF
--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -19,9 +19,7 @@
 #include "nnue_accumulator.h"
 
 #include <cassert>
-#include <cstdint>
 #include <new>
-#include <type_traits>
 
 #include "../bitboard.h"
 #include "../misc.h"
@@ -38,83 +36,38 @@ using namespace SIMD;
 
 namespace {
 
+template<bool Forward>
+void update_accumulator_incremental(Color                     perspective,
+                                    const ActiveFeatureTransformer& featureTransformer,
+                                    const Square              ksq,
+                                    AccumulatorState&         target_state,
+                                    const AccumulatorState&   computed);
 
-
-template<bool Forward, typename FeatureSet, IndexType TransformedFeatureDimensions>
-void update_accumulator_incremental(
-  Color                                                   perspective,
-  const FeatureTransformer<TransformedFeatureDimensions>& featureTransformer,
-  const Square                                            ksq,
-  AccumulatorState<FeatureSet>&                           target_state,
-  const AccumulatorState<FeatureSet>&                     computed);
-
-template<IndexType Dimensions>
-void update_accumulator_refresh_cache(Color                                 perspective,
-                                      const FeatureTransformer<Dimensions>& featureTransformer,
-                                      const Position&                       pos,
-                                      AccumulatorState<PSQFeatureSet>&      accumulatorState,
-                                      AccumulatorCaches::Cache<Dimensions>& cache);
-
-template<IndexType Dimensions>
-void update_threats_accumulator_full(Color                                 perspective,
-                                     const FeatureTransformer<Dimensions>& featureTransformer,
-                                     const Position&                       pos,
-                                     AccumulatorState<ThreatFeatureSet>&   accumulatorState);
+void update_accumulator_refresh_cache(Color                     perspective,
+                                      const ActiveFeatureTransformer& featureTransformer,
+                                      const Position&           pos,
+                                      AccumulatorState&         accumulatorState,
+                                      ActiveAccumulatorCache&        cache);
 }
 
-template<typename T>
-const AccumulatorState<T>& AccumulatorStack::latest() const noexcept {
-    return accumulators<T>()[size - 1];
-}
+const AccumulatorState& AccumulatorStack::latest() const noexcept { return accumulators[size - 1]; }
 
-// Explicit template instantiations
-template const AccumulatorState<PSQFeatureSet>&    AccumulatorStack::latest() const noexcept;
-template const AccumulatorState<ThreatFeatureSet>& AccumulatorStack::latest() const noexcept;
-
-template<typename T>
-AccumulatorState<T>& AccumulatorStack::mut_latest() noexcept {
-    return mut_accumulators<T>()[size - 1];
-}
-
-template<typename T>
-const std::array<AccumulatorState<T>, AccumulatorStack::MaxSize>&
-AccumulatorStack::accumulators() const noexcept {
-    static_assert(std::is_same_v<T, PSQFeatureSet> || std::is_same_v<T, ThreatFeatureSet>,
-                  "Invalid Feature Set Type");
-
-    if constexpr (std::is_same_v<T, PSQFeatureSet>)
-        return psq_accumulators;
-
-    if constexpr (std::is_same_v<T, ThreatFeatureSet>)
-        return threat_accumulators;
-}
-
-template<typename T>
-std::array<AccumulatorState<T>, AccumulatorStack::MaxSize>&
-AccumulatorStack::mut_accumulators() noexcept {
-    static_assert(std::is_same_v<T, PSQFeatureSet> || std::is_same_v<T, ThreatFeatureSet>,
-                  "Invalid Feature Set Type");
-
-    if constexpr (std::is_same_v<T, PSQFeatureSet>)
-        return psq_accumulators;
-
-    if constexpr (std::is_same_v<T, ThreatFeatureSet>)
-        return threat_accumulators;
-}
+AccumulatorState& AccumulatorStack::mut_latest() noexcept { return accumulators[size - 1]; }
 
 void AccumulatorStack::reset() noexcept {
-    psq_accumulators[0].reset({});
-    threat_accumulators[0].reset({});
+    accumulators[0].dirtyPiece = {};
+    new (&accumulators[0].dirtyThreats) DirtyThreats;
+    accumulators[0].computed.fill(false);
     size = 1;
 }
 
 std::pair<DirtyPiece&, DirtyThreats&> AccumulatorStack::push() noexcept {
     assert(size < MaxSize);
-    auto& dp  = psq_accumulators[size].reset();
-    auto& dts = threat_accumulators[size].reset();
-    new (&dts) DirtyThreats;
+    auto& st = accumulators[size];
+    st.computed.fill(false);
+    new (&st.dirtyThreats) DirtyThreats;
     size++;
-    return {dp, dts};
+    return {st.dirtyPiece, st.dirtyThreats};
 }
 
 void AccumulatorStack::pop() noexcept {
@@ -122,410 +75,308 @@ void AccumulatorStack::pop() noexcept {
     size--;
 }
 
-template<IndexType Dimensions>
-void AccumulatorStack::evaluate(const Position&                       pos,
-                                const FeatureTransformer<Dimensions>& featureTransformer,
-                                AccumulatorCaches::Cache<Dimensions>& cache) noexcept {
-    constexpr bool UseThreats = (Dimensions == TransformedFeatureDimensionsBig);
-
-    evaluate_side<PSQFeatureSet>(WHITE, pos, featureTransformer, cache);
-
-    if (UseThreats)
-        evaluate_side<ThreatFeatureSet>(WHITE, pos, featureTransformer, cache);
-
-    evaluate_side<PSQFeatureSet>(BLACK, pos, featureTransformer, cache);
-
-    if (UseThreats)
-        evaluate_side<ThreatFeatureSet>(BLACK, pos, featureTransformer, cache);
+void AccumulatorStack::evaluate(const Position&           pos,
+                                const ActiveFeatureTransformer& featureTransformer,
+                                // Silence spurious warning on GCC 10
+                                [[maybe_unused]] ActiveAccumulatorCache& cache) noexcept {
+    evaluate_side(WHITE, pos, featureTransformer, cache);
+    evaluate_side(BLACK, pos, featureTransformer, cache);
 }
 
-template<typename FeatureSet, IndexType Dimensions>
-void AccumulatorStack::evaluate_side(Color                                 perspective,
-                                     const Position&                       pos,
-                                     const FeatureTransformer<Dimensions>& featureTransformer,
-                                     AccumulatorCaches::Cache<Dimensions>& cache) noexcept {
+void AccumulatorStack::evaluate_side(Color                     perspective,
+                                     const Position&           pos,
+                                     const ActiveFeatureTransformer& featureTransformer,
+                                     ActiveAccumulatorCache&        cache) noexcept {
 
-    const auto last_usable_accum =
-      find_last_usable_accumulator<FeatureSet, Dimensions>(perspective);
+    const auto last_usable_accum = find_last_usable_accumulator(perspective);
 
-    if ((accumulators<FeatureSet>()[last_usable_accum].template acc<Dimensions>())
-          .computed[perspective])
-        forward_update_incremental<FeatureSet>(perspective, pos, featureTransformer,
-                                               last_usable_accum);
+    if (accumulators[last_usable_accum].computed[perspective])
+        forward_update_incremental(perspective, pos, featureTransformer, last_usable_accum);
 
     else
     {
-        if constexpr (std::is_same_v<FeatureSet, PSQFeatureSet>)
-            update_accumulator_refresh_cache(perspective, featureTransformer, pos,
-                                             mut_latest<PSQFeatureSet>(), cache);
-        else
-            update_threats_accumulator_full(perspective, featureTransformer, pos,
-                                            mut_latest<ThreatFeatureSet>());
-
-        backward_update_incremental<FeatureSet>(perspective, pos, featureTransformer,
-                                                last_usable_accum);
+        update_accumulator_refresh_cache(perspective, featureTransformer, pos, mut_latest(), cache);
+        backward_update_incremental(perspective, pos, featureTransformer, last_usable_accum);
     }
 }
 
 // Find the earliest usable accumulator, this can either be a computed accumulator or the accumulator
 // state just before a change that requires full refresh.
-template<typename FeatureSet, IndexType Dimensions>
 usize AccumulatorStack::find_last_usable_accumulator(Color perspective) const noexcept {
 
     for (usize curr_idx = size - 1; curr_idx > 0; curr_idx--)
     {
-        if ((accumulators<FeatureSet>()[curr_idx].template acc<Dimensions>()).computed[perspective])
+        if (accumulators[curr_idx].computed[perspective])
             return curr_idx;
 
-        if (FeatureSet::requires_refresh(accumulators<FeatureSet>()[curr_idx].diff, perspective))
+        // Threat feature set refreshes require a king move across the center, i.e.,
+        // a subset of halfka refreshes
+        if (PSQFeatureSet::requires_refresh(accumulators[curr_idx].dirtyPiece, perspective))
             return curr_idx;
     }
 
     return 0;
 }
 
-template<typename FeatureSet, IndexType Dimensions>
-void AccumulatorStack::forward_update_incremental(
-  Color                                 perspective,
-  const Position&                       pos,
-  const FeatureTransformer<Dimensions>& featureTransformer,
-  const usize                     begin) noexcept {
+void AccumulatorStack::forward_update_incremental(Color                     perspective,
+                                                  const Position&           pos,
+                                                  const ActiveFeatureTransformer& featureTransformer,
+                                                  const usize               begin) noexcept {
 
-    assert(begin < accumulators<FeatureSet>().size());
-    assert((accumulators<FeatureSet>()[begin].template acc<Dimensions>()).computed[perspective]);
+    assert(begin < accumulators.size());
+    assert(accumulators[begin].computed[perspective]);
 
     const Square ksq = pos.square<KING>(perspective);
 
     for (usize next = begin + 1; next < size; next++)
-    {
         update_accumulator_incremental<true>(perspective, featureTransformer, ksq,
-                                             mut_accumulators<FeatureSet>()[next],
-                                             accumulators<FeatureSet>()[next - 1]);
-    }
+                                             accumulators[next], accumulators[next - 1]);
 
-    assert((latest<PSQFeatureSet>().acc<Dimensions>()).computed[perspective]);
+    assert(latest().computed[perspective]);
 }
 
-template<typename FeatureSet, IndexType Dimensions>
-void AccumulatorStack::backward_update_incremental(
-  Color perspective,
+void AccumulatorStack::backward_update_incremental(Color                     perspective,
+                                                   const Position&           pos,
+                                                   const ActiveFeatureTransformer& featureTransformer,
+                                                   const usize               end) noexcept {
 
-  const Position&                       pos,
-  const FeatureTransformer<Dimensions>& featureTransformer,
-  const usize                     end) noexcept {
-
-    assert(end < accumulators<FeatureSet>().size());
+    assert(end < accumulators.size());
     assert(end < size);
-    assert((latest<FeatureSet>().template acc<Dimensions>()).computed[perspective]);
+    assert(latest().computed[perspective]);
 
     const Square ksq = pos.square<KING>(perspective);
 
     for (i64 next = i64(size) - 2; next >= i64(end); next--)
         update_accumulator_incremental<false>(perspective, featureTransformer, ksq,
-                                              mut_accumulators<FeatureSet>()[next],
-                                              accumulators<FeatureSet>()[next + 1]);
+                                              accumulators[next], accumulators[next + 1]);
 
-    assert((accumulators<FeatureSet>()[end].template acc<Dimensions>()).computed[perspective]);
+    assert(accumulators[end].computed[perspective]);
 }
-
-// Explicit template instantiations
-template void AccumulatorStack::evaluate<TransformedFeatureDimensionsBig>(
-  const Position&                                            pos,
-  const FeatureTransformer<TransformedFeatureDimensionsBig>& featureTransformer,
-  AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>& cache) noexcept;
-
 
 namespace {
 
-template<typename VectorWrapper,
-         IndexType Width,
-         UpdateOperation... ops,
-         typename ElementType,
-         typename... Ts,
-         std::enable_if_t<is_all_same_v<ElementType, Ts...>, bool> = true>
-void fused_row_reduce(const ElementType* in, ElementType* out, const Ts* const... rows) {
-    constexpr IndexType size = Width * sizeof(ElementType) / sizeof(typename VectorWrapper::type);
+void apply_combined(Color                              perspective,
+                    const ActiveFeatureTransformer&          featureTransformer,
+                    const AccumulatorState&            from,
+                    AccumulatorState&                  to,
+                    const PSQFeatureSet::IndexList&    psqAdded,
+                    const PSQFeatureSet::IndexList&    psqRemoved,
+                    const ThreatFeatureSet::IndexList& thrAdded,
+                    const ThreatFeatureSet::IndexList& thrRemoved) {
+    constexpr IndexType Dimensions = ActiveFeatureTransformer::OutputDimensions;
 
-    auto* vecIn  = reinterpret_cast<const typename VectorWrapper::type*>(in);
-    auto* vecOut = reinterpret_cast<typename VectorWrapper::type*>(out);
+    const auto& fromAcc = from.accumulation[perspective];
+    auto&       toAcc   = to.accumulation[perspective];
 
-    for (IndexType i = 0; i < size; ++i)
-        vecOut[i] = fused<VectorWrapper, ops...>(
-          vecIn[i], reinterpret_cast<const typename VectorWrapper::type*>(rows)[i]...);
-}
-
-template<typename FeatureSet, IndexType Dimensions>
-struct AccumulatorUpdateContext {
-    Color                                 perspective;
-    const FeatureTransformer<Dimensions>& featureTransformer;
-    const AccumulatorState<FeatureSet>&   from;
-    AccumulatorState<FeatureSet>&         to;
-
-    AccumulatorUpdateContext(Color                                 persp,
-                             const FeatureTransformer<Dimensions>& ft,
-                             const AccumulatorState<FeatureSet>&   accF,
-                             AccumulatorState<FeatureSet>&         accT) noexcept :
-        perspective{persp},
-        featureTransformer{ft},
-        from{accF},
-        to{accT} {}
-
-    template<UpdateOperation... ops,
-             typename... Ts,
-             std::enable_if_t<is_all_same_v<IndexType, Ts...>, bool> = true>
-    void apply(const Ts... indices) {
-        auto to_weight_vector = [&](const IndexType index) {
-            return &featureTransformer.weights[index * Dimensions];
-        };
-
-        auto to_psqt_weight_vector = [&](const IndexType index) {
-            return &featureTransformer.psqtWeights[index * PSQTBuckets];
-        };
-
-        fused_row_reduce<Vec16Wrapper, Dimensions, ops...>(
-          (from.template acc<Dimensions>()).accumulation[perspective].data(),
-          (to.template acc<Dimensions>()).accumulation[perspective].data(),
-          to_weight_vector(indices)...);
-
-        fused_row_reduce<Vec32Wrapper, PSQTBuckets, ops...>(
-          (from.template acc<Dimensions>()).psqtAccumulation[perspective].data(),
-          (to.template acc<Dimensions>()).psqtAccumulation[perspective].data(),
-          to_psqt_weight_vector(indices)...);
-    }
-
-    void apply(const typename FeatureSet::IndexList& added,
-               const typename FeatureSet::IndexList& removed) {
-        const auto& fromAcc = from.template acc<Dimensions>().accumulation[perspective];
-        auto&       toAcc   = to.template acc<Dimensions>().accumulation[perspective];
-
-        const auto& fromPsqtAcc = from.template acc<Dimensions>().psqtAccumulation[perspective];
-        auto&       toPsqtAcc   = to.template acc<Dimensions>().psqtAccumulation[perspective];
+    const auto& fromPsqtAcc = from.psqtAccumulation[perspective];
+    auto&       toPsqtAcc   = to.psqtAccumulation[perspective];
 
 #ifdef VECTOR
-        using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
-        vec_t      acc[Tiling::NumRegs];
-        psqt_vec_t psqt[Tiling::NumPsqtRegs];
+    using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
 
-        const auto* threatWeights = &featureTransformer.threatWeights[0];
+    vec_t      acc[Tiling::NumRegs];
+    psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
-        for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
+    const auto* psqWeights    = &featureTransformer.weights[0];
+    const auto* threatWeights = &featureTransformer.threatWeights[0];
+
+    for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
+    {
+        const usize tileOff  = j * Tiling::TileHeight;
+        auto*       fromTile = reinterpret_cast<const vec_t*>(&fromAcc[tileOff]);
+        auto*       toTile   = reinterpret_cast<vec_t*>(&toAcc[tileOff]);
+
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            acc[k] = fromTile[k];
+
+        for (int i = 0; i < psqRemoved.ssize(); ++i)
         {
-            auto* fromTile = reinterpret_cast<const vec_t*>(&fromAcc[j * Tiling::TileHeight]);
-            auto* toTile   = reinterpret_cast<vec_t*>(&toAcc[j * Tiling::TileHeight]);
-
+            auto* row =
+              reinterpret_cast<const vec_t*>(&psqWeights[psqRemoved[i] * Dimensions + tileOff]);
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = fromTile[k];
-
-            for (int i = 0; i < removed.ssize(); ++i)
-            {
-                usize       index  = removed[i];
-                const usize offset = Dimensions * index;
-                auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
-
-    #ifdef USE_NEON
-                for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-                {
-                    acc[k]     = vec_sub_16(acc[k], vmovl_s8(vget_low_s8(column[k / 2])));
-                    acc[k + 1] = vec_sub_16(acc[k + 1], vmovl_high_s8(column[k / 2]));
-                }
-    #else
-                for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                    acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-            }
-
-            for (int i = 0; i < added.ssize(); ++i)
-            {
-                usize       index  = added[i];
-                const usize offset = Dimensions * index;
-                auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
-
-    #ifdef USE_NEON
-                for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-                {
-                    acc[k]     = vec_add_16(acc[k], vmovl_s8(vget_low_s8(column[k / 2])));
-                    acc[k + 1] = vec_add_16(acc[k + 1], vmovl_high_s8(column[k / 2]));
-                }
-    #else
-                for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                    acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-            }
-
-            for (IndexType k = 0; k < Tiling::NumRegs; k++)
-                vec_store(&toTile[k], acc[k]);
-
-            threatWeights += Tiling::TileHeight;
+                acc[k] = vec_sub_16(acc[k], row[k]);
         }
 
-        for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
+        for (int i = 0; i < psqAdded.ssize(); ++i)
         {
-            auto* fromTilePsqt =
-              reinterpret_cast<const psqt_vec_t*>(&fromPsqtAcc[j * Tiling::PsqtTileHeight]);
-            auto* toTilePsqt =
-              reinterpret_cast<psqt_vec_t*>(&toPsqtAcc[j * Tiling::PsqtTileHeight]);
-
-            for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = fromTilePsqt[k];
-
-            for (int i = 0; i < removed.ssize(); ++i)
-            {
-                usize       index      = removed[i];
-                const usize offset     = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
-                auto*        columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-                  &featureTransformer.threatPsqtWeights[offset]);
-
-                for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                    psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
-            }
-
-            for (int i = 0; i < added.ssize(); ++i)
-            {
-                usize       index      = added[i];
-                const usize offset     = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
-                auto*        columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-                  &featureTransformer.threatPsqtWeights[offset]);
-
-                for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                    psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-            }
-
-            for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
-                vec_store_psqt(&toTilePsqt[k], psqt[k]);
+            auto* row =
+              reinterpret_cast<const vec_t*>(&psqWeights[psqAdded[i] * Dimensions + tileOff]);
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], row[k]);
         }
+
+        for (int i = 0; i < thrRemoved.ssize(); ++i)
+        {
+            auto* column = reinterpret_cast<const vec_i8_t*>(
+              &threatWeights[thrRemoved[i] * Dimensions + tileOff]);
+
+    #ifdef USE_NEON
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #else
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
+    #endif
+        }
+
+        for (int i = 0; i < thrAdded.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_i8_t*>(&threatWeights[thrAdded[i] * Dimensions + tileOff]);
+
+    #ifdef USE_NEON
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #else
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
+    #endif
+        }
+
+        for (IndexType k = 0; k < Tiling::NumRegs; k++)
+            vec_store(&toTile[k], acc[k]);
+    }
+
+    for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
+    {
+        const usize psqtTileOff  = j * Tiling::PsqtTileHeight;
+        auto*       fromTilePsqt = reinterpret_cast<const psqt_vec_t*>(&fromPsqtAcc[psqtTileOff]);
+        auto*       toTilePsqt   = reinterpret_cast<psqt_vec_t*>(&toPsqtAcc[psqtTileOff]);
+
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+            psqt[k] = fromTilePsqt[k];
+
+        for (int i = 0; i < psqRemoved.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[psqRemoved[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (int i = 0; i < psqAdded.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[psqAdded[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (int i = 0; i < thrRemoved.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.threatPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (int i = 0; i < thrAdded.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.threatPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+            vec_store_psqt(&toTilePsqt[k], psqt[k]);
+    }
 
 #else
 
-        toAcc     = fromAcc;
-        toPsqtAcc = fromPsqtAcc;
+    toAcc     = fromAcc;
+    toPsqtAcc = fromPsqtAcc;
 
-        for (const auto index : removed)
-        {
-            const IndexType offset = Dimensions * index;
+    for (const auto index : psqRemoved)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] -= featureTransformer.weights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
 
-            for (IndexType j = 0; j < Dimensions; ++j)
-                toAcc[j] -= featureTransformer.threatWeights[offset + j];
+    for (const auto index : psqAdded)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] += featureTransformer.weights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
 
-            for (usize k = 0; k < PSQTBuckets; ++k)
-                toPsqtAcc[k] -= featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
-        }
+    for (const auto index : thrRemoved)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] -= featureTransformer.threatWeights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] -= featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
+    }
 
-        for (const auto index : added)
-        {
-            const IndexType offset = Dimensions * index;
-
-            for (IndexType j = 0; j < Dimensions; ++j)
-                toAcc[j] += featureTransformer.threatWeights[offset + j];
-
-            for (usize k = 0; k < PSQTBuckets; ++k)
-                toPsqtAcc[k] += featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
-        }
+    for (const auto index : thrAdded)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] += featureTransformer.threatWeights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] += featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
+    }
 
 #endif
-    }
-};
-
-template<typename FeatureSet, IndexType Dimensions>
-auto make_accumulator_update_context(Color                                 perspective,
-                                     const FeatureTransformer<Dimensions>& featureTransformer,
-                                     const AccumulatorState<FeatureSet>&   accumulatorFrom,
-                                     AccumulatorState<FeatureSet>&         accumulatorTo) noexcept {
-    return AccumulatorUpdateContext<FeatureSet, Dimensions>{perspective, featureTransformer,
-                                                            accumulatorFrom, accumulatorTo};
 }
 
+template<bool Forward>
+void update_accumulator_incremental(Color                     perspective,
+                                    const ActiveFeatureTransformer& featureTransformer,
+                                    const Square              ksq,
+                                    AccumulatorState&         target_state,
+                                    const AccumulatorState&   computed) {
 
-
-template<bool Forward, typename FeatureSet, IndexType TransformedFeatureDimensions>
-void update_accumulator_incremental(
-  Color                                                   perspective,
-  const FeatureTransformer<TransformedFeatureDimensions>& featureTransformer,
-  const Square                                            ksq,
-  AccumulatorState<FeatureSet>&                           target_state,
-  const AccumulatorState<FeatureSet>&                     computed) {
-
-    assert((computed.template acc<TransformedFeatureDimensions>()).computed[perspective]);
-    assert(!(target_state.template acc<TransformedFeatureDimensions>()).computed[perspective]);
+    assert(computed.computed[perspective]);
+    assert(!target_state.computed[perspective]);
 
     // The size must be enough to contain the largest possible update.
     // That might depend on the feature set and generally relies on the
     // feature set's update cost calculation to be correct and never allow
     // updates with more added/removed features than MaxActiveDimensions.
-    // In this case, the maximum size of both feature addition and removal
-    // is 2, since we are incrementally updating one move at a time.
-    typename FeatureSet::IndexList removed, added;
-    if constexpr (std::is_same_v<FeatureSet, ThreatFeatureSet>)
+    PSQFeatureSet::IndexList    psqRemoved, psqAdded;
+    ThreatFeatureSet::IndexList thrRemoved, thrAdded;
+
+    const auto& dirtyPiece   = Forward ? target_state.dirtyPiece : computed.dirtyPiece;
+    const auto& dirtyThreats = Forward ? target_state.dirtyThreats : computed.dirtyThreats;
+
+    const auto* pfBase   = &featureTransformer.threatWeights[0];
+    IndexType   pfStride = ActiveFeatureTransformer::OutputDimensions;
+
+    if constexpr (Forward)
     {
-        const auto* pfBase   = &featureTransformer.threatWeights[0];
-        auto        pfStride = static_cast<IndexType>(TransformedFeatureDimensions);
-        if constexpr (Forward)
-            FeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added,
-                                               nullptr, false, pfBase, pfStride);
-        else
-            FeatureSet::append_changed_indices(perspective, ksq, computed.diff, added, removed,
-                                               nullptr, false, pfBase, pfStride);
+        ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
+                                                 thrAdded, nullptr, false, pfBase, pfStride);
+        PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
-        if constexpr (Forward)
-            FeatureSet::append_changed_indices(perspective, ksq, target_state.diff, removed, added);
-        else
-            FeatureSet::append_changed_indices(perspective, ksq, computed.diff, added, removed);
+        ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
+                                                 thrRemoved, nullptr, false, pfBase, pfStride);
+        PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 
-    auto updateContext =
-      make_accumulator_update_context(perspective, featureTransformer, computed, target_state);
+    apply_combined(perspective, featureTransformer, computed, target_state, psqAdded, psqRemoved,
+                   thrAdded, thrRemoved);
 
-    if constexpr (std::is_same_v<FeatureSet, ThreatFeatureSet>)
-        updateContext.apply(added, removed);
-    else
-    {
-        [[maybe_unused]] const int addedSize   = added.ssize();
-        [[maybe_unused]] const int removedSize = removed.ssize();
-
-        assert(addedSize == 1 || addedSize == 2);
-        assert(removedSize == 1 || removedSize == 2);
-        assert((Forward && addedSize <= removedSize) || (!Forward && addedSize >= removedSize));
-
-        // Workaround compiler warning for uninitialized variables, replicated
-        // on profile builds on windows with gcc 14.2.0.
-        // Also helps with optimizations on some compilers.
-
-        sf_assume(addedSize == 1 || addedSize == 2);
-        sf_assume(removedSize == 1 || removedSize == 2);
-
-        if (!(removedSize == 1 || removedSize == 2) || !(addedSize == 1 || addedSize == 2))
-            sf_unreachable();
-
-        if ((Forward && removedSize == 1) || (!Forward && addedSize == 1))
-        {
-            assert(addedSize == 1 && removedSize == 1);
-            updateContext.template apply<Add, Sub>(added[0], removed[0]);
-        }
-        else if (Forward && addedSize == 1)
-        {
-            assert(removedSize == 2);
-            updateContext.template apply<Add, Sub, Sub>(added[0], removed[0], removed[1]);
-        }
-        else if (!Forward && removedSize == 1)
-        {
-            assert(addedSize == 2);
-            updateContext.template apply<Add, Add, Sub>(added[0], added[1], removed[0]);
-        }
-        else
-        {
-            assert(addedSize == 2 && removedSize == 2);
-            updateContext.template apply<Add, Add, Sub, Sub>(added[0], added[1], removed[0],
-                                                             removed[1]);
-        }
-    }
-
-    (target_state.template acc<TransformedFeatureDimensions>()).computed[perspective] = true;
+    target_state.computed[perspective] = true;
 }
 
 Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
                             const std::array<Piece, SQUARE_NB>& newPieces) {
-#if defined(USE_AVX512) || defined(USE_AVX2)
+#if defined(USE_AVX2)
     static_assert(sizeof(Piece) == 1);
     Bitboard sameBB = 0;
 
@@ -533,11 +384,45 @@ Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
     {
         const __m256i old_v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&oldPieces[i]));
         const __m256i new_v = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(&newPieces[i]));
-        const __m256i cmpEqual        = _mm256_cmpeq_epi8(old_v, new_v);
-        const u32 equalMask = _mm256_movemask_epi8(cmpEqual);
+        const __m256i cmpEqual  = _mm256_cmpeq_epi8(old_v, new_v);
+        const u32     equalMask = _mm256_movemask_epi8(cmpEqual);
         sameBB |= static_cast<Bitboard>(equalMask) << i;
     }
     return ~sameBB;
+#elif defined(USE_LASX)
+    static_assert(sizeof(Piece) == 1);
+
+    Bitboard changed = 0;
+
+    for (int i = 0; i < 64; i += 32)
+    {
+        const __m256i old_v = __lasx_xvld(reinterpret_cast<const void*>(&oldPieces[i]), 0);
+        const __m256i new_v = __lasx_xvld(reinterpret_cast<const void*>(&newPieces[i]), 0);
+        const __m256i diff  = __lasx_xvxor_v(old_v, new_v);
+        const __m256i mask  = __lasx_xvmsknz_b(diff);
+        const auto    lo    = __lasx_xvpickve2gr_d(mask, 0);
+        const auto    hi    = __lasx_xvpickve2gr_d(mask, 2);
+
+        changed |= (static_cast<Bitboard>(lo) | (static_cast<Bitboard>(hi) << 16)) << i;
+    }
+
+    return changed;
+#elif defined(USE_LSX)
+    static_assert(sizeof(Piece) == 1);
+
+    Bitboard changed = 0;
+
+    for (int i = 0; i < 64; i += 16)
+    {
+        const __m128i old_v = __lsx_vld(reinterpret_cast<const void*>(&oldPieces[i]), 0);
+        const __m128i new_v = __lsx_vld(reinterpret_cast<const void*>(&newPieces[i]), 0);
+        const __m128i diff  = __lsx_vxor_v(old_v, new_v);
+        const __m128i mask  = __lsx_vmsknz_b(diff);
+
+        changed |= static_cast<Bitboard>(__lsx_vpickve2gr_d(mask, 0)) << i;
+    }
+
+    return changed;
 #elif defined(USE_NEON)
     uint8x16x4_t old_v = vld4q_u8(reinterpret_cast<const u8*>(oldPieces.data()));
     uint8x16x4_t new_v = vld4q_u8(reinterpret_cast<const u8*>(newPieces.data()));
@@ -573,12 +458,14 @@ Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
 #endif
 }
 
-template<IndexType Dimensions>
-void update_accumulator_refresh_cache(Color                                 perspective,
-                                      const FeatureTransformer<Dimensions>& featureTransformer,
-                                      const Position&                       pos,
-                                      AccumulatorState<PSQFeatureSet>&      accumulatorState,
-                                      AccumulatorCaches::Cache<Dimensions>& cache) {
+// HalfKA data comes from the Finny table entry, while the threats are built
+// from the active threat features
+void update_accumulator_refresh_cache(Color                     perspective,
+                                      const ActiveFeatureTransformer& featureTransformer,
+                                      const Position&           pos,
+                                      AccumulatorState&         accumulator,
+                                      ActiveAccumulatorCache&        cache) {
+    constexpr auto Dimensions = ActiveFeatureTransformer::OutputDimensions;
 
     using Tiling [[maybe_unused]] = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
 
@@ -590,6 +477,10 @@ void update_accumulator_refresh_cache(Color                                 pers
     Bitboard       removedBB = changedBB & entry.pieceBB;
     Bitboard       addedBB   = changedBB & pos.pieces();
 
+#if defined(USE_AVX512ICL)
+    PSQFeatureSet::write_indices(entry.pieces, pos.piece_array(), removedBB, addedBB, perspective,
+                                 ksq, removed, added);
+#else
     while (removedBB)
     {
         Square sq = pop_lsb(removedBB);
@@ -600,101 +491,107 @@ void update_accumulator_refresh_cache(Color                                 pers
         Square sq = pop_lsb(addedBB);
         added.push_back(PSQFeatureSet::make_index(perspective, sq, pos.piece_on(sq), ksq));
     }
+#endif
 
     entry.pieceBB = pos.pieces();
     entry.pieces  = pos.piece_array();
 
-    auto& accumulator                 = accumulatorState.acc<Dimensions>();
+    ThreatFeatureSet::IndexList active;
+    ThreatFeatureSet::append_active_indices(perspective, pos, active);
+
     accumulator.computed[perspective] = true;
 
 #ifdef VECTOR
     vec_t      acc[Tiling::NumRegs];
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
-    const auto* weights = &featureTransformer.weights[0];
+    const auto* weights       = &featureTransformer.weights[0];
+    const auto* threatWeights = &featureTransformer.threatWeights[0];
 
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
-        auto* accTile =
-          reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][j * Tiling::TileHeight]);
-        auto* entryTile = reinterpret_cast<vec_t*>(&entry.accumulation[j * Tiling::TileHeight]);
+        const usize tileOff = j * Tiling::TileHeight;
+        auto* accTile   = reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][tileOff]);
+        auto* entryTile = reinterpret_cast<vec_t*>(&entry.accumulation[tileOff]);
 
         for (IndexType k = 0; k < Tiling::NumRegs; ++k)
             acc[k] = entryTile[k];
 
-        int i = 0;
-        for (; i < std::min(removed.ssize(), added.ssize()); ++i)
+        for (int i = 0; i < removed.ssize(); ++i)
         {
-            usize       indexR  = removed[i];
-            const usize offsetR = Dimensions * indexR;
-            auto*        columnR = reinterpret_cast<const vec_t*>(&weights[offsetR]);
-            usize       indexA  = added[i];
-            const usize offsetA = Dimensions * indexA;
-            auto*        columnA = reinterpret_cast<const vec_t*>(&weights[offsetA]);
-
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = fused<Vec16Wrapper, Add, Sub>(acc[k], columnA[k], columnR[k]);
-        }
-        for (; i < removed.ssize(); ++i)
-        {
-            usize       index  = removed[i];
-            const usize offset = Dimensions * index;
-            auto*        column = reinterpret_cast<const vec_t*>(&weights[offset]);
-
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[removed[i] * Dimensions + tileOff]);
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = vec_sub_16(acc[k], column[k]);
         }
-        for (; i < added.ssize(); ++i)
+        for (int i = 0; i < added.ssize(); ++i)
         {
-            usize       index  = added[i];
-            const usize offset = Dimensions * index;
-            auto*        column = reinterpret_cast<const vec_t*>(&weights[offset]);
-
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[added[i] * Dimensions + tileOff]);
             for (IndexType k = 0; k < Tiling::NumRegs; ++k)
                 acc[k] = vec_add_16(acc[k], column[k]);
         }
 
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&entryTile[k], acc[k]);
+
+        for (int i = 0; i < active.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_i8_t*>(&threatWeights[active[i] * Dimensions + tileOff]);
+
+    #ifdef USE_NEON
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #else
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
+    #endif
+        }
+
         for (IndexType k = 0; k < Tiling::NumRegs; k++)
             vec_store(&accTile[k], acc[k]);
-
-        weights += Tiling::TileHeight;
     }
 
     for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
     {
-        auto* accTilePsqt = reinterpret_cast<psqt_vec_t*>(
-          &accumulator.psqtAccumulation[perspective][j * Tiling::PsqtTileHeight]);
-        auto* entryTilePsqt =
-          reinterpret_cast<psqt_vec_t*>(&entry.psqtAccumulation[j * Tiling::PsqtTileHeight]);
+        const usize psqtTileOff = j * Tiling::PsqtTileHeight;
+        auto*       accTilePsqt =
+          reinterpret_cast<psqt_vec_t*>(&accumulator.psqtAccumulation[perspective][psqtTileOff]);
+        auto* entryTilePsqt = reinterpret_cast<psqt_vec_t*>(&entry.psqtAccumulation[psqtTileOff]);
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             psqt[k] = entryTilePsqt[k];
 
         for (int i = 0; i < removed.ssize(); ++i)
         {
-            usize       index  = removed[i];
-            const usize offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
-            auto*        columnPsqt =
-              reinterpret_cast<const psqt_vec_t*>(&featureTransformer.psqtWeights[offset]);
-
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[removed[i] * PSQTBuckets + psqtTileOff]);
             for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
         }
         for (int i = 0; i < added.ssize(); ++i)
         {
-            usize       index  = added[i];
-            const usize offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
-            auto*        columnPsqt =
-              reinterpret_cast<const psqt_vec_t*>(&featureTransformer.psqtWeights[offset]);
-
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[added[i] * PSQTBuckets + psqtTileOff]);
             for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
         }
 
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&entryTilePsqt[k], psqt[k]);
+
+        for (int i = 0; i < active.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.threatPsqtWeights[active[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
         for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
             vec_store_psqt(&accTilePsqt[k], psqt[k]);
     }
@@ -724,92 +621,6 @@ void update_accumulator_refresh_cache(Color                                 pers
     // Now copy its content to the actual accumulator we were refreshing.
     accumulator.accumulation[perspective]     = entry.accumulation;
     accumulator.psqtAccumulation[perspective] = entry.psqtAccumulation;
-#endif
-}
-
-template<IndexType Dimensions>
-void update_threats_accumulator_full(Color                                 perspective,
-                                     const FeatureTransformer<Dimensions>& featureTransformer,
-                                     const Position&                       pos,
-                                     AccumulatorState<ThreatFeatureSet>&   accumulatorState) {
-    using Tiling [[maybe_unused]] = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
-
-    ThreatFeatureSet::IndexList active;
-    ThreatFeatureSet::append_active_indices(perspective, pos, active);
-
-    auto& accumulator                 = accumulatorState.acc<Dimensions>();
-    accumulator.computed[perspective] = true;
-
-#ifdef VECTOR
-    vec_t      acc[Tiling::NumRegs];
-    psqt_vec_t psqt[Tiling::NumPsqtRegs];
-
-    const auto* threatWeights = &featureTransformer.threatWeights[0];
-
-    for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
-    {
-        auto* accTile =
-          reinterpret_cast<vec_t*>(&accumulator.accumulation[perspective][j * Tiling::TileHeight]);
-
-        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-            acc[k] = vec_zero();
-
-        int i = 0;
-
-        for (; i < active.ssize(); ++i)
-        {
-            usize       index  = active[i];
-            const usize offset = Dimensions * index;
-            auto*        column = reinterpret_cast<const vec_i8_t*>(&threatWeights[offset]);
-
-    #ifdef USE_NEON
-            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
-            {
-                acc[k]     = vec_add_16(acc[k], vmovl_s8(vget_low_s8(column[k / 2])));
-                acc[k + 1] = vec_add_16(acc[k + 1], vmovl_high_s8(column[k / 2]));
-            }
-    #else
-            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
-                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
-    #endif
-        }
-
-        for (IndexType k = 0; k < Tiling::NumRegs; k++)
-            vec_store(&accTile[k], acc[k]);
-
-        threatWeights += Tiling::TileHeight;
-    }
-
-    for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
-    {
-        auto* accTilePsqt = reinterpret_cast<psqt_vec_t*>(
-          &accumulator.psqtAccumulation[perspective][j * Tiling::PsqtTileHeight]);
-
-        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
-            psqt[k] = vec_zero_psqt();
-
-        for (int i = 0; i < active.ssize(); ++i)
-        {
-            usize       index  = active[i];
-            const usize offset = PSQTBuckets * index + j * Tiling::PsqtTileHeight;
-            auto*        columnPsqt =
-              reinterpret_cast<const psqt_vec_t*>(&featureTransformer.threatPsqtWeights[offset]);
-
-            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
-                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
-        }
-
-        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
-            vec_store_psqt(&accTilePsqt[k], psqt[k]);
-    }
-
-#else
-
-    for (IndexType j = 0; j < Dimensions; ++j)
-        accumulator.accumulation[perspective][j] = 0;
-
-    for (usize k = 0; k < PSQTBuckets; ++k)
-        accumulator.psqtAccumulation[perspective][k] = 0;
 
     for (const auto index : active)
     {

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -23,11 +23,11 @@
 
 #include <array>
 #include <cstddef>
-#include <cstdint>
 #include <cstring>
 #include <utility>
 
 #include "../types.h"
+#include "../misc.h"
 #include "nnue_architecture.h"
 #include "nnue_common.h"
 
@@ -45,12 +45,13 @@ class FeatureTransformer;
 
 using ActiveFeatureTransformer = FeatureTransformer<ActiveTransformedFeatureDimensions>;
 
-// Class that holds the result of affine transformation of input features
+// Class that holds the result of affine transformation of input features,
+// combined HalfKA + Threats
 template<IndexType Size>
 struct alignas(CacheLineSize) Accumulator {
     std::array<std::array<i16, Size>, COLOR_NB>        accumulation;
     std::array<std::array<i32, PSQTBuckets>, COLOR_NB> psqtAccumulation;
-    std::array<bool, COLOR_NB>                                  computed = {};
+    std::array<bool, COLOR_NB>                         computed = {};
 };
 
 
@@ -61,25 +62,16 @@ struct alignas(CacheLineSize) Accumulator {
 // This idea, was first described by Luecx (author of Koivisto) and
 // is commonly referred to as "Finny Tables".
 struct AccumulatorCaches {
-
     AccumulatorCaches() = default;
-
-    template<typename Network>
-    void init_big(const Network& network) {
-        clear_big(network);
-    }
 
     template<IndexType Size>
     struct alignas(CacheLineSize) Cache {
-
         struct alignas(CacheLineSize) Entry {
             std::array<BiasType, Size>              accumulation;
             std::array<PSQTWeightType, PSQTBuckets> psqtAccumulation;
             std::array<Piece, SQUARE_NB>            pieces;
             Bitboard                                pieceBB;
 
-            // To initialize a refresh entry, we set all its bitboards empty,
-            // so we put the biases in the accumulation, without any weights on top
             void clear(const std::array<BiasType, Size>& biases) {
                 accumulation = biases;
                 std::memset(reinterpret_cast<std::byte*>(this) + offsetof(Entry, psqtAccumulation),
@@ -95,109 +87,69 @@ struct AccumulatorCaches {
         }
 
         std::array<Entry, COLOR_NB>& operator[](Square sq) { return entries[sq]; }
-
         std::array<std::array<Entry, COLOR_NB>, SQUARE_NB> entries;
     };
 
     template<typename Network>
-    void clear_big(const Network& network) {
-        big.clear(network);
-    }
+    void init_big(const Network& network) { big.clear(network); }
+
+    template<typename Network>
+    void clear_big(const Network& network) { big.clear(network); }
 
     Cache<TransformedFeatureDimensionsBig> big;
 };
 
-using ActiveAccumulatorCache  =
-  AccumulatorCaches::Cache<ActiveTransformedFeatureDimensions>;
+using ActiveAccumulatorCache = AccumulatorCaches::Cache<ActiveTransformedFeatureDimensions>;
 using ActiveAccumulatorCaches = AccumulatorCaches;
 
 
-template<typename FeatureSet>
-struct AccumulatorState {
-    Accumulator<TransformedFeatureDimensionsBig>   accumulatorBig;
-    typename FeatureSet::DiffType                  diff;
-
-    template<IndexType Size>
-    auto& acc() noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
-
-        if constexpr (Size == TransformedFeatureDimensionsBig)
-            return accumulatorBig;
-    }
-
-    template<IndexType Size>
-    const auto& acc() const noexcept {
-        static_assert(Size == TransformedFeatureDimensionsBig, "Invalid size for accumulator");
-
-        if constexpr (Size == TransformedFeatureDimensionsBig)
-            return accumulatorBig;
-    }
-
-    void reset(const typename FeatureSet::DiffType& dp) noexcept {
-        diff = dp;
-        accumulatorBig.computed.fill(false);
-    }
-
-    typename FeatureSet::DiffType& reset() noexcept {
-        accumulatorBig.computed.fill(false);
-        return diff;
-    }
+struct AccumulatorState: public Accumulator<ActiveTransformedFeatureDimensions> {
+    DirtyPiece   dirtyPiece;
+    DirtyThreats dirtyThreats;
 };
 
-using ActiveAccumulator            = Accumulator<ActiveTransformedFeatureDimensions>;
-using ActivePSQAccumulatorState    = AccumulatorState<PSQFeatureSet>;
-using ActiveThreatAccumulatorState = AccumulatorState<ThreatFeatureSet>;
+using ActiveAccumulator = Accumulator<ActiveTransformedFeatureDimensions>;
+using ActivePSQAccumulatorState = AccumulatorState;
+using ActiveThreatAccumulatorState = AccumulatorState;
 
 class AccumulatorStack {
    public:
     static constexpr usize MaxSize = MAX_PLY + 1;
 
-    template<typename T>
-    [[nodiscard]] const AccumulatorState<T>& latest() const noexcept;
+    [[nodiscard]] const AccumulatorState& latest() const noexcept;
 
     void                                  reset() noexcept;
     std::pair<DirtyPiece&, DirtyThreats&> push() noexcept;
     void                                  pop() noexcept;
 
-    template<IndexType Dimensions>
-    void evaluate(const Position&                       pos,
-                  const FeatureTransformer<Dimensions>& featureTransformer,
-                  AccumulatorCaches::Cache<Dimensions>& cache) noexcept;
+    void evaluate(const Position&           pos,
+                  const ActiveFeatureTransformer& featureTransformer,
+                  // Silence spurious warning on GCC 10
+                  [[maybe_unused]] ActiveAccumulatorCache& cache) noexcept;
 
    private:
-    template<typename T>
-    [[nodiscard]] AccumulatorState<T>& mut_latest() noexcept;
+    [[nodiscard]] AccumulatorState& mut_latest() noexcept;
 
-    template<typename T>
-    [[nodiscard]] const std::array<AccumulatorState<T>, MaxSize>& accumulators() const noexcept;
+    void evaluate_side(Color                     perspective,
+                       const Position&           pos,
+                       const ActiveFeatureTransformer& featureTransformer,
+                       // Silence spurious warning on GCC 10
+                       [[maybe_unused]] ActiveAccumulatorCache& cache) noexcept;
 
-    template<typename T>
-    [[nodiscard]] std::array<AccumulatorState<T>, MaxSize>& mut_accumulators() noexcept;
-
-    template<typename FeatureSet, IndexType Dimensions>
-    void evaluate_side(Color                                 perspective,
-                       const Position&                       pos,
-                       const FeatureTransformer<Dimensions>& featureTransformer,
-                       AccumulatorCaches::Cache<Dimensions>& cache) noexcept;
-
-    template<typename FeatureSet, IndexType Dimensions>
     [[nodiscard]] usize find_last_usable_accumulator(Color perspective) const noexcept;
 
-    template<typename FeatureSet, IndexType Dimensions>
-    void forward_update_incremental(Color                                 perspective,
-                                    const Position&                       pos,
-                                    const FeatureTransformer<Dimensions>& featureTransformer,
-                                    const usize                     begin) noexcept;
+    void forward_update_incremental(Color                     perspective,
+                                    const Position&           pos,
+                                    const ActiveFeatureTransformer& featureTransformer,
+                                    const usize               begin) noexcept;
 
-    template<typename FeatureSet, IndexType Dimensions>
-    void backward_update_incremental(Color                                 perspective,
-                                     const Position&                       pos,
-                                     const FeatureTransformer<Dimensions>& featureTransformer,
-                                     const usize                     end) noexcept;
+    void backward_update_incremental(Color                     perspective,
+                                     const Position&           pos,
+                                     const ActiveFeatureTransformer& featureTransformer,
+                                     const usize               end) noexcept;
 
-    std::array<AccumulatorState<PSQFeatureSet>, MaxSize>    psq_accumulators;
-    std::array<AccumulatorState<ThreatFeatureSet>, MaxSize> threat_accumulators;
-    usize                                             size = 1;
+    std::array<AccumulatorState, MaxSize> accumulators;
+    usize                                 size = 1;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -232,28 +232,15 @@ class FeatureTransformer {
 
         using namespace SIMD;
         accumulatorStack.evaluate(pos, *this, cache);
-        const auto& accumulatorState       = accumulatorStack.latest<PSQFeatureSet>();
-        const auto& threatAccumulatorState = accumulatorStack.latest<ThreatFeatureSet>();
+        const auto& accumulatorState = accumulatorStack.latest();
 
         const Color perspectives[2]  = {pos.side_to_move(), ~pos.side_to_move()};
-        const auto& psqtAccumulation = (accumulatorState.acc<HalfDimensions>()).psqtAccumulation;
-        auto        psqt =
-          (psqtAccumulation[perspectives[0]][bucket] - psqtAccumulation[perspectives[1]][bucket]);
+        const auto& psqtAccumulation = accumulatorState.psqtAccumulation;
+        const auto  psqt =
+          (psqtAccumulation[perspectives[0]][bucket] - psqtAccumulation[perspectives[1]][bucket])
+          / 2;
 
-        if constexpr (UseThreats)
-        {
-            const auto& threatPsqtAccumulation =
-              (threatAccumulatorState.acc<HalfDimensions>()).psqtAccumulation;
-            psqt = (psqt + threatPsqtAccumulation[perspectives[0]][bucket]
-                    - threatPsqtAccumulation[perspectives[1]][bucket])
-                 / 2;
-        }
-        else
-            psqt /= 2;
-
-        const auto& accumulation = (accumulatorState.acc<HalfDimensions>()).accumulation;
-        const auto& threatAccumulation =
-          (threatAccumulatorState.acc<HalfDimensions>()).accumulation;
+        const auto& accumulation = accumulatorState.accumulation;
 
         for (IndexType p = 0; p < 2; ++p)
         {
@@ -323,47 +310,6 @@ class FeatureTransformer {
             // 8 bits. Shifting it by 7 bits left will no longer occupy the
             // signed bit, so we are safe.
 
-            if constexpr (UseThreats)
-            {
-                const vec_t* tin0 =
-                  reinterpret_cast<const vec_t*>(&(threatAccumulation[perspectives[p]][0]));
-                const vec_t* tin1 = reinterpret_cast<const vec_t*>(
-                  &(threatAccumulation[perspectives[p]][HalfDimensions / 2]));
-                for (IndexType j = 0; j < NumOutputChunks; ++j)
-                {
-                    const vec_t acc0a = vec_add_16(in0[j * 2 + 0], tin0[j * 2 + 0]);
-                    const vec_t acc0b = vec_add_16(in0[j * 2 + 1], tin0[j * 2 + 1]);
-                    const vec_t acc1a = vec_add_16(in1[j * 2 + 0], tin1[j * 2 + 0]);
-                    const vec_t acc1b = vec_add_16(in1[j * 2 + 1], tin1[j * 2 + 1]);
-
-#if defined(USE_NEON)
-                    // The NEON path relies on unsigned saturation for crelu.
-                    static_assert(FtMaxVal == 255);
-
-                    const uint16x8_t mul0 = vmull_u8(vqmovun_s16(acc0a), vqmovun_s16(acc1a));
-                    const uint16x8_t mul1 = vmull_u8(vqmovun_s16(acc0b), vqmovun_s16(acc1b));
-
-                    const uint8x16x2_t uzp =
-                      vuzpq_u8(vreinterpretq_u8_u16(mul0), vreinterpretq_u8_u16(mul1));
-                    const uint8x16_t pab = vshrq_n_u8(uzp.val[1], 1);
-                    out[j] = reinterpret_cast<vec_t>(pab);
-#else
-                    const vec_t sum0a =
-                      vec_slli_16(vec_max_16(vec_min_16(acc0a, FtMax), Zero), shift);
-                    const vec_t sum0b =
-                      vec_slli_16(vec_max_16(vec_min_16(acc0b, FtMax), Zero), shift);
-                    const vec_t sum1a = vec_min_16(acc1a, FtMax);
-                    const vec_t sum1b = vec_min_16(acc1b, FtMax);
-
-                    const vec_t pa = vec_mulhi_16(sum0a, sum1a);
-                    const vec_t pb = vec_mulhi_16(sum0b, sum1b);
-
-                    out[j] = vec_packus_16(pa, pb);
-#endif
-                }
-            }
-            else
-            {
                 for (IndexType j = 0; j < NumOutputChunks; ++j)
                 {
 #if defined(USE_NEON)
@@ -393,7 +339,6 @@ class FeatureTransformer {
                     out[j] = vec_packus_16(pa, pb);
 #endif
                 }
-            }
 
 #else
 
@@ -403,12 +348,6 @@ class FeatureTransformer {
                 BiasType sum1 =
                   accumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
 
-                if constexpr (UseThreats)
-                {
-                    sum0 += threatAccumulation[static_cast<int>(perspectives[p])][j + 0];
-                    sum1 +=
-                      threatAccumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
-                }
 
                 sum0 = std::clamp<BiasType>(sum0, 0, FtMaxVal);
                 sum1 = std::clamp<BiasType>(sum1, 0, FtMaxVal);


### PR DESCRIPTION
### Motivation
- Apply the official Stockfish intent to store a single per-side accumulator that combines HalfKA + Threats to avoid repeated end-of-transform sums, reduce cache footprint and eliminate an extra accumulator load/store while preserving Revolution's single active NNUE topology. 
- Integrate the change via the R1 active-NNUE bridge so the active single-net invariants and interfaces remain the external contract.

### Description
- Combined HalfKA and Threats accumulator surfaces into a single `AccumulatorState` and replaced separate PSQ/Threat stacks with one `AccumulatorStack` holding `AccumulatorState` (kept `DirtyPiece` and `DirtyThreats` inside the combined state). 
- Implemented a unified incremental update path (`update_accumulator_incremental` + `apply_combined`) that applies PSQ and Threat delta updates together and a single refresh-cache path (`update_accumulator_refresh_cache`) to compute both simultaneously; `forward_update_incremental` / `backward_update_incremental` now operate on the combined stack. 
- Collapsed `ActivePSQAccumulatorState` and `ActiveThreatAccumulatorState` into the same combined alias while preserving the R1 aliases `ActiveFeatureTransformer`, `ActiveAccumulator`, `ActiveAccumulatorCache(s)` and `ActiveNetwork` as the integration surface. 
- Updated the feature transformer to read the already-combined accumulator directly (remove the final runtime sum of separate HalfKA + Threats) and adjust PSQT handling accordingly. 
- Files changed: `src/nnue/nnue_accumulator.cpp`, `src/nnue/nnue_accumulator.h`, `src/nnue/nnue_feature_transformer.h`.

### Testing
- Ran negative/invariant greps for forbidden surfaces with `rg` which returned no matches for `EvalFileSmall|NetworkSmall|nn-83a0d6daf7e5|MCTS|MonteCarlo`, and confirmed `nn-71d6d32cb962.nnue` is still referenced. (passed)
- Verified previous Jun6/Jun8/Jun9 endpoints and R1 bridge aliases (`ActiveTransformedFeatureDimensions`, `ActiveFeatureTransformer`, `ActiveNetwork`, `ActiveAccumulator*`) are present and coherent. (passed)
- Performed source hygiene check `git diff --check` (no problems). (passed)
- Built the engine: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` and the build completed successfully with `0` warnings and `0` errors. (passed)
- Ran config sanity: `make -C src config-sanity ARCH=x86-64-sse41-popcnt COMP=clang NNUE_EMBEDDING_OFF=yes` (passed)
- All automated validation checks completed successfully and the change set is limited to the three NNUE accumulator/transformer files listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cdcd5a4cc8327ac1a9c49e9dd4c88)