### PR TITLE
REVOLUTION-P0-SFDEV20260610-R4: stop search when no better move is possible

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -566,8 +566,10 @@ void Search::Worker::iterative_deepening() {
 
             auto elapsedTime = elapsed();
 
-            // Stop the search if we have exceeded the totalTime or maximum
-            if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum())))
+            // Stop the search if we have exceeded totalTime or maximum time,
+            // or if we know that there are no better moves in the analysed line(s)
+            if (elapsedTime > std::min(totalTime, double(mainThread->tm.maximum()))
+                || rootMoves[multiPV - 1].score >= mate_in(3) || rootMoves[0].score == mated_in(2))
             {
                 // If we are allowed to ponder do not stop the search now but
                 // keep pondering until the GUI sends "ponderhit" or "stop".


### PR DESCRIPTION
### Motivation
- Implement the search-only intent of Stockfish commit `7b37032885b20d95472ef08fd38bad16f07ada25` so the main thread can stop time-managed searches early when it can prove no better move is possible (e.g., mate found or mated-in-1). 

### Description
- Add a time-management stop condition in `Search::Worker::iterative_deepening()` by extending the existing `elapsedTime` check in `src/search.cpp` with `|| rootMoves[multiPV - 1].score >= mate_in(3) || rootMoves[0].score == mated_in(2)`, and change only `src/search.cpp`.

### Testing
- Built the project with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=clang NNUE_EMBEDDING_OFF=yes` and ran `make -C src config-sanity`, both succeeded with zero warnings and zero errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9697e1d08327acff960362807c3b)