### PR TITLE
Revolution P0A: apply Stockfish Jun14 topology block

### DIFF
--- a/.github/workflows/matetrack.yml
+++ b/.github/workflows/matetrack.yml
@@ -7,9 +7,12 @@ jobs:
   Matetrack:
     name: Matetrack
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout SF repo 
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: Stockfish
@@ -20,11 +23,11 @@ jobs:
         run: make -j profile-build
 
       - name: Checkout matetrack repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: vondele/matetrack
           path: matetrack
-          ref: 2d96fa3373f90edb032b7ea7468473fb9e6f0343
+          ref: 1e7f6c6fff8e2f23923880a94fae596281346395
           persist-credentials: false
 
       - name: matetrack install deps
@@ -33,7 +36,7 @@ jobs:
 
       - name: cache syzygy
         id: cache-syzygy
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
            path: |
               matetrack/3-4-5-wdl/
@@ -47,17 +50,54 @@ jobs:
           wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-wdl/
           wget --no-verbose -r -nH --cut-dirs=2 --no-parent --reject="index.html*" -e robots=off https://tablebase.lichess.ovh/tables/standard/3-4-5-dtz/
 
+
+      # matecheck/python chess is not good at handling crashing engines. Do a basic check first.
+      - name: Test engine functionality
+        working-directory: Stockfish/src
+        run: |
+           python3 ../tests/instrumented.py --none ./stockfish
+
       - name: Run matetrack th1
         working-directory: matetrack
         run: |
-          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheckout1.out
-          ! grep "issues were detected" matecheckout1.out > /dev/null
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 | tee matecheck1.out
+          ! grep "issues were detected" matecheck1.out > /dev/null
 
       - name: Run matetrack th4
         working-directory: matetrack
         run: |
-          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 --threads 4 | tee matecheckout4.out
-          ! grep "issues were detected" matecheckout4.out > /dev/null
+          python matecheck.py --syzygyPath 3-4-5-wdl/:3-4-5-dtz/ --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --nodes 100000 --threads 4 | tee matecheck4.out
+          ! grep "issues were detected" matecheck4.out > /dev/null
+
+      - name: Run matetrack th4 gameplay
+        working-directory: matetrack
+        run: |
+          python matecheck.py --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile mates2000.epd --time 3 --timeinc 0.01 --threads 4 | tee matecheck4g.out
+          ! grep "issues were detected" matecheck4g.out > /dev/null
+
+      - name: Run matetrack th4 go-mate
+        working-directory: matetrack
+        run: |
+          python matecheck.py --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile matetrack.epd matedtrack.epd --bmMax 2 --mate 0 --threads 4 | tee matecheck4gm.out
+          ! grep "issues were detected" matecheck4gm.out > /dev/null
+          total=$(grep "Total FENs:" matecheck4gm.out | awk '{print $3}')
+          bmates=$(grep "Best mates:" matecheck4gm.out | awk '{print $3}')
+          if [ $bmates -ne $total ]; then
+            echo "At least one go-mate search did not yield expected mate, see matecheck4gm.out" >&2
+            exit 1
+          fi
+
+      - name: Run matetrack th1 multiPV
+        working-directory: matetrack
+        run: |
+          python matecheck.py --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile matetrack.epd matedtrack.epd --bmMax 10 --nodes 5000 --multiPV 20 --checkMultiPVs | tee matecheck1mpv.out
+          ! grep "issues were detected" matecheck1mpv.out > /dev/null
+
+      - name: Run matetrack th4 multiPV
+        working-directory: matetrack
+        run: |
+          python matecheck.py --engine /home/runner/work/Stockfish/Stockfish/Stockfish/src/stockfish --epdFile matetrack.epd matedtrack.epd --bmMax 10 --nodes 5000 --threads 4 --multiPV 20 --checkMultiPVs | tee matecheck4mpv.out
+          ! grep "issues were detected" matecheck4mpv.out > /dev/null
 
       - name: Run matetrack th1 with --syzygy50MoveRule false
         working-directory: matetrack

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -18,6 +18,7 @@
 
 #include "benchmark.h"
 #include "numa.h"
+#include "misc.h"
 
 #include <cstdlib>
 #include <fstream>
