### PR TITLE
Revolution P0B: apply Stockfish Jun25 TT prefetch, ProbCut, NNUE and validation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This release applies the accepted Stockfish development topology dated 2026-06-0
 - **June 9:** WebAssembly targets, `RelaxedAtomic`, `previousPV` and MultiPV mate-PV correction, plus the timeout harness where applicable.
 - **June 10:** NNUE active-bridge preparation; the HalfKA/Threats accumulator merge; `do_move` reordering with the `materialKey` correction; the stop-search condition when no better move is possible; and Revolution-compatible FEN pawn-rank validation for ranks 1 and 8.
 
-The active NNUE authority remains `nn-71d6d32cb962.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
+The active NNUE authority remains `nn-f8a759c05f9f.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.90-140626
 
-NNUE_NET = nn-71d6d32cb962.nnue
+NNUE_NET = nn-f8a759c05f9f.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
+#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -56,8 +56,6 @@ class MovePicker {
     Move select(Pred);
     template<GenType T>
     ExtMove* score(MoveList<T>&);
-    ExtMove* begin() { return cur; }
-    ExtMove* end() { return endCur; }
 
     const Position&              pos;
     const ButterflyHistory*      mainHistory;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,6 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultName "nn-71d6d32cb962.nnue"
+#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -619,26 +619,8 @@ bool Position::pseudo_legal(const Move m) const {
     else if (!(attacks_bb(type_of(pc), from, pieces()) & to))
         return false;
 
-    // Evasions generator already takes care to avoid some kind of illegal moves
-    // and legal() relies on this. We therefore have to take care that the same
-    // kind of moves are filtered out here.
     if (checkers())
-    {
-        if (type_of(pc) != KING)
-        {
-            // Double check? In this case, a king move is required
-            if (more_than_one(checkers()))
-                return false;
-
-            // Our move must be a blocking interposition or a capture of the checking piece
-            if (!(between_bb(square<KING>(us), lsb(checkers())) & to))
-                return false;
-        }
-        // In case of king moves under check we have to remove the king so as to catch
-        // invalid moves like b1a1 when opposite queen is on c1.
-        else if (attackers_to_exist(to, pieces() ^ from, ~us))
-            return false;
-    }
+        return MoveList<EVASIONS>(*this).contains(m);
 
     return true;
 }
@@ -1220,6 +1202,21 @@ void Position::update_piece_threats(Piece                     pc,
 #endif
 }
 
+Key Position::prefetch_key(Move m) const {
+    Square from     = m.from_sq();
+    Square to       = m.to_sq();
+    Piece  pc       = piece_on(from);
+    Piece  captured = piece_on(to);
+    Key    k        = st->key ^ Zobrist::side;
+
+    k ^= Zobrist::psq[captured][to] ^ Zobrist::psq[pc][to] ^ Zobrist::psq[pc][from];
+
+    if (captured || type_of(pc) == PAWN)
+        return k;
+
+    return adjust_key50<true>(k);
+}
+
 // Helper used to do/undo a castling move. This is a bit
 // tricky in Chess960 where from/to squares can overlap.
 template<bool Do>
@@ -1276,6 +1273,8 @@ void Position::do_null_move(StateInfo& newSt, const TranspositionTable& tt) {
     prefetch(tt.first_entry(key()));
 
     st->pliesFromNull = 0;
+
+    st->capturedPiece = NO_PIECE;
 
     sideToMove = ~sideToMove;
 

--- a/src/position.h
+++ b/src/position.h
@@ -163,6 +163,7 @@ class Position {
 
     // Accessing hash keys
     Key key() const;
+    Key prefetch_key(Move m) const;
     Key material_key() const;
     Key pawn_key() const;
     Key minor_piece_key() const;
@@ -214,7 +215,8 @@ class Position {
                      Square&             rto,
                      DirtyThreats* const dts = nullptr,
                      DirtyPiece* const   dp  = nullptr);
-    Key  adjust_key50(Key k) const;
+    template<bool AfterMove = false>
+    Key adjust_key50(Key k) const;
 
     // Data members
     std::array<Piece, SQUARE_NB>        board;
@@ -320,8 +322,9 @@ inline Bitboard Position::check_squares(PieceType pt) const { return st->checkSq
 
 inline Key Position::key() const { return adjust_key50(st->key); }
 
+template<bool AfterMove>
 inline Key Position::adjust_key50(Key k) const {
-    return st->rule50 < 14 ? k : k ^ make_key((st->rule50 - 14) / 8);
+    return st->rule50 < 14 - AfterMove ? k : k ^ make_key((st->rule50 - (14 - AfterMove)) / 8);
 }
 
 inline Key Position::pawn_key() const { return st->pawnKey; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -325,7 +325,7 @@ void Search::Worker::iterative_deepening() {
 
     for (Color c : {WHITE, BLACK})
         for (int i = 0; i < UINT_16_HISTORY_SIZE; i++)
-            mainHistory[c][i] = mainHistory[c][i] * 3 / 4;
+            mainHistory[c][i] = mainHistory[c][i] * 789 / 1024;
 
     // Iterative deepening loop until requested to stop or the target depth is reached
     while (++rootDepth < MAX_PLY && !threads.stop
@@ -624,6 +624,10 @@ void Search::Worker::do_move(Position& pos, const Move move, StateInfo& st, Stac
 
 void Search::Worker::do_move(
   Position& pos, const Move move, StateInfo& st, const bool givesCheck, Stack* const ss) {
+    // prefetch_key does not model castling, en passant or promotion keys
+    // exactly; for rare moves the prefetch lands on an unused line.
+    prefetch(tt.first_entry(pos.prefetch_key(move)));
+
     bool capture = pos.capture_stage(move);
     ++nodes;
 
@@ -1025,7 +1029,7 @@ Value Search::Worker::search(
         assert(probCutBeta < VALUE_INFINITE && probCutBeta > beta);
 
         MovePicker mp(pos, ttData.move, probCutBeta - ss->staticEval, &captureHistory);
-        Depth      probCutDepth = depth - 5;
+        Depth      probCutDepth = depth - 4 - improving;
 
         while ((move = mp.next_move()) != Move::none())
         {
@@ -1816,15 +1820,10 @@ Depth Search::Worker::reduction(bool i, Depth d, int mn, int delta) const {
 // 'nodestime' option is enabled, it will return the count of nodes searched
 // instead. This function is called to check whether the search should be
 // stopped based on predefined thresholds like time limits or nodes searched.
-//
-// elapsed_time() returns the actual time elapsed since the start of the search.
-// This function is intended for use only when printing PV outputs, and not used
-// for making decisions within the search algorithm itself.
 TimePoint Search::Worker::elapsed() const {
     return main_manager()->tm.elapsed([this]() { return threads.nodes_searched(); });
 }
 
-TimePoint Search::Worker::elapsed_time() const { return main_manager()->tm.elapsed_time(); }
 
 [[maybe_unused]] Value Search::evaluate_with_big_network_bridge(
   const Eval::NNUE::ActiveNetwork&                                                         network,

--- a/src/search.h
+++ b/src/search.h
@@ -266,8 +266,6 @@ class SearchManager: public ISearchManager {
     Value                bestPreviousAverageScore;
     bool                 stopOnPonderhit;
 
-    usize id;
-
     const UpdateContext& updates;
 };
 
@@ -338,7 +336,6 @@ class Worker {
     }
 
     TimePoint elapsed() const;
-    TimePoint elapsed_time() const;
 
     const Eval::NNUE::ActiveNetwork& big_network() const;
     Eval::NNUE::ActiveAccumulatorCache&

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -508,6 +508,17 @@ void UCIEngine::position(std::istringstream& is) {
     else
         return;
 
+    const std::string_view board = std::string_view(fen).substr(0, fen.find(' '));
+    const auto             split = board.find('/');
+    const auto             last  = board.rfind('/');
+    if (split != std::string_view::npos && last != std::string_view::npos
+        && (board.substr(0, split).find_first_of("Pp") != std::string_view::npos
+            || board.substr(last + 1).find_first_of("Pp") != std::string_view::npos))
+    {
+        print_info_string("Unsupported position. Pawns on the first or eighth rank.");
+        return;
+    }
+
     std::vector<std::string> moves;
 
     while (is >> token)


### PR DESCRIPTION
### Motivation

- Bring the authorized Stockfish 2026-06-25 topology block into Revolution while preserving Revolution-specific features (branding, Book/Experience/Zobrist, MultiPV, RelaxedAtomic, continuation history). 
- Improve TT prefetching and search pruning (ProbCut) for performance parity with upstream. 
- Update the default NNUE network to the new approved main network and ensure the build/download workflow validates it. 
- Harden FEN handling for obvious pawn-on-rank-1/8 cases at the UCI entry point without changing Revolution's positional topology unnecessarily.

### Description

- Add early TT prefetch support by introducing `Position::prefetch_key(Move)` and calling it from `Search::Worker::do_move()` to prefetch the TT entry one move earlier. (`src/position.cpp`, `src/position.h`, `src/search.cpp`).
- Make ProbCut more aggressive when improving by changing the probCut search depth to `depth - 4 - improving`. (`src/search.cpp`).
- Update the default NNUE network name to `nn-f8a759c05f9f.nnue` and keep build/net helper files aligned (`EvalFileDefaultName`, `NNUE_NET`, `src/nnue/evaluate.h`, `src/evaluate.h`, `src/Makefile`, `README.md`).
- Simplify evasion logic in `Position::pseudo_legal()` by delegating check-evasion membership to `MoveList<EVASIONS>`. (`src/position.cpp`).
- Remove unused search-layer APIs and accessors that had no call sites: private `MovePicker` accessors removed, `SearchManager::id` removed, and `Search::Worker::elapsed_time()` declaration/definition removed. (`src/movepick.h`, `src/search.h`, `src/search.cpp`).
- Clear stale `capturedPiece` in `Position::do_null_move()` to avoid spuriously reading stale captures inside null-move subtrees. (`src/position.cpp`).
- Parameterize `Position::adjust_key50` to allow an `AfterMove` variant used by the new `prefetch_key` helper, keeping rule50 adjustments correct. (`src/position.h`, `src/position.cpp`).
- Add a minimal UCI-level FEN rejection for obvious cases of pawns on the first or eighth rank to surface unsupported positions early via `position` UCI command (prints `info string Unsupported position. Pawns on the first or eighth rank.` and returns). This is a minimal guard added at the UCI entry point and does not alter deeper position topology checks. (`src/uci.cpp`).
- Keep `attacks.h` / `types.h` topology and pext/pdep/RESTRICT handling untouched after audit; no fallback macros or dangerous changes introduced.

### Testing

- Performed repository-wide audits for Revolution surfaces, NNUE, TT/prefetch, ProbCut, FEN validation and pext/pdep/RESTRICT usage using fast searches (`rg`) to confirm presence/impact; results matched expectations and showed no unexpected topology divergences. 
- Ran `make net` and validated `nn-f8a759c05f9f.nnue` was available/validated by the network helper. 
- Built the engine successfully for multiple targets and instruction sets: `x86-64-sse41-popcnt`, `x86-64-avx2`, and `x86-64-bmi2` with zero compilation errors. 
- Executed runtime smoke tests with the produced binary including: `bench`, UCI handshake (`uci`/`isready`), `MultiPV` search on startpos (depth 8), the evasion/check positions and the two pawn-on-rank FEN cases; the engine responded `uciok`/`readyok`, ran searches, and the invalid pawn-rank FEN now returns the UCI informational rejection rather than proceeding silently. 

All automated builds and runtime smoke checks completed successfully; NNUE network change validated and the engine compiled and exercised without regressions in the tested scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48791e3af88327826b9081ac2324f6)