### PR TITLE
Revolution P0E: apply Stockfish Jun30 PSQT block

### DIFF
--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -62,7 +62,7 @@ Value Eval::evaluate(const Eval::NNUE::ActiveNetwork& network,
 
     auto [psqt, positional] = network.evaluate(pos, accumulators, cache);
 
-    Value nnue = (125 * psqt + 131 * positional) / 128;
+    Value nnue = psqt + positional;
 
     int nnueComplexity = std::abs(psqt - positional);
     optimism += optimism * nnueComplexity / 476;


### PR DESCRIPTION
### Motivation
- Apply upstream Stockfish commit `6088838797d6333711c17fe2c0962fa0858517ec` ("Yeet psqt weights") to simplify the NNUE evaluation blend while preserving Revolution topology and the active net `nn-af1339a6dea3.nnue`.

### Description
- Replace the weighted PSQT/positional blend with a direct sum in `src/evaluate.cpp` by changing `Value nnue = (125 * psqt + 131 * positional) / 128;` to `Value nnue = psqt + positional;`, with no other source files modified and NNUE/default net left unchanged.

### Testing
- Confirmed upstream commit presence, ran `rg` audits, executed `make -C src net`, built `ARCH=x86-64-sse41-popcnt`, `avx2` and `bmi2`, executed a bench and UCI smoke tests (MultiPV, invalid-rank FEN guard, short depth positions), and observed all automated builds/tests complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48b0a44ce08327a391565569b0300b)