### PR TITLE
REVOLUTION-P0-SFDEV20260610-R3: apply do_move reorder and materialKey fix

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -818,18 +818,6 @@ void Position::do_move(Move                      m,
         k ^= Zobrist::castling[st->castlingRights];
     }
 
-    // Move the piece. The tricky Chess960 castling is handled earlier
-    if (m.type_of() != CASTLING)
-    {
-        if (captured && m.type_of() != EN_PASSANT)
-        {
-            remove_piece(from, &dts);
-            swap_piece(to, pc, &dts);
-        }
-        else
-            move_piece(from, to, &dts);
-    }
-
     // If the moving piece is a pawn do some special extra work
     if (type_of(pc) == PAWN)
     {
@@ -845,8 +833,6 @@ void Position::do_move(Move                      m,
             assert(relative_rank(us, to) == RANK_8);
             assert(type_of(promotion) >= KNIGHT && type_of(promotion) <= QUEEN);
 
-            swap_piece(to, promotion, &dts);
-
             dp.add_pc = promotion;
             dp.add_sq = to;
             dp.to     = SQ_NONE;
@@ -854,8 +840,8 @@ void Position::do_move(Move                      m,
             // Update hash keys
             // Zobrist::psq[pc][to] is zero, so we don't need to clear it
             k ^= Zobrist::psq[promotion][to];
-            st->materialKey ^= Zobrist::psq[promotion][8 + pieceCount[promotion] - 1]
-                             ^ Zobrist::psq[pc][8 + pieceCount[pc]];
+            st->materialKey ^= Zobrist::psq[promotion][8 + pieceCount[promotion]]
+                             ^ Zobrist::psq[pc][8 + pieceCount[pc] - 1];
             st->nonPawnKey[us] ^= Zobrist::psq[promotion][to];
 
             if (promotionType <= BISHOP)
@@ -891,6 +877,27 @@ void Position::do_move(Move                      m,
         prefetch(&history->minor_piece_correction_entry(*this));
         prefetch(&history->nonpawn_correction_entry<WHITE>(*this));
         prefetch(&history->nonpawn_correction_entry<BLACK>(*this));
+    }
+
+    // Move the piece. The tricky Chess960 castling is handled earlier
+    if (m.type_of() != CASTLING)
+    {
+        Piece toPc = pc;
+        if (m.type_of() == PROMOTION)
+            toPc = make_piece(us, m.promotion_type());
+
+        if (captured && m.type_of() != EN_PASSANT)
+        {
+            remove_piece(from, &dts);
+            swap_piece(to, toPc, &dts);
+        }
+        else if (pc == toPc)
+            move_piece(from, to, &dts);
+        else
+        {
+            remove_piece(from, &dts);
+            put_piece(toPc, to, &dts);
+        }
     }
 
     // Set capture piece
@@ -1517,7 +1524,7 @@ bool Position::material_key_is_ok() const { return compute_material_key() == st-
 // This is meant to be helpful when debugging.
 bool Position::pos_is_ok() const {
 
-    constexpr bool Fast = true;  // Quick (default) or full check?
+    constexpr bool Fast = false;  // fast or full check?
 
     if ((sideToMove != WHITE && sideToMove != BLACK) || piece_on(square<KING>(WHITE)) != W_KING
         || piece_on(square<KING>(BLACK)) != B_KING


### PR DESCRIPTION
### Motivation
- Apply Stockfish intent to reorder `Position::do_move` so TT/history prefetching happens earlier to improve performance while preserving Revolution semantics. 
- Correct the promotion `materialKey` indexing bug introduced by that reorder so material-key consistency is restored.
- Keep all Revolution invariants and avoid unrelated Stockfish changes (FEN/API/search/other commits).

### Description
- Reordered piece-list/board mutation in `Position::do_move` so key calculation and `tt`/`history` prefetches occur before the helpers that modify piece lists and bitboards; the actual mutation now happens after prefetch. (Only `src/position.cpp` changed.)
- Fixed promotion `materialKey` update to use the corrected indices: `Zobrist::psq[promotion][8 + pieceCount[promotion]] ^ Zobrist::psq[pc][8 + pieceCount[pc] - 1]` so the material key is computed correctly after the reorder.
- Preserved Revolution-specific behaviors including `DirtyPiece`/`DirtyThreats`, en-passant, `adjust_key50`/key50 semantics, castling, Syzygy handling, undo compatibility, and the R2 merged accumulator surface.
- Enabled the matching fuller `pos_is_ok()` checks (set `Fast = false`) to align debug consistency checks with the authority patch without changing public APIs.
- Did not apply Stockfish changes outside the coupled pair: `7b37032` (search stopping) and `5595cb2` (FEN validation/API) were explicitly not applied.

### Testing
- Authority verification and inspection commands (`git fetch` + `git show` on the two upstream commits) were executed and matched the intended surfaces; these checks passed.
- Source hygiene and invariant checks (`git diff --check`, negative invariant greps, endpoint greps for `materialKey`, `pieceCount`, `prefetch`, and `do_move`) were run and passed with no forbidden code introduced.
- Forbidden-surface diff verified no changes were made to `src/search.*`, `src/tt.cpp`, `src/history.h`, `src/Makefile`, `scripts/get_native_properties.sh`, or other disallowed files.
- Build: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld" NNUE_EMBEDDING_OFF=yes` completed successfully with `0` warnings and `0` errors.
- Config sanity: `make -C src config-sanity ARCH=x86-64-sse41-popcnt COMP=clang NNUE_EMBEDDING_OFF=yes` passed.
- Commit recorded with PR extraction created titled `REVOLUTION-P0-SFDEV20260610-R3: apply do_move reorder and materialKey fix` and only `src/position.cpp` changed.
- All automated validation steps succeeded (build and greps), so the coupled `do_move` reorder and `materialKey` fix were applied together as one atomic correctness patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2db5b719dc8327a393d4d6f5f9eb66)