@@ -485,8 +486,8 @@ BenchmarkSetup setup_benchmark(std::istream& is) {
     for (const auto& game : BenchmarkPositions)
     {
         setup.commands.emplace_back("ucinewgame");
-        int ply = 1;
-        for (int i = 0; i < static_cast<int>(game.size()); ++i)
+        usize ply = 1;
+        for (usize i = 0; i < game.size(); ++i)
         {
             const float correctedTime = getCorrectedTime(ply);
             totalTime += correctedTime;

--- a/src/history.h
+++ b/src/history.h
@@ -132,7 +132,7 @@ using LowPlyHistory = Stats<i16, 7183, LOW_PLY_HISTORY_SIZE, UINT_16_HISTORY_SIZ
 using CapturePieceToHistory = Stats<i16, 10692, PIECE_NB, SQUARE_NB, PIECE_TYPE_NB>;
 
 // PieceToHistory is like ButterflyHistory but is addressed by a move's [piece][to]
-using PieceToHistory = Stats<i16, 30000, PIECE_NB, SQUARE_NB>;
+using PieceToHistory = AtomicStats<i16, 30000, PIECE_NB, SQUARE_NB>;
 
 // ContinuationHistory is the combined history of a given pair of moves, usually
 // the current one given a previous one. The nested history table is based on
@@ -250,6 +250,7 @@ struct SharedHistories {
     }
 
     UnifiedCorrectionHistory correctionHistory;
+    ContinuationHistory      continuationHistory[2][2];
     PawnHistory              pawnHistory;
 
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,6 +1,6 @@
 /*
   Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,13 +19,19 @@
 #include "memory.h"
 
 #include <cstdlib>
+#include <iostream>  // std::cerr
 
 #if __has_include("features.h")
     #include <features.h>
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__)
+    #include <errno.h>
     #include <sys/mman.h>
+    // IWYU pragma: no_include <bits/mman-map-flags-generic.h>
+    #include <cstring>
+    #include <mutex>
+    #include <map>
 #endif
 
 #if defined(__APPLE__) || defined(__ANDROID__) || defined(__OpenBSD__) \
@@ -45,9 +51,7 @@
         #define NOMINMAX
     #endif
 
-    #include <ios>       // std::hex, std::dec
-    #include <iostream>  // std::cerr
-    #include <ostream>   // std::endl
+    #include <ios>  // std::hex, std::dec
     #include <windows.h>
 
 // The needed Windows API for processor groups could be missed from old Windows
@@ -64,7 +68,7 @@ namespace Stockfish {
 // availability of aligned_alloc(). Memory allocated with std_aligned_alloc()
 // must be freed with std_aligned_free().
 
-void* std_aligned_alloc(size_t alignment, size_t size) {
+void* std_aligned_alloc(usize alignment, usize size) {
 #if defined(_ISOC11_SOURCE)
     return aligned_alloc(alignment, size);
 #elif defined(POSIXALIGNEDALLOC)
@@ -98,19 +102,19 @@ void std_aligned_free(void* ptr) {
 
 #if defined(_WIN32)
 
-static void* aligned_large_pages_alloc_windows([[maybe_unused]] size_t allocSize) {
+static void* aligned_large_pages_alloc_windows([[maybe_unused]] usize allocSize) {
 
     return windows_try_with_large_page_priviliges(
-      [&](size_t largePageSize) {
+      [&](usize largePageSize) {
           // Round up size to full pages and allocate
-          allocSize = (allocSize + largePageSize - 1) & ~size_t(largePageSize - 1);
+          allocSize = (allocSize + largePageSize - 1) & ~usize(largePageSize - 1);
           return VirtualAlloc(nullptr, allocSize, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES,
                               PAGE_READWRITE);
       },
       []() { return (void*) nullptr; });
 }
 
-void* aligned_large_pages_alloc(size_t allocSize) {
+void* aligned_large_pages_alloc_with_hint(usize allocSize, bool) {
 
     // Try to allocate large pages
     void* mem = aligned_large_pages_alloc_windows(allocSize);
@@ -124,17 +128,45 @@ void* aligned_large_pages_alloc(size_t allocSize) {
 
 #else
 
-void* aligned_large_pages_alloc(size_t allocSize) {
+    #if defined(__linux__) && defined(MAP_HUGE_SHIFT) && defined(__x86_64__)
+        #define HAS_HUGE_PAGES
+
+static std::map<void*, usize> huge_pages;
+static std::mutex             huge_pages_mtx;
+
+static void* try_huge_pages_alloc(usize allocSize) {
+    usize size = ((allocSize + HugePageSize - 1) / HugePageSize) * HugePageSize;
+    void* mem  = mmap(NULL, size, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | (30 << MAP_HUGE_SHIFT), -1, 0);
+
+    if (mem == MAP_FAILED)
+        return nullptr;
+
+    std::lock_guard lg(huge_pages_mtx);
+    huge_pages[mem] = size;
+    return mem;
+}
+    #endif  // defined(__linux__) && defined(MAP_HUGE_SHIFT) && defined(__x86_64__)
+
+void* aligned_large_pages_alloc_with_hint(usize allocSize, [[maybe_unused]] bool hugePageHint) {
+    #ifdef HAS_HUGE_PAGES
+    if (hugePageHint && allocSize >= HugePageSize)
+    {
+        void* mem = try_huge_pages_alloc(allocSize);
+        if (mem)
+            return mem;
+    }
+    #endif
 
     #if defined(__linux__)
-    constexpr size_t alignment = 2 * 1024 * 1024;  // 2MB page size assumed
+    constexpr usize alignment = 2 * 1024 * 1024;  // 2MB page size assumed
     #else
-    constexpr size_t alignment = 4096;  // small page size assumed
+    constexpr usize alignment = 4096;  // small page size assumed
     #endif
 
     // Round up to multiples of alignment
-    size_t size = ((allocSize + alignment - 1) / alignment) * alignment;
-    void*  mem  = std_aligned_alloc(alignment, size);
+    usize size = ((allocSize + alignment - 1) / alignment) * alignment;
+    void* mem  = std_aligned_alloc(alignment, size);
     #if defined(MADV_HUGEPAGE)
     madvise(mem, size, MADV_HUGEPAGE);
     #endif
@@ -143,12 +175,16 @@ void* aligned_large_pages_alloc(size_t allocSize) {
 
 #endif
 
+void* aligned_large_pages_alloc(usize size) {
+    return aligned_large_pages_alloc_with_hint(size, false);
+}
+
 bool has_large_pages() {
 
 #if defined(_WIN32)
 
-    constexpr size_t page_size = 2 * 1024 * 1024;  // 2MB page size assumed
-    void*            mem       = aligned_large_pages_alloc_windows(page_size);
+    constexpr usize page_size = 2 * 1024 * 1024;  // 2MB page size assumed
+    void*           mem       = aligned_large_pages_alloc_windows(page_size);
     if (mem == nullptr)
     {
         return false;
@@ -193,7 +229,26 @@ void aligned_large_pages_free(void* mem) {
 
 #else
 
-void aligned_large_pages_free(void* mem) { std_aligned_free(mem); }
+void aligned_large_pages_free(void* mem) {
+    if (!mem)
+        return;
+
+    #ifdef HAS_HUGE_PAGES
+    std::lock_guard lg(huge_pages_mtx);
+    if (auto it = huge_pages.find(mem); it != huge_pages.end())
+    {
+        if (munmap(mem, it->second) != 0)
+        {
+            std::cerr << "munmap failed: " << strerror(errno) << std::endl;
+            exit(EXIT_FAILURE);
+        }
+        huge_pages.erase(it);
+        return;
+    }
+    #endif
+
+    std_aligned_free(mem);
+}
 
 #endif
 }  // namespace Stockfish

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,6 +1,6 @@
 /*
   Stockfish, a UCI chess playing engine derived from Glaurung 2.1
-  Copyright (C) 2004-2025 The Stockfish developers (see AUTHORS file)
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -20,14 +20,15 @@
 #define MEMORY_H_INCLUDED
 
 #include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <new>
 #include <type_traits>
 #include <utility>
+#include <cstring>
 
 #include "types.h"
+#include "misc.h"
 
 #if defined(_WIN64)
 
@@ -40,6 +41,13 @@
         #define NOMINMAX
     #endif
     #include <windows.h>
+
+    // Some Windows headers (RPC/old headers) define short macros such
+    // as 'small' expanding to 'char', which breaks identifiers in the code.
+    // Undefine those macros immediately after including <windows.h>.
+    #ifdef small
+        #undef small
+    #endif
 
     #include <psapi.h>
 
@@ -54,11 +62,14 @@ using AdjustTokenPrivileges_t =
 
 namespace Stockfish {
 
-void* std_aligned_alloc(size_t alignment, size_t size);
+constexpr usize HugePageSize = usize(1) << 30;
+
+void* std_aligned_alloc(usize alignment, usize size);
 void  std_aligned_free(void* ptr);
 
 // Memory aligned by page size, min alignment: 4096 bytes
-void* aligned_large_pages_alloc(size_t size);
+void* aligned_large_pages_alloc_with_hint(usize size, bool hugePageHint);
+void* aligned_large_pages_alloc(usize size);
 void  aligned_large_pages_free(void* mem);
 
 bool has_large_pages();
@@ -86,15 +97,15 @@ void memory_deleter_array(T* ptr, FREE_FUNC free_func) {
 
 
     // Move back on the pointer to where the size is allocated
-    const size_t array_offset = std::max(sizeof(size_t), alignof(T));
-    char*        raw_memory   = reinterpret_cast<char*>(ptr) - array_offset;
+    const usize array_offset = std::max(sizeof(usize), alignof(T));
+    char*       raw_memory   = reinterpret_cast<char*>(ptr) - array_offset;
 
     if constexpr (!std::is_trivially_destructible_v<T>)
     {
-        const size_t size = *reinterpret_cast<size_t*>(raw_memory);
+        const usize size = *reinterpret_cast<usize*>(raw_memory);
 
         // Explicitly call the destructor for each element in reverse order
-        for (size_t i = size; i-- > 0;)
+        for (usize i = size; i-- > 0;)
             ptr[i].~T();
     }
 
@@ -113,19 +124,19 @@ inline std::enable_if_t<!std::is_array_v<T>, T*> memory_allocator(ALLOC_FUNC all
 // Allocates memory for an array of unknown bound and places it there with placement new
 template<typename T, typename ALLOC_FUNC>
 inline std::enable_if_t<std::is_array_v<T>, std::remove_extent_t<T>*>
-memory_allocator(ALLOC_FUNC alloc_func, size_t num) {
+memory_allocator(ALLOC_FUNC alloc_func, usize num) {
     using ElementType = std::remove_extent_t<T>;
 
-    const size_t array_offset = std::max(sizeof(size_t), alignof(ElementType));
+    const usize array_offset = std::max(sizeof(usize), alignof(ElementType));
 
     // Save the array size in the memory location
     char* raw_memory =
       reinterpret_cast<char*>(alloc_func(array_offset + num * sizeof(ElementType)));
     ASSERT_ALIGNED(raw_memory, alignof(T));
 
-    new (raw_memory) size_t(num);
+    new (raw_memory) usize(num);
 
-    for (size_t i = 0; i < num; ++i)
+    for (usize i = 0; i < num; ++i)
         new (raw_memory + array_offset + i * sizeof(ElementType)) ElementType();
 
     // Need to return the pointer at the start of the array so that
@@ -168,7 +179,7 @@ std::enable_if_t<!std::is_array_v<T>, LargePagePtr<T>> make_unique_large_page(Ar
 
 // make_unique_large_page for arrays of unknown bound
 template<typename T>
-std::enable_if_t<std::is_array_v<T>, LargePagePtr<T>> make_unique_large_page(size_t num) {
+std::enable_if_t<std::is_array_v<T>, LargePagePtr<T>> make_unique_large_page(usize num) {
     using ElementType = std::remove_extent_t<T>;
 
     static_assert(alignof(ElementType) <= 4096,
@@ -204,7 +215,7 @@ using AlignedPtr =
 // make_unique_aligned for single objects
 template<typename T, typename... Args>
 std::enable_if_t<!std::is_array_v<T>, AlignedPtr<T>> make_unique_aligned(Args&&... args) {
-    const auto func = [](size_t size) { return std_aligned_alloc(alignof(T), size); };
+    const auto func = [](usize size) { return std_aligned_alloc(alignof(T), size); };
     T*         obj  = memory_allocator<T>(func, std::forward<Args>(args)...);
 
     return AlignedPtr<T>(obj);
@@ -212,10 +223,10 @@ std::enable_if_t<!std::is_array_v<T>, AlignedPtr<T>> make_unique_aligned(Args&&.
 
 // make_unique_aligned for arrays of unknown bound
 template<typename T>
-std::enable_if_t<std::is_array_v<T>, AlignedPtr<T>> make_unique_aligned(size_t num) {
+std::enable_if_t<std::is_array_v<T>, AlignedPtr<T>> make_unique_aligned(usize num) {
     using ElementType = std::remove_extent_t<T>;
 
-    const auto   func   = [](size_t size) { return std_aligned_alloc(alignof(ElementType), size); };
+    const auto   func   = [](usize size) { return std_aligned_alloc(alignof(ElementType), size); };
     ElementType* memory = memory_allocator<T>(func, num);
 
     return AlignedPtr<T>(memory);
@@ -246,7 +257,7 @@ auto windows_try_with_large_page_priviliges([[maybe_unused]] FuncYesT&& fyes, Fu
     HANDLE hProcessToken{};
     LUID   luid{};
 
-    const size_t largePageSize = GetLargePageMinimum();
+    const usize largePageSize = GetLargePageMinimum();
     if (!largePageSize)
         return fno();
 
@@ -309,6 +320,17 @@ auto windows_try_with_large_page_priviliges([[maybe_unused]] FuncYesT&& fyes, Fu
 }
 
 #endif
+
+template<typename T, typename ByteT>
+T load_as(const ByteT* buffer) {
+    static_assert(std::is_trivially_copyable<T>::value, "Type must be trivially copyable");
+    static_assert(sizeof(ByteT) == 1);
+
+    T value;
+    std::memcpy(&value, buffer, sizeof(T));
+
+    return value;
+}
 
 }  // namespace Stockfish
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -342,7 +342,7 @@ template<typename T>
 class RelaxedAtomic {
     static constexpr bool UseAtomic =
 #ifdef USE_SLOPPY_ATOMICS
-      !std::atomic<T>::is_always_lock_free || sizeof(T) > sizeof(size_t);
+      !std::atomic<T>::is_always_lock_free || sizeof(T) > sizeof(usize);
 #else
       true;
 #endif
@@ -366,7 +366,7 @@ class RelaxedAtomic {
 
     operator T() const { return load(std::memory_order_relaxed); }
 
-    RelaxedAtomic& operator+=(int val) {
+    RelaxedAtomic& operator+=(T val) {
         store(load(std::memory_order_relaxed) + val, std::memory_order_relaxed);
         return *this;
     }
@@ -393,7 +393,7 @@ class RelaxedAtomic {
         return val;
     }
 
-    RelaxedAtomic& operator-=(int val) {
+    RelaxedAtomic& operator-=(T val) {
         store(load(std::memory_order_relaxed) - val, std::memory_order_relaxed);
         return *this;
     }

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -20,8 +20,8 @@
 #define MOVEGEN_H_INCLUDED
 
 #include <algorithm>  // IWYU pragma: keep
-#include <cstddef>
 
+#include "misc.h"
 #include "types.h"
 
 namespace Stockfish {
@@ -61,7 +61,7 @@ struct MoveList {
         last(generate<T>(pos, moveList)) {}
     const Move* begin() const { return moveList; }
     const Move* end() const { return last; }
-    size_t      size() const { return last - moveList; }
+    usize       size() const { return last - moveList; }
     bool        contains(Move move) const { return std::find(begin(), end(), move) != end(); }
 
    private:

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -295,8 +295,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
                                          const DiffType&         diff,
                                          IndexList&              removed,
                                          IndexList&              added,
-                                         FusedUpdateData*        fusedData,
-                                         bool                    first,
                                          const ThreatWeightType* prefetchBase,
                                          IndexType               prefetchStride) {
 
@@ -307,37 +305,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
         auto from     = dirty.pc_sq();
         auto to       = dirty.threatened_sq();
         auto add      = dirty.add();
-
-        if (fusedData)
-        {
-            if (from == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedOriginBoard |= to;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedOriginBoard & to)
-                    continue;
-            }
-
-            if (to != SQ_NONE && to == fusedData->dp2removed)
-            {
-                if (add)
-                {
-                    if (first)
-                    {
-                        fusedData->dp2removedTargetBoard |= from;
-                        continue;
-                    }
-                }
-                else if (fusedData->dp2removedTargetBoard & from)
-                    continue;
-            }
-        }
 
         auto&           insert = add ? added : removed;
         const IndexType index  = make_index(perspective, attacker, from, to, attacked, ksq);
@@ -350,10 +317,6 @@ void FullThreats::append_changed_indices(Color                   perspective,
             insert.push_back(index);
         }
     }
-}
-
-bool FullThreats::requires_refresh(const DiffType& diff, Color perspective) {
-    return perspective == diff.us && (i8(diff.ksq) & 0b100) != (i8(diff.prevKsq) & 0b100);
 }
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -13,7 +13,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features Simplified_Threats of NNUE evaluation function
+//Definition of input features Full_Threats of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_FULL_THREATS_INCLUDED
 #define NNUE_FEATURES_FULL_THREATS_INCLUDED
@@ -34,9 +34,6 @@ static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 0, 0,
 
 class FullThreats {
    public:
-    // Feature name
-    static constexpr const char* Name = "Full_Threats(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr u32 HashValue = 0x8f234cb8u;
 
@@ -66,13 +63,6 @@ class FullThreats {
     };
     // clang-format on
 
-    struct FusedUpdateData {
-        Bitboard dp2removedOriginBoard = 0;
-        Bitboard dp2removedTargetBoard = 0;
-
-        Square dp2removed;
-    };
-
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 128;
     using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
@@ -90,14 +80,8 @@ class FullThreats {
                                        const DiffType&         diff,
                                        IndexList&              removed,
                                        IndexList&              added,
-                                       FusedUpdateData*        fd             = nullptr,
-                                       bool                    first          = false,
                                        const ThreatWeightType* prefetchBase   = nullptr,
                                        IndexType               prefetchStride = 0);
-
-    // Returns whether the change stored in this DirtyPiece means
-    // that a full accumulator refresh is required.
-    static bool requires_refresh(const DiffType& diff, Color perspective);
 };
 
 }  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -20,10 +20,12 @@
 
 #include "half_ka_v2_hm.h"
 
-#include "../../bitboard.h"
-#include "../../position.h"
 #include "../../types.h"
 #include "../nnue_common.h"
+
+#if defined(USE_AVX512ICL)
+    #include "../../bitboard.h"
+#endif
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -33,18 +35,6 @@ IndexType HalfKAv2_hm::make_index(Color perspective, Square s, Piece pc, Square 
     const IndexType flip = 56 * perspective;
     return (IndexType(s) ^ OrientTBL[ksq] ^ flip) + PieceSquareIndex[perspective][pc]
          + KingBuckets[int(ksq) ^ flip];
-}
-
-// Get a list of indices for active features
-
-void HalfKAv2_hm::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
-    Square   ksq = pos.square<KING>(perspective);
-    Bitboard bb  = pos.pieces();
-    while (bb)
-    {
-        Square s = pop_lsb(bb);
-        active.push_back(make_index(perspective, s, pos.piece_on(s), ksq));
-    }
 }
 
 // Get a list of indices for recently changed features

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -16,7 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-//Definition of input features HalfKP of NNUE evaluation function
+//Definition of input features HalfKAv2_hm of NNUE evaluation function
 
 #ifndef NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
 #define NNUE_FEATURES_HALF_KA_V2_HM_H_INCLUDED
@@ -24,10 +24,6 @@
 #include "../../misc.h"
 #include "../../types.h"
 #include "../nnue_common.h"
-
-namespace Stockfish {
-class Position;
-}
 
 namespace Stockfish::Eval::NNUE::Features {
 
@@ -61,9 +57,6 @@ class HalfKAv2_hm {
        PS_NONE, PS_W_PAWN, PS_W_KNIGHT, PS_W_BISHOP, PS_W_ROOK, PS_W_QUEEN, PS_KING, PS_NONE}};
 
    public:
-    // Feature name
-    static constexpr const char* Name = "HalfKAv2_hm(Friend)";
-
     // Hash value embedded in the evaluation file
     static constexpr u32 HashValue = 0x7f234cb8u;
 
@@ -107,10 +100,6 @@ class HalfKAv2_hm {
     // Index of a feature for a given king position and another piece on some square
 
     static IndexType make_index(Color perspective, Square s, Piece pc, Square ksq);
-
-    // Get a list of indices for active features
-
-    static void append_active_indices(Color perspective, const Position& pos, IndexList& active);
 
     // Get a list of indices for recently changed features
     static void append_changed_indices(

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -358,13 +358,13 @@ void update_accumulator_incremental(Color                     perspective,
     if constexpr (Forward)
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
-                                                 thrAdded, nullptr, false, pfBase, pfStride);
+                                                 thrAdded, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
-                                                 thrRemoved, nullptr, false, pfBase, pfStride);
+                                                 thrRemoved, pfBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -60,10 +60,8 @@ constexpr u32 Version = 0x6A448AFAu;
 // Constant used in evaluation value calculation
 constexpr int OutputScale     = 16;
 constexpr int WeightScaleBits = 6;
-constexpr int FtOneVal        = 256;
 constexpr int FtMaxVal        = 255;
 constexpr int HiddenOneVal    = 128;
-constexpr int HiddenMaxVal    = 127;
 
 // Size of cache line (in bytes)
 constexpr usize CacheLineSize = 64;

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -166,8 +166,7 @@ inline __m128i _mm_cvtsi64_si128(i64 val) {
         #ifdef __wasm__
             #define vec_convert_8_16(a) wasm_i16x8_load8x8(reinterpret_cast<const void*>(&a))
         #else
-            #define vec_convert_8_16(a) \
-                _mm_cvtepi8_epi16(_mm_cvtsi64_si128(static_cast<int64_t>(a)))
+            #define vec_convert_8_16(a) _mm_cvtepi8_epi16(_mm_cvtsi64_si128(static_cast<i64>(a)))
         #endif
     #else
 // Credit: Yoshie2000

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -731,12 +731,10 @@ void Position::do_move(Move                      m,
 
     bool checkEP = false;
 
-    dp.pc             = pc;
-    dp.from           = from;
-    dp.to             = to;
-    dp.add_sq         = SQ_NONE;
-    dts.us            = us;
-    dts.prevKsq       = square<KING>(us);
+    dp.pc     = pc;
+    dp.from   = from;
+    dp.to     = to;
+    dp.add_sq = SQ_NONE;
 
     assert(color_of(pc) == us);
     assert(captured == NO_PIECE || color_of(captured) == (m.type_of() != CASTLING ? them : us));
@@ -987,8 +985,6 @@ void Position::do_move(Move                      m,
         }
     }
 
-    dts.ksq = square<KING>(us);
-
     assert(pos_is_ok());
 
     assert(dp.pc != NO_PIECE);
@@ -1118,16 +1114,46 @@ void Position::update_piece_threats(Piece                     pc,
     const Bitboard occupied     = pieces();
     const Bitboard rookQueens   = pieces(ROOK, QUEEN);
     const Bitboard bishopQueens = pieces(BISHOP, QUEEN);
-    const Bitboard knights      = pieces(KNIGHT);
+    const Bitboard rAttacks     = attacks_bb<ROOK>(s, occupied);
+    const Bitboard bAttacks     = attacks_bb<BISHOP>(s, occupied);
     const Bitboard kings        = pieces(KING);
-    const Bitboard whitePawns   = pieces(WHITE, PAWN);
-    const Bitboard blackPawns   = pieces(BLACK, PAWN);
+    Bitboard       occupiedNoK  = occupied ^ kings;
 
-    const Bitboard rAttacks = attacks_bb<ROOK>(s, occupied);
-    const Bitboard bAttacks = attacks_bb<BISHOP>(s, occupied);
+    Bitboard sliders         = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
+    auto     process_sliders = [&](bool addDirectAttacks) {
+        while (sliders)
+        {
+            Square sliderSq = pop_lsb(sliders);
+            Piece  slider   = piece_on(sliderSq);
 
-    Bitboard threatened = attacks_bb(pc, s, occupied) & occupied;
-    Bitboard sliders    = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
+            const Bitboard ray        = RayPassBB[sliderSq][s] & ~BetweenBB[sliderSq][s];
+            const Bitboard discovered = ray & (rAttacks | bAttacks) & occupiedNoK;
+
+            assert(!more_than_one(discovered));
+            if (discovered && (ray & noRaysContaining) != noRaysContaining)
+            {
+                const Square threatenedSq = lsb(discovered);
+                const Piece  threatenedPc = piece_on(threatenedSq);
+                add_dirty_threat(dts, !putPiece, slider, threatenedPc, sliderSq, threatenedSq);
+            }
+
+            if (addDirectAttacks)
+                add_dirty_threat(dts, putPiece, slider, pc, sliderSq, s);
+        }
+    };
+
+    if (type_of(pc) == KING)
+    {
+        if constexpr (ComputeRay)
+            process_sliders(false);
+        return;
+    }
+
+    const Bitboard knights    = pieces(KNIGHT);
+    const Bitboard whitePawns = pieces(WHITE, PAWN);
+    const Bitboard blackPawns = pieces(BLACK, PAWN);
+
+    Bitboard threatened = attacks_bb(pc, s, occupied) & occupiedNoK;
     Bitboard incoming_threats =
       (PseudoAttacks[KNIGHT][s] & knights) | (PseudoAttacks[KING][s] & kings);
 
@@ -1176,32 +1202,9 @@ void Position::update_piece_threats(Piece                     pc,
 #endif
 
     if constexpr (ComputeRay)
-    {
-        while (sliders)
-        {
-            Square sliderSq = pop_lsb(sliders);
-            Piece  slider   = piece_on(sliderSq);
-
-            const Bitboard ray        = RayPassBB[sliderSq][s] & ~BetweenBB[sliderSq][s];
-            const Bitboard discovered = ray & (rAttacks | bAttacks) & occupied;
-
-            assert(!more_than_one(discovered));
-            if (discovered && (RayPassBB[sliderSq][s] & noRaysContaining) != noRaysContaining)
-            {
-                const Square threatenedSq = lsb(discovered);
-                const Piece  threatenedPc = piece_on(threatenedSq);
-                add_dirty_threat(dts, !putPiece, slider, threatenedPc, sliderSq, threatenedSq);
-            }
-
-#ifndef USE_AVX512ICL  // for ICL, direct threats were processed earlier (all_attackers)
-            add_dirty_threat(dts, putPiece, slider, pc, sliderSq, s);
-#endif
-        }
-    }
+        process_sliders(true);
     else
-    {
         incoming_threats |= sliders;
-    }
 
 #ifndef USE_AVX512ICL
     while (incoming_threats)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -161,6 +161,7 @@ Search::Worker::Worker(SharedState&                    sharedState,
                        NumaReplicatedAccessToken       token) :
     // Unpack the SharedState struct into member variables
     sharedHistory(sharedState.sharedHistories.at(token.get_numa_index())),
+    continuationHistory(sharedHistory.continuationHistory),
     threadIdx(threadId),
     numaThreadIdx(numaThreadId),
     numaTotal(numaTotalThreads),
@@ -271,9 +272,9 @@ void Search::Worker::iterative_deepening() {
 
     Move pv[MAX_PLY + 1];
 
-    Depth            lastBestMoveDepth = 0;
-    Value            lastIterationScore = -VALUE_INFINITE;
-    std::vector<Move> lastIterationPV;
+    std::vector<Move> lastBestMovePV;
+    Depth             lastBestMoveDepth = 0;
+    Value             lastBestMoveScore = -VALUE_INFINITE;
 
     Value  alpha, beta;
     Value  bestValue     = -VALUE_INFINITE;
@@ -336,10 +337,11 @@ void Search::Worker::iterative_deepening() {
 
         // Save the last iteration's scores before the first PV line is searched and
         // all the move scores except the (new) PV are set to -VALUE_INFINITE.
-        for (RootMove& rm : rootMoves)
+        for (usize i = 0; i < rootMoves.size(); ++i)
         {
-            rm.previousScore = rm.score;
-            rm.previousPV    = rm.pv;
+            rootMoves[i].previousScore      = rootMoves[i].score;
+            rootMoves[i].previousPV         = rootMoves[i].pv;
+            rootMoves[i].previousScoreExact = i < multiPV;
         }
 
         usize pvFirst = 0;
@@ -431,36 +433,52 @@ void Search::Worker::iterative_deepening() {
                 assert(alpha >= -VALUE_INFINITE && beta <= VALUE_INFINITE);
             }
 
-            // In multiPV analysis we do not let aborted searches spoil mated-in/
-            // TB loss scores from a completed search in an earlier PV line.
-            if (threads.stop && pvIdx
-                && ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
-                    || rootMoves[pvIdx].score_is_exact_loss()))
+            if (threads.stop && pvIdx)
             {
-                if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
-                    && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
+                // In multiPV analysis we do not let aborted searches spoil mated-in/
+                // TB loss scores from a completed search in an earlier PV line.
+                // Hence we guard against an aborted pvIdx line overtaking pvIdx - 1
+                // when pvIdx - 1 is a proven loss.
+                // Moreover, we do not trust an exact loss score from an aborted search.
+                if ((is_loss(rootMoves[pvIdx - 1].score) && rootMoves[pvIdx] < rootMoves[pvIdx - 1])
+                    || rootMoves[pvIdx].score_is_exact_loss())
                 {
-                    rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
-                      rootMoves[pvIdx].previousScore;
-                    rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
-                    rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
-                    rootMoves[pvIdx].unset_bound_flags();
-                }
-                else
-                {
-                    if (is_loss(rootMoves[pvIdx - 1].score))
+                    // If previousScore is exact and worse than pvIdx - 1, we can safely use it.
+                    // If it is equal, we make sure it cannot overtake pvIdx - 1.
+                    if (rootMoves[pvIdx].previousScore != -VALUE_INFINITE
+                        && rootMoves[pvIdx].previousScoreExact
+                        && rootMoves[pvIdx].previousScore <= rootMoves[pvIdx - 1].score)
                     {
                         rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
-                          rootMoves[pvIdx - 1].score;
+                          rootMoves[pvIdx].previousScore;
                         rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
-                        rootMoves[pvIdx].pv.resize(1);
-                        rootMoves[pvIdx].scoreUpperbound = true;
+                        rootMoves[pvIdx].pv            = rootMoves[pvIdx].previousPV;
+                        rootMoves[pvIdx].unset_bound_flags();
                     }
-                    else
-                        rootMoves[pvIdx].scoreUpperbound = false;
 
-                    rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                    // Otherwise, if we can, we cap the score to the best possible, and mark
+                    // the score as a bound (also a valid excuse for the incomplete PV.)
+                    else
+                    {
+                        if (is_loss(rootMoves[pvIdx - 1].score))
+                        {
+                            rootMoves[pvIdx].score = rootMoves[pvIdx].uciScore =
+                              rootMoves[pvIdx - 1].score;
+                            rootMoves[pvIdx].previousScore = -VALUE_INFINITE;
+                            rootMoves[pvIdx].pv.resize(1);
+                            rootMoves[pvIdx].scoreUpperbound = true;
+                        }
+                        else
+                            rootMoves[pvIdx].scoreUpperbound = false;
+
+                        rootMoves[pvIdx].scoreLowerbound = !rootMoves[pvIdx].scoreUpperbound;
+                    }
                 }
+
+                // Finally, we mark all loss scores from partially searched moves as a bound.
+                for (usize i = pvIdx + 1; i < multiPV; ++i)
+                    if (rootMoves[i].score_is_exact_loss())
+                        rootMoves[i].scoreLowerbound = true;
             }
 
             // Sort the PV lines searched so far and update the GUI
@@ -473,23 +491,23 @@ void Search::Worker::iterative_deepening() {
                 break;
         }
 
-        const bool forgottenMate = lastIterationScore != -VALUE_INFINITE
-                                && is_mate_or_mated(lastIterationScore)
-                                && (std::abs(rootMoves[0].score) < std::abs(lastIterationScore)
+        const bool forgottenMate = lastBestMoveScore != -VALUE_INFINITE
+                                && is_mate_or_mated(lastBestMoveScore)
+                                && (std::abs(rootMoves[0].score) < std::abs(lastBestMoveScore)
                                     || rootMoves[0].score_is_bound());
 
         if (!threads.stop)
         {
             completedDepth = rootDepth;
 
-            if (lastIterationPV.empty() || rootMoves[0].pv[0] != lastIterationPV[0])
+            if (lastBestMovePV.empty() || lastBestMovePV[0] != rootMoves[0].pv[0])
                 lastBestMoveDepth = rootDepth;
 
             // Do not replace shorter mate scores from a previous iteration.
             if (!forgottenMate)
             {
-                lastIterationPV    = rootMoves[0].pv;
-                lastIterationScore = rootMoves[0].score;
+                lastBestMovePV    = rootMoves[0].pv;
+                lastBestMoveScore = rootMoves[0].score;
             }
         }
 
@@ -502,14 +520,15 @@ void Search::Worker::iterative_deepening() {
         // in a previous iteration.
         if (abortedLossSearch || (rootMoves[0].score != -VALUE_INFINITE && forgottenMate))
         {
-            if (!lastIterationPV.empty())
+            // Bring the last best move to the front for best thread selection.
+            if (!lastBestMovePV.empty())
             {
-                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastIterationPV)](
+                Utility::move_to_front(rootMoves, [&lastPV = std::as_const(lastBestMovePV)](
                                                     const auto& rm) { return rm == lastPV[0]; });
-
-                rootMoves[0].pv    = lastIterationPV;
-                rootMoves[0].score = rootMoves[0].uciScore = lastIterationScore;
+                rootMoves[0].score = rootMoves[0].uciScore = lastBestMoveScore;
+                rootMoves[0].pv                            = lastBestMovePV;
                 rootMoves[0].unset_bound_flags();
+
             }
             else if (abortedLossSearch)
                 rootMoves[0].scoreLowerbound = true;

--- a/src/search.h
+++ b/src/search.h
@@ -99,16 +99,17 @@ struct RootMove {
     }
     void unset_bound_flags() { scoreLowerbound = scoreUpperbound = false; }
 
-    u64          effort           = 0;
-    Value             score            = -VALUE_INFINITE;
-    Value             previousScore    = -VALUE_INFINITE;
-    Value             averageScore     = -VALUE_INFINITE;
-    Value             meanSquaredScore = -VALUE_INFINITE * VALUE_INFINITE;
-    Value             uciScore         = -VALUE_INFINITE;
-    bool              scoreLowerbound  = false;
-    bool              scoreUpperbound  = false;
-    int               selDepth         = 0;
-    int               tbRank           = 0;
+    u64               effort             = 0;
+    Value             score              = -VALUE_INFINITE;
+    Value             previousScore      = -VALUE_INFINITE;
+    Value             averageScore       = -VALUE_INFINITE;
+    Value             meanSquaredScore   = -VALUE_INFINITE * VALUE_INFINITE;
+    Value             uciScore           = -VALUE_INFINITE;
+    bool              scoreLowerbound    = false;
+    bool              scoreUpperbound    = false;
+    bool              previousScoreExact = false;
+    int               selDepth           = 0;
+    int               tbRank             = 0;
     Value             tbScore;
     std::vector<Move> pv, previousPV;
 };
@@ -304,11 +305,11 @@ class Worker {
     LowPlyHistory    lowPlyHistory;
 
     CapturePieceToHistory           captureHistory;
-    ContinuationHistory             continuationHistory[2][2];
     CorrectionHistory<Continuation> continuationCorrectionHistory;
 
     TTMoveHistory    ttMoveHistory;
     SharedHistories& sharedHistory;
+    ContinuationHistory (&continuationHistory)[2][2];
 
    private:
     void iterative_deepening();

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -37,7 +37,7 @@ namespace Stockfish {
 class NativeThread {
     pthread_t thread;
 
-    static constexpr size_t TH_STACK_SIZE = 8 * 1024 * 1024;
+    static constexpr usize TH_STACK_SIZE = 8 * 1024 * 1024;
 
    public:
     template<class Function, class... Args>

--- a/src/tune.h
+++ b/src/tune.h
@@ -19,12 +19,13 @@
 #ifndef TUNE_H_INCLUDED
 #define TUNE_H_INCLUDED
 
-#include <cstddef>
 #include <memory>
 #include <string>
 #include <type_traits>  // IWYU pragma: keep
 #include <utility>
 #include <vector>
+
+#include "misc.h"
 
 namespace Stockfish {
 
@@ -132,9 +133,9 @@ class Tune {
     }
 
     // Template specialization for arrays: recursively handle multi-dimensional arrays
-    template<typename T, size_t N, typename... Args>
+    template<typename T, usize N, typename... Args>
     int add(const SetRange& range, std::string&& names, T (&value)[N], Args&&... args) {
-        for (size_t i = 0; i < N; i++)
+        for (usize i = 0; i < N; i++)
             add(range, next(names, i == N - 1) + "[" + std::to_string(i) + "]", value[i]);
         return add(range, std::move(names), args...);
     }

--- a/src/types.h
+++ b/src/types.h
@@ -391,9 +391,6 @@ using DirtyThreatList = ValueList<DirtyThreat, 96>;
 
 struct DirtyThreats {
     DirtyThreatList list;
-    Color           us;
-    Square          prevKsq, ksq;
-
 };
 
     #define ENABLE_INCR_OPERATORS_ON(T) \


### PR DESCRIPTION
### Motivation
- Bring Revolution up-to-date with the audited Stockfish dev block from 2026-06-14 while preserving Revolution-specific topology (branding, active NNUE net, Book/Experience/Zobrist, attacks topology and local NNUE merge). 
- Apply only the safe, per-commit changes from the upstream DAG in the real chronological order, and document any upstream cleanup that did not fully apply to the local topology.

### Description
- Applied the seven Jun 14 upstream changes in upstream/master chronological order and resolved local topology conflicts; created a single commit `P0A-SF20260614: apply type NNUE threats and MultiPV updates` on branch `codex/revolution-p0a-sf20260614` (HEAD final `610b5d5c`).
- Commit-by-commit summary: `0dc19b61` (matetrack CI) — APPLIED (workflow updated but retained Revolution CI context); `718a001e` (RelaxedAtomic operator types) — APPLIED (operators now use template `T` in `src/misc.h`); `6e4e03fd` (replace remaining types) — APPLIED (selected size/type replacements to `usize`/aliases, added includes where needed); `ed8e35d7` (remove unused NNUE post-accumulator code) — PARTIAL WITH JUSTIFICATION (removed obsolete fused/unused blocks in FullThreats and related headers while preserving Revolution-only fields and `do_move`/`checkEP` behavior required by local topology); `f9beec5f` (reuse computed ray bitboard) — APPLIED (refactored `update_piece_threats` to reuse computed ray and preserved `RayPassBB/BetweenBB` integration); `f9b002cf` (share continuation history) — APPLIED (Worker now binds `continuationHistory` to NUMA `SharedHistories`); `74a0a737` (final MultiPV mate PV fix) — APPLIED (added `previousScoreExact`/previous-score handling and robust capping/rollback logic in `src/search.*`).
- Key technical edits: unify integer aliases to local `usize` where upstream intended, fix `RelaxedAtomic` operator signatures, update matetrack workflow file `.github/workflows/matetrack.yml`, prune unused NNUE fused-data paths in `src/nnue/features/*`, reuse computed ray in `src/position.cpp::update_piece_threats`, share continuation history via `SharedHistories` in `src/search.*`/`src/history.h`, and incorporate MultiPV mate/PV corner-case logic and related data members in `src/search.h`/`src/search.cpp`.
- Notably preserved: `ENGINE_BASENAME = Revolution`, `RELEASE_TAG = 5.90-140626`, active NNUE net `nn-71d6d32cb962.nnue`, Book/CTG/BIN, Experience/learning, Zobrist, attacks topology and the NNUE accumulator merge introduced earlier in Jun10; no Jun25+ changes or net swaps were applied.

### Testing
- Ran repository forensic/audit commands and upstream chronology check (`git fetch upstream master --tags` and `git log --reverse --oneline upstream/master --since="2026-06-14" --until="2026-06-15"`) and confirmed the seven Jun14 commits were present and applied.
- Ran static searches/grep validations for required symbols and preserved items (`rg` queries for Revolution, EvalFileDefaultName, Experience, RelaxedAtomic, previousScoreExact, continuationHistory, update_piece_threats, RayPassBB/BetweenBB/LineBB, Zobrist) and validated presence/updates as expected.
- Built the engine with the mandated target: `make -C src -j build ARCH=x86-64-sse41-popcnt COMP=gcc` and the build completed successfully with the embedded `nn-71d6d32cb962.nnue` network validated and used.
- Executed runtime smoke and functional checks using the produced binary `src/Revolution-5.90-140626-sse41popcnt`: the benchmark command (`bench 16 1 8 default depth`) ran and reported nodes/nps; MultiPV UCI smoke (`setoption name MultiPV value 3` then `go depth 8`) completed and returned `bestmove` without crash; UCI handshake returned `uciok`/`readyok`.
- Executed the FEN corner-case checks specified (pawn on rank 1 and rank 8) and both produced valid responses (engine did not crash and returned moves). 
- All automated checks listed in the procedure (diff checks, `git diff --check`, `make clean` + `make`, bench, MultiPV and FEN smoke tests) passed; resulting tree is committed and `git status` is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487471760c83278e836751147e1184)