### PR TITLE
Revolution P0C: apply Stockfish Jun27 topology block

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,6 +1,12 @@
 name: Report issue
 description: Create a report to help us fix issues with the engine
 body:
+- type: markdown
+  attributes:
+    value: |
+      > [!IMPORTANT]
+      > Please do not open bug reports regarding the engine's choice of moves, such as the engine failing to find a particular "best" move. If you have any questions or wish to discuss engine analysis, please use our community channels, such as Discord.
+
 - type: textarea
   attributes:
     label: Describe the issue

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This release applies the accepted Stockfish development topology dated 2026-06-0
 - **June 9:** WebAssembly targets, `RelaxedAtomic`, `previousPV` and MultiPV mate-PV correction, plus the timeout harness where applicable.
 - **June 10:** NNUE active-bridge preparation; the HalfKA/Threats accumulator merge; `do_move` reordering with the `materialKey` correction; the stop-search condition when no better move is possible; and Revolution-compatible FEN pawn-rank validation for ranks 1 and 8.
 
-The active NNUE authority remains `nn-f8a759c05f9f.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
+The active NNUE authority remains `nn-1b6a82263149.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.90-140626
 
-NNUE_NET = nn-f8a759c05f9f.nnue
+NNUE_NET = nn-1b6a82263149.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
+#define EvalFileDefaultName "nn-1b6a82263149.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,6 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultName "nn-f8a759c05f9f.nnue"
+#define EvalFileDefaultName "nn-1b6a82263149.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED


### PR DESCRIPTION
### Motivation

- Aplicar únicamente los commits oficiales de Stockfish del 27 de junio de 2026 para actualizar la plantilla de reports y la red NNUE activa sin afectar la topología P0A/P0B ni la marca Revolution. 
- Mantener una auditoría y validación estricta de `src/attacks.h` y `src/types.h` por riesgo de roturas en `pext`/`pdep`/`RESTRICT` y en builds AVX2/BMI2.

### Description

- Añade el bloque informativo de bug reports a `.github/ISSUE_TEMPLATE/BUG-REPORT.yml` según `feb93253` sin introducir nueva estructura y respetando la plantilla existente. 
- Actualiza la red NNUE por defecto cambiando `EvalFileDefaultName` de `nn-f8a759c05f9f.nnue` a `nn-1b6a82263149.nnue` en `src/evaluate.h` y `src/nnue/evaluate.h`. 
- Sincroniza `NNUE_NET` en `src/Makefile` y el texto del `README.md` para reflejar `nn-1b6a82263149.nnue`, y preserva explícitamente Book/Experience/Zobrist/Syzygy y branding. 
- No se modificaron `src/attacks.h` ni `src/types.h`; se realizaron auditorías de presencia/uso de `RESTRICT`, `pext` y `pdep` como sanity check.

### Testing

- Confirmada la presencia y orden del DAG upstream para los commits Jun27 con la verificación de los hashes `feb93253` y `9d2ba2be`. 
- Ejecutado `make -C src net` y validada la descarga/validación oficial de `nn-1b6a82263149.nnue`. 
- Compilaciones completas y satisfactorias en `ARCH=x86-64-sse41-popcnt`, `ARCH=x86-64-avx2` y `ARCH=x86-64-bmi2` con `make -C src -j build`, incluidas verificaciones de `USE_PEXT` en BMI2. 
- Ejecutados bench y pruebas UCI y de humo usando el binario `Revolution-5.90-140626-sse41popcnt`, incluyendo `bench`, `setoption MultiPV`, varias posiciones FEN de evasión y la comprobación de que la opción UCI muestra `EvalFile` por defecto `nn-1b6a82263149.nnue`, y todas las pruebas automáticas completaron con éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a487c4220e08327a147042ba513c001)