### PR TITLE
Revolution P0D: apply Stockfish Jun29 network block

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This release applies the accepted Stockfish development topology dated 2026-06-0
 - **June 9:** WebAssembly targets, `RelaxedAtomic`, `previousPV` and MultiPV mate-PV correction, plus the timeout harness where applicable.
 - **June 10:** NNUE active-bridge preparation; the HalfKA/Threats accumulator merge; `do_move` reordering with the `materialKey` correction; the stop-search condition when no better move is possible; and Revolution-compatible FEN pawn-rank validation for ranks 1 and 8.
 
-The active NNUE authority remains `nn-1b6a82263149.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
+The active NNUE authority remains `nn-af1339a6dea3.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
 
 ## Overview
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.90-140626
 
-NNUE_NET = nn-1b6a82263149.nnue
+NNUE_NET = nn-af1339a6dea3.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-1b6a82263149.nnue"
+#define EvalFileDefaultName "nn-af1339a6dea3.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,6 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultName "nn-1b6a82263149.nnue"
+#define EvalFileDefaultName "nn-af1339a6dea3.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED


### PR DESCRIPTION
### Motivation

- Aplicar el bloque oficial de Stockfish del 29-jun-2026 para actualizar la NNUE activa a `nn-af1339a6dea3.nnue` manteniendo la topología y branding de Revolution. 
- Hacer una auditoría focal de `src/attacks.h` y `src/types.h` y validar que `pext`/`pdep`/`RESTRICT` y los builds AVX2/BMI2 no queden rotos.

### Description

- Actualicé el nombre de la red por defecto en `src/evaluate.h` y `src/nnue/evaluate.h` cambiando `EvalFileDefaultName` a `"nn-af1339a6dea3.nnue"`.
- Actualicé `NNUE_NET` en `src/Makefile` a `nn-af1339a6dea3.nnue` y el texto explicativo en `README.md` para reflejar la nueva red activa.
- Creé el commit del PR en la rama `codex/revolution-p0d-sf20260629-network` con mensaje `P0D-SF20260629: update main NNUE network` (`HEAD` final `5c5c20ba7fa5258d5dfc7282c8a9ef99d01a434b`).
- No se modificaron `src/attacks.h` ni `src/types.h`; la auditoría confirmó que `RESTRICT`, `pext`/`pdep` guards y la topología de ataques permanecen intactas.

### Testing

- Confirmé el commit upstream con `git fetch upstream` y `git log --reverse --oneline upstream/master --since="2026-06-29" --until="2026-06-30"` que muestra `Update main network to nn-af1339a6dea3.nnue` (auditado).
- Ejecuté `make -C src net` y la red `nn-af1339a6dea3.nnue` se validó/descargó correctamente desde las fuentes oficiales configuradas en el repo.
- Compilé y verificé builds exitosos: `make -C src -j build ARCH=x86-64-sse41-popcnt COMP=gcc`, `ARCH=x86-64-avx2` y `ARCH=x86-64-bmi2` completaron sin errores.
- Ejecuté el binario generado en pruebas de humo: `bench`, sesiones UCI (incluyendo `setoption MultiPV`, `go depth 8`) y posiciones de evasión/check y FEN con peones en ranks inválidos; UCI respondió `uciok`/`readyok` y la salida indicó `NNUE evaluation using nn-af1339a6dea3.nnue`.
- Ejecuté búsquedas por `rg` y `git diff` para verificar preservación de `Book`/`Experience`/`Zobrist`, `previousScoreExact`/`MultiPV`, `ProbCut`/`prefetch_key`, y `capturedPiece` en null-move; todas las comprobaciones automatizadas pasaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4883897f808327aa9fc195c232e2e3)