### PR TITLE
Revolution P0F: apply Stockfish Jul3 final topology block

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -39,11 +39,12 @@ jobs:
           message: |
             clang-format 20 needs to be run on this PR.
             If you do not have clang-format installed, the maintainer will run it when merging.
-            For the exact version please see https://packages.ubuntu.com/plucky/clang-format-20.
+            For the exact version please see https://packages.ubuntu.com/questing/clang-format-20.
+            An easier way to install it might be through https://apt.llvm.org/#llvmsh.
 
             _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          comment_tag: execution
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          comment-tag: execution
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment on PR
         if: steps.clang-format.outcome != 'failure'
@@ -51,7 +52,7 @@ jobs:
         with:
           message: |
             _(execution **${{ github.run_id }}** / attempt **${{ github.run_attempt }}**)_
-          create_if_not_exists: false
-          comment_tag: execution
+          create-if-not-exists: false
+          comment-tag: execution
           mode: delete
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/AUTHORS
+++ b/AUTHORS
@@ -183,6 +183,7 @@ Moez Jellouli (MJZ1977)
 Mohammed Li (tthsqe12)
 Mukhammedali Beriktassuly (Berektassuly)
 Muzhen J (XInTheDark)
+Mafanwei
 Nathan Rugg (nmrugg)
 Nguyen Pham (nguyenpham)
 Nicklas Persson (NicklasPersson)

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,13 @@ ifeq ($(KERNEL),Linux)
 	OS := $(shell uname -o)
 endif
 
+### Target operating system (may differ from KERNEL when cross-compiling)
+TARGET_KERNEL := $(KERNEL)
+ifeq ($(COMP),ndk)
+	TARGET_KERNEL := Linux
+	OS := Android
+endif
+
 ### Target Windows OS
 ifeq ($(OS),Windows_NT)
 	ifneq ($(COMP),ndk)
@@ -55,7 +62,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 5.90-140626
 
-NNUE_NET = nn-af1339a6dea3.nnue
+NNUE_NET = nn-0ee0657fb25e.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -565,7 +572,7 @@ ifeq ($(COMP),gcc)
 		LDFLAGS += -latomic
 	endif
 
-	ifneq ($(KERNEL),Darwin)
+	ifneq ($(TARGET_KERNEL),Darwin)
 	ifneq ($(arch),wasm32)
 	   LDFLAGS += -Wl,--no-as-needed
 	endif
@@ -612,7 +619,7 @@ ifeq ($(COMP),clang)
 	CXXFLAGS += -pedantic -Wextra -Wshadow -Wmissing-prototypes \
 	            -Wconditional-uninitialized
 
-	ifeq ($(filter $(KERNEL),Darwin OpenBSD FreeBSD),)
+	ifeq ($(filter $(TARGET_KERNEL),Darwin OpenBSD FreeBSD),)
 	ifeq ($(target_windows),)
 	ifneq ($(RTLIB),compiler-rt)
 		LDFLAGS += -latomic
@@ -636,7 +643,7 @@ ifeq ($(COMP),clang)
 	endif
 endif
 
-ifeq ($(KERNEL),Darwin)
+ifeq ($(TARGET_KERNEL),Darwin)
 	CXXFLAGS += -mmacosx-version-min=10.15
 	LDFLAGS += -mmacosx-version-min=10.15
 	ifneq ($(arch),any)
@@ -696,7 +703,7 @@ else ifeq ($(comp),clang)
 else
 	profile_make = gcc-profile-make
 	profile_use = gcc-profile-use
-	ifeq ($(KERNEL),Darwin)
+	ifeq ($(TARGET_KERNEL),Darwin)
 		EXTRAPROFILEFLAGS = -fvisibility=hidden
 	endif
 endif
@@ -727,7 +734,7 @@ ifneq ($(comp),mingw)
 					add_lrt = no
 				endif
 
-				ifeq ($(KERNEL),Darwin)
+				ifeq ($(TARGET_KERNEL),Darwin)
 					add_lrt = no
 				endif
 
@@ -765,7 +772,7 @@ ifeq ($(optimize),yes)
 		endif
 	endif
 
-	ifeq ($(KERNEL),Darwin)
+	ifeq ($(TARGET_KERNEL),Darwin)
 		ifeq ($(comp),$(filter $(comp),clang icx))
 			CXXFLAGS += -mdynamic-no-pic
 		endif
@@ -895,7 +902,7 @@ endif
 
 ifeq ($(neon),yes)
 	CXXFLAGS += -DUSE_NEON=$(arm_version)
-	ifeq ($(KERNEL),Linux)
+	ifeq ($(TARGET_KERNEL),Linux)
 	ifneq ($(COMP),ndk)
 	ifneq ($(arch),armv8)
 		CXXFLAGS += -mfpu=neon

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -38,12 +38,6 @@ alignas(64) Magic Magics[SQUARE_NB][2];
 
 }
 
-#ifdef USE_PEXT
-using MagicMask = u16;
-#else
-using MagicMask = Bitboard;
-#endif
-
 [[maybe_unused]] static Bitboard line_mask(Square sq, Direction d1, Direction d2) {
     Bitboard mask = 0, dest;
     for (Direction d : {d1, d2})
@@ -76,7 +70,7 @@ static void init_magics(Magic magics[][2]) {
 
 // Sliding attacks within a rank, indexed by the slider's file and the
 // 8-bit rank occupancy, yielding the 8-bit attack set on that rank
-constexpr auto RankAttacks = []() {
+[[maybe_unused]] constexpr auto RankAttacks = []() {
     std::array<std::array<u8, 256>, FILE_NB> table{};
     for (int file = 0; file < 8; ++file)
         for (int occ = 0; occ < 256; ++occ)
@@ -102,38 +96,15 @@ static void init_dual_magics(DualMagic magics[]) {
 #else
 
 namespace {
-[[maybe_unused]] constexpr Bitboard constexpr_pext(Bitboard b, Bitboard m) {
-    Bitboard result = 0, bit = 0;
-    while (m)
-    {
-        Bitboard last = m & -m;
-        result |= bool(b & last) << bit++;
-        m ^= last;
-    }
-    return result;
-}
+void init_magics(PieceType pt, Bitboard table[], Magic magics[][2]) {
 
-    #ifdef USE_COMPTIME_ATTACKS
-constexpr
-    #endif
-  void
-  init_magics(PieceType             pt,
-              MagicMask             table[],
-              Magic                 magics[][2],
-              [[maybe_unused]] bool tableAlreadyInit) {
-    #if !defined(USE_COMPTIME_ATTACKS)
-    tableAlreadyInit = false;
-    #endif
-
-    #ifndef USE_PEXT
     int seeds[][RANK_NB] = {{8977, 44560, 54343, 38998, 5731, 95205, 104912, 17020},
                             {728, 10316, 55013, 32803, 12281, 15100, 16645, 255}};
 
     Bitboard occupancy[4096];
     int      epoch[4096] = {}, cnt = 0;
     Bitboard reference[4096] = {};
-    #endif
-    int size = 0;
+    int      size            = 0;
 
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
@@ -142,36 +113,21 @@ constexpr
         Magic&   m       = magics[s][pt - BISHOP];
         Bitboard attacks = sliding_attack(pt, s, 0);
         m.mask           = attacks & ~edges;
-    #ifdef USE_PEXT
-        m.pseudoAttacks = attacks;
-    #else
-        m.shift = (Is64Bit ? 64 : 32) - popcount(m.mask);
-    #endif
-        m.attacks = s == SQ_A1 ? table : magics[s - 1][pt - BISHOP].attacks + size;
-        size      = 0;
+        m.shift          = (Is64Bit ? 64 : 32) - popcount(m.mask);
+        m.attacks        = s == SQ_A1 ? table : magics[s - 1][pt - BISHOP].attacks + size;
+        size             = 0;
 
         Bitboard                  b           = 0;
         [[maybe_unused]] Bitboard prevSliding = -1;
         do
         {
-    #ifdef USE_PEXT
-            if (!tableAlreadyInit)
-            {
-                Bitboard sliding = sliding_attack(pt, s, b);
-                m.attacks[size] =
-                  sliding != prevSliding ? constexpr_pext(sliding, attacks) : m.attacks[size - 1];
-                prevSliding = sliding;
-            }
-    #else
             occupancy[size] = b;
             reference[size] = sliding_attack(pt, s, b);
-    #endif
 
             size++;
             b = (b - m.mask) & m.mask;
         } while (b);
 
-    #ifndef USE_PEXT
         PRNG rng(seeds[Is64Bit][rank_of(s)]);
 
         for (int i = 0; i < size;)
@@ -192,26 +148,12 @@ constexpr
                     break;
             }
         }
-    #endif
     }
 }
 
-    #if defined(USE_COMPTIME_ATTACKS) && defined(USE_PEXT)
-constexpr auto RookTable = []() {
-    std::array<u16, 0x19000> result{};
-    Magic                    magics[64][2] = {};
-    init_magics(ROOK, result.data(), magics, false);
-    return result;
-}();
-constexpr auto BishopTable = []() {
-    std::array<u16, 0x1480> result{};
-    Magic                   magics[64][2] = {};
-    init_magics(BISHOP, result.data(), magics, false);
-    return result;
-}();
-    #elif !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_HYPERBOLA_QUINT)
-std::array<MagicMask, 0x19000> RookTable;
-std::array<MagicMask, 0x1480>  BishopTable;
+    #if !defined(USE_DUAL_HYPERBOLA_QUINT) && !defined(USE_HYPERBOLA_QUINT)
+static std::array<Bitboard, 0x19000> RookTable;
+static std::array<Bitboard, 0x1480>  BishopTable;
     #endif
 }
 
@@ -224,8 +166,8 @@ void init() {
 #elif defined(USE_DUAL_HYPERBOLA_QUINT)
     init_dual_magics(DualMagics);
 #else
-    init_magics(ROOK, const_cast<MagicMask*>(RookTable.data()), Magics, true);
-    init_magics(BISHOP, const_cast<MagicMask*>(BishopTable.data()), Magics, true);
+    init_magics(ROOK, RookTable.data(), Magics);
+    init_magics(BISHOP, BishopTable.data(), Magics);
 #endif
 
     for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -31,7 +31,7 @@
     #define USE_HYPERBOLA_QUINT
 #elif defined(__loongarch__) && __loongarch_grlen == 64
     #define USE_HYPERBOLA_QUINT
-#elif defined(USE_AVX2) && !defined(USE_PEXT)
+#elif defined(USE_AVX2)
     #include <immintrin.h>
     #define USE_DUAL_HYPERBOLA_QUINT
 #endif
@@ -75,7 +75,7 @@ const Magic& magic(Square s, PieceType pt);
 
 #elif defined(USE_DUAL_HYPERBOLA_QUINT)
 
-struct DualMagic {
+struct alignas(32) DualMagic {
     // file, diagonal, unused, antidiagonal
     Bitboard maskFile, maskDiag, maskNone, maskAntidiag;
     // Precomputed 2 * square_bb(sq), 2 * reverse(square_bb(sq))
@@ -128,37 +128,23 @@ const DualMagic& dual_magic(Square s);
 #else
 // Magic holds all magic bitboards relevant data for a single square
 struct Magic {
-    Bitboard mask;
-    #ifdef USE_PEXT
-    u16*     attacks;
-    Bitboard pseudoAttacks;
-    #else
+    Bitboard  mask;
     Bitboard* attacks;
     Bitboard  magic;
     unsigned  shift;
-    #endif
 
     // Compute the attack's index using the 'magic bitboards' approach
     unsigned index(Bitboard occupied) const {
-
-    #ifdef USE_PEXT
-        return unsigned(pext(occupied, mask));
-    #else
         if (Is64Bit)
             return unsigned(((occupied & mask) * magic) >> shift);
 
         unsigned lo = unsigned(occupied) & unsigned(mask);
         unsigned hi = unsigned(occupied >> 32) & unsigned(mask >> 32);
         return (lo * unsigned(magic) ^ hi * unsigned(magic >> 32)) >> shift;
-    #endif
     }
 
     Bitboard attacks_bb([[maybe_unused]] Square s, Bitboard occupied) const {
-    #ifdef USE_PEXT
-        return pdep(attacks[index(occupied)], pseudoAttacks);
-    #else
         return attacks[index(occupied)];
-    #endif
     }
 };
 

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <tuple>
 
+#include "misc.h"
 #include "nnue/network.h"
 #include "nnue/nnue_misc.h"
 #include "position.h"
@@ -65,11 +66,11 @@ Value Eval::evaluate(const Eval::NNUE::ActiveNetwork& network,
     Value nnue = psqt + positional;
 
     int nnueComplexity = std::abs(psqt - positional);
-    optimism += optimism * nnueComplexity / 476;
-    nnue -= nnue * nnueComplexity / 18236;
+    optimism += optimism * i64(nnueComplexity) / 476;
+    nnue -= nnue * i64(nnueComplexity) / 18236;
 
     int material = 534 * pos.count<PAWN>() + pos.non_pawn_material();
-    int v        = (nnue * (77871 + material) + optimism * (7191 + material)) / 77871;
+    int v        = (nnue * i64(77871 + material) + optimism * i64(7191 + material)) / 77871;
 
     v -= v * pos.rule50_count() / 199;
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-af1339a6dea3.nnue"
+#define EvalFileDefaultName "nn-0ee0657fb25e.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -56,12 +56,82 @@ enum Stages {
     QCAPTURE
 };
 
+#ifdef USE_AVX512
+// Load the Move, and the ExtMove value, into all lanes of 512-bit registers
+static void splat_extmove(const ExtMove& m, __m512i& move, __m512i& value) {
+    move  = _mm512_set1_epi32(m.raw());
+    value = _mm512_set1_epi32(m.value);
+}
+
+// Sorts up to 16 moves.
+struct MoveSorter {
+    static constexpr int MAX_ELEMENTS = 16;
+    __m512i              sortedValues, sortedMoves;
+
+    explicit MoveSorter(const ExtMove& first) {
+        splat_extmove(first, sortedMoves, sortedValues);
+
+        // Set the uninitialized move values to INT_MIN, so that they sort less than any other move
+        sortedValues = _mm512_mask_set1_epi32(sortedValues, ~1, std::numeric_limits<int>::min());
+    }
+
+    void insert(const ExtMove& m) {
+        __m512i move, value;
+        splat_extmove(m, move, value);
+
+        // Mask of all elements except the insertion point
+        assert(m.value != std::numeric_limits<int>::min());
+        const u16 expand = _kadd_mask16(_mm512_cmplt_epi32_mask(sortedValues, value), -1);
+
+        sortedValues = _mm512_mask_expand_epi32(value, expand, sortedValues);
+        sortedMoves  = _mm512_mask_expand_epi32(move, expand, sortedMoves);
+    }
+
+    void write_sorted(ExtMove* moves, isize count) const {
+        static_assert(sizeof(ExtMove) == 8);
+        assert(count <= MAX_ELEMENTS);
+
+        // Because values and moves are stored separately, we need to reassemble the ExtMoves
+        auto write = [&](int offset, const __m512i indices) {
+            const __m512i extMoves = _mm512_permutex2var_epi32(sortedMoves, indices, sortedValues);
+            const isize   storeCount = count - offset;
+
+            if (storeCount > 0)
+                _mm512_mask_storeu_epi64(moves + offset, (1 << storeCount) - 1, extMoves);
+        };
+
+        write(0, _mm512_setr_epi32(0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23));
+        write(8, _mm512_setr_epi32(8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31));
+    }
+};
+#endif
 
 // Sort moves in descending order up to and including a given limit.
 // The order of moves smaller than the limit is left unspecified.
 void partial_insertion_sort(ExtMove* begin, ExtMove* end, int limit) {
+    ExtMove *sortedEnd = begin, *p = begin + 1;
 
-    for (ExtMove *sortedEnd = begin, *p = begin + 1; p < end; ++p)
+#ifdef USE_AVX512
+    if (begin == end)
+        return;
+
+    MoveSorter sorter(*begin);
+    for (; p < end; ++p)
+    {
+        if (p->value >= limit)
+        {
+            if (sortedEnd - begin + 1 >= MoveSorter::MAX_ELEMENTS)  // sorter full
+                break;
+
+            sorter.insert(*p);
+            *p = *++sortedEnd;
+        }
+    }
+    sorter.write_sorted(begin, sortedEnd - begin + 1);
+    // Use scalar implementation for any remaining elements
+#endif
+
+    for (; p < end; ++p)
         if (p->value >= limit)
         {
             ExtMove tmp = *p, *q;

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -212,6 +212,10 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
     Bitboard occupied = pos.pieces();
     Bitboard pawns    = pos.pieces(PAWN);
 
+    const Bitboard pawnTargets        = pos.pieces(PAWN, KNIGHT, ROOK);
+    const Bitboard minorSliderTargets = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK);
+    const Bitboard queenTargets       = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK, QUEEN);
+
     for (Color color : {WHITE, BLACK})
     {
         for (PieceType pt = PAWN; pt < KING; ++pt)
@@ -225,9 +229,9 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                 auto right = (c == WHITE) ? NORTH_EAST : SOUTH_WEST;
                 auto left  = (c == WHITE) ? NORTH_WEST : SOUTH_EAST;
                 auto attacks_left =
-                  ((c == WHITE) ? shift<NORTH_EAST>(bb) : shift<SOUTH_WEST>(bb)) & occupied;
+                  ((c == WHITE) ? shift<NORTH_EAST>(bb) : shift<SOUTH_WEST>(bb)) & pawnTargets;
                 auto attacks_right =
-                  ((c == WHITE) ? shift<NORTH_WEST>(bb) : shift<SOUTH_EAST>(bb)) & occupied;
+                  ((c == WHITE) ? shift<NORTH_WEST>(bb) : shift<SOUTH_EAST>(bb)) & pawnTargets;
 
                 while (attacks_left)
                 {
@@ -270,7 +274,8 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                 while (bb)
                 {
                     Square   from    = pop_lsb(bb);
-                    Bitboard attacks = (attacks_bb(pt, from, occupied)) & occupied;
+                    Bitboard targets = pt == KNIGHT || pt == QUEEN ? queenTargets : minorSliderTargets;
+                    Bitboard attacks = (attacks_bb(pt, from, occupied)) & targets;
 
                     while (attacks)
                     {

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -40,10 +40,10 @@ using ThreatFeatureSet = Features::FullThreats;
 using PSQFeatureSet    = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
-constexpr IndexType TransformedFeatureDimensionsBig = 1024;
+constexpr IndexType TransformedFeatureDimensionsBig    = 1024;
 constexpr IndexType ActiveTransformedFeatureDimensions = TransformedFeatureDimensionsBig;
-constexpr int       L2Big                           = 31;
-constexpr int       L3Big                           = 32;
+constexpr int       L2Big                              = 32;
+constexpr int       L3Big                              = 32;
 
 static_assert(ActiveTransformedFeatureDimensions == TransformedFeatureDimensionsBig);
 
@@ -62,12 +62,13 @@ struct NetworkArchitecture {
     static constexpr int       FC_0_OUTPUTS                 = L2;
     static constexpr int       FC_1_OUTPUTS                 = L3;
 
-    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS + 1> fc_0;
-    Layers::SqrClippedReLU<FC_0_OUTPUTS + 1, WeightScaleBits + 1>                      ac_sqr_0;
-    Layers::ClippedReLU<FC_0_OUTPUTS + 1, WeightScaleBits + 1>                         ac_0;
-    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS>                            fc_1;
-    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                                 ac_1;
-    Layers::AffineTransform<FC_1_OUTPUTS, 1>                                           fc_2;
+    Layers::AffineTransformSparseInput<TransformedFeatureDimensions, FC_0_OUTPUTS> fc_0;
+    Layers::SqrClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                      ac_sqr_0;
+    Layers::ClippedReLU<FC_0_OUTPUTS, WeightScaleBits + 1>                         ac_0;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2, FC_1_OUTPUTS>                        fc_1;
+    Layers::SqrClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                          ac_sqr_1;
+    Layers::ClippedReLU<FC_1_OUTPUTS, WeightScaleBits>                             ac_1;
+    Layers::AffineTransform<FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 1>                fc_2;
 
     // Hash value embedded in the evaluation file
     static constexpr u32 get_hash_value() {
@@ -104,13 +105,13 @@ struct NetworkArchitecture {
         struct alignas(CacheLineSize) Buffer {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
-              ac_sqr_0_out[ceil_to_multiple<IndexType>(FC_0_OUTPUTS * 2, 32)];
+              concat_buffer[ceil_to_multiple<IndexType>(FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 32)];
             alignas(CacheLineSize) typename decltype(ac_0)::OutputBuffer ac_0_out;
             alignas(CacheLineSize) typename decltype(fc_1)::OutputBuffer fc_1_out;
             alignas(CacheLineSize) typename decltype(ac_1)::OutputBuffer ac_1_out;
             alignas(CacheLineSize) typename decltype(fc_2)::OutputBuffer fc_2_out;
 
-            Buffer() { std::memset(this, 0, sizeof(*this)); }
+            Buffer() { std::memset(concat_buffer, 0, sizeof(concat_buffer)); }
         };
 
 #if defined(__clang__) && (__APPLE__)
@@ -123,19 +124,23 @@ struct NetworkArchitecture {
 #endif
 
         fc_0.propagate(transformedFeatures, buffer.fc_0_out);
-        ac_sqr_0.propagate(buffer.fc_0_out, buffer.ac_sqr_0_out);
+        ac_sqr_0.propagate(buffer.fc_0_out, buffer.concat_buffer);
         ac_0.propagate(buffer.fc_0_out, buffer.ac_0_out);
-        std::memcpy(buffer.ac_sqr_0_out + FC_0_OUTPUTS, buffer.ac_0_out,
+        std::memcpy(buffer.concat_buffer + FC_0_OUTPUTS, buffer.ac_0_out,
                     FC_0_OUTPUTS * sizeof(typename decltype(ac_0)::OutputType));
-        fc_1.propagate(buffer.ac_sqr_0_out, buffer.fc_1_out);
-        ac_1.propagate(buffer.fc_1_out, buffer.ac_1_out);
-        fc_2.propagate(buffer.ac_1_out, buffer.fc_2_out);
 
-        // max value for fwdOut is (L1 + L3) * HiddenMaxVal * WeightMaxVal
-        // for int8 activations and weights this is (L1 + L3) * 16129 making
-        // fwdOut safe from overflow until (L1 + L3) > 133,144
-        // first layer and last layer use WeightScaleBits + 1
-        i32 fwdOut = buffer.fc_2_out[0] + buffer.fc_0_out[FC_0_OUTPUTS];
+        fc_1.propagate(buffer.concat_buffer, buffer.fc_1_out);
+        ac_sqr_1.propagate(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2);
+        ac_1.propagate(buffer.fc_1_out, buffer.ac_1_out);
+        std::memcpy(buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS, buffer.ac_1_out,
+                    FC_1_OUTPUTS * sizeof(typename decltype(ac_1)::OutputType));
+
+        fc_2.propagate(buffer.concat_buffer, buffer.fc_2_out);
+
+        static_assert(FC_0_OUTPUTS >= 2);
+        i32 fwdOut = buffer.fc_2_out[0];
+        i32 skip_0 = buffer.fc_0_out[FC_0_OUTPUTS - 2] - buffer.fc_0_out[FC_0_OUTPUTS - 1];
+        fwdOut += skip_0;
 
         // fwdOut is such that 1.0 is equal to HiddenOneVal*(1<<WeightScaleBits)*2 in
         // quantized form, but we want 1.0 to be equal to 600*OutputScale.
@@ -156,6 +161,7 @@ struct NetworkArchitecture {
         hash_combine(h, ac_sqr_0.get_content_hash());
         hash_combine(h, ac_0.get_content_hash());
         hash_combine(h, fc_1.get_content_hash());
+        // hash_combine(h, ac_sqr_1.get_content_hash()); TODO
         hash_combine(h, ac_1.get_content_hash());
         hash_combine(h, fc_2.get_content_hash());
         hash_combine(h, get_hash_value());

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1087,6 +1087,10 @@ void write_multiple_dirties(const Position& p,
 }
 #endif
 
+constexpr bool can_slider_threat(Piece pc, Piece slider) {
+    return type_of(pc) != QUEEN || type_of(slider) == QUEEN;
+}
+
 template<bool ComputeRay>
 void Position::update_piece_threats(Piece                     pc,
                                     bool                      putPiece,
@@ -1098,11 +1102,12 @@ void Position::update_piece_threats(Piece                     pc,
     const Bitboard bishopQueens = pieces(BISHOP, QUEEN);
     const Bitboard rAttacks     = attacks_bb<ROOK>(s, occupied);
     const Bitboard bAttacks     = attacks_bb<BISHOP>(s, occupied);
-    const Bitboard kings        = pieces(KING);
-    Bitboard       occupiedNoK  = occupied ^ kings;
+    const Bitboard occupiedNoK  = occupied ^ pieces(KING);
 
-    Bitboard sliders         = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
-    auto     process_sliders = [&](bool addDirectAttacks) {
+    Bitboard sliders       = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
+    Bitboard directSliders = type_of(pc) == QUEEN ? sliders & pieces(QUEEN) : sliders;
+
+    auto process_sliders = [&](bool addDirectAttacks) {
         while (sliders)
         {
             Square sliderSq = pop_lsb(sliders);
@@ -1116,10 +1121,11 @@ void Position::update_piece_threats(Piece                     pc,
             {
                 const Square threatenedSq = lsb(discovered);
                 const Piece  threatenedPc = piece_on(threatenedSq);
-                add_dirty_threat(dts, !putPiece, slider, threatenedPc, sliderSq, threatenedSq);
+                if (can_slider_threat(threatenedPc, slider))
+                    add_dirty_threat(dts, !putPiece, slider, threatenedPc, sliderSq, threatenedSq);
             }
 
-            if (addDirectAttacks)
+            if (addDirectAttacks && can_slider_threat(pc, slider))
                 add_dirty_threat(dts, putPiece, slider, pc, sliderSq, s);
         }
     };
@@ -1135,10 +1141,12 @@ void Position::update_piece_threats(Piece                     pc,
     const Bitboard whitePawns = pieces(WHITE, PAWN);
     const Bitboard blackPawns = pieces(BLACK, PAWN);
 
-    Bitboard threatened = attacks_bb(pc, s, occupied) & occupiedNoK;
-    Bitboard incoming_threats =
-      (PseudoAttacks[KNIGHT][s] & knights) | (PseudoAttacks[KING][s] & kings);
+    Bitboard threatened       = attacks_bb(pc, s, occupied) & occupiedNoK;
+    Bitboard incoming_threats = PseudoAttacks[KNIGHT][s] & knights;
 
+    // Compute both incoming and outgoing pawn threats. Incoming pawn pushers are only
+    // added if 'pc' is a pawn.
+    Bitboard pawnThreats = 0;
     if (type_of(pc) == PAWN)
     {
         Bitboard whiteAttacks = PawnPushOrAttacks[WHITE][s];
@@ -1146,13 +1154,30 @@ void Position::update_piece_threats(Piece                     pc,
 
         threatened |= (color_of(pc) == WHITE ? whiteAttacks : blackAttacks) & pieces(PAWN);
 
-        incoming_threats |= whiteAttacks & blackPawns;
-        incoming_threats |= blackAttacks & whitePawns;
+        pawnThreats = whiteAttacks & blackPawns;
+        pawnThreats |= blackAttacks & whitePawns;
     }
     else
     {
-        incoming_threats |=
+        pawnThreats =
           (attacks_bb<PAWN>(s, WHITE) & blackPawns) | (attacks_bb<PAWN>(s, BLACK) & whitePawns);
+    }
+
+    if (type_of(pc) == PAWN || type_of(pc) == KNIGHT || type_of(pc) == ROOK)
+        incoming_threats |= pawnThreats;
+
+    switch (type_of(pc))
+    {
+    case PAWN :
+        threatened &= pieces(PAWN, KNIGHT, ROOK);
+        break;
+    case BISHOP :
+    case ROOK :
+        threatened &= pieces(PAWN, KNIGHT, BISHOP, ROOK);
+        break;
+    default :
+        threatened &= occupiedNoK;
+        break;
     }
 
 #ifdef USE_AVX512ICL
@@ -1163,9 +1188,7 @@ void Position::update_piece_threats(Piece                     pc,
           *this, threatened, dt_template, dts);
     }
 
-    Bitboard all_attackers = sliders | incoming_threats;
-    if (!all_attackers)
-        return;  // Square s is threatened iff there's at least one attacker
+    Bitboard all_attackers = directSliders | incoming_threats;
 
     DirtyThreat dt_template{NO_PIECE, pc, Square(0), s, putPiece};
     write_multiple_dirties<DirtyThreat::PcSqOffset, DirtyThreat::PcOffset>(*this, all_attackers,
@@ -1186,7 +1209,7 @@ void Position::update_piece_threats(Piece                     pc,
     if constexpr (ComputeRay)
         process_sliders(true);
     else
-        incoming_threats |= sliders;
+        incoming_threats |= directSliders;
 
 #ifndef USE_AVX512ICL
     while (incoming_threats)

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -349,22 +349,17 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
 Thread* ThreadPool::get_best_thread() const {
 
     Thread* bestThread = threads.front().get();
-    Value   minScore   = VALUE_NONE;
+    Value   minScore   = VALUE_INFINITE;
 
     std::unordered_map<Move, i64, Move::MoveHash> votes(
       2 * std::min(size(), bestThread->worker->rootMoves.size()));
 
-    // Find the minimum score of all threads
     for (auto&& th : threads)
         minScore = std::min(minScore, th->worker->rootMoves[0].score);
 
-    // Vote according to score and depth, and select the best thread
-    auto thread_voting_value = [minScore](Thread* th) {
-        return (th->worker->rootMoves[0].score - minScore + 14) * int(th->worker->completedDepth);
-    };
-
+    // Vote according to score, and select the best thread
     for (auto&& th : threads)
-        votes[th->worker->rootMoves[0].pv[0]] += thread_voting_value(th.get());
+        votes[th->worker->rootMoves[0].pv[0]] += th->worker->rootMoves[0].score - minScore + 14;
 
     for (auto&& th : threads)
     {
@@ -385,11 +380,6 @@ Thread* ThreadPool::get_best_thread() const {
         const bool newThreadInProvenLoss =
           newThreadScore != -VALUE_INFINITE && is_loss(newThreadScore);
 
-        // We make sure not to pick a thread with truncated principal variation
-        const bool betterVotingValue =
-          thread_voting_value(th.get()) * int(newThreadPV.size() > 2)
-          > thread_voting_value(bestThread) * int(bestThreadPV.size() > 2);
-
         if (bestThreadInProvenWin)
         {
             // Make sure we pick the shortest mate / TB conversion
@@ -405,7 +395,8 @@ Thread* ThreadPool::get_best_thread() const {
         else if (newThreadInProvenWin || newThreadInProvenLoss
                  || (!is_loss(newThreadScore)
                      && (newThreadMoveVote > bestThreadMoveVote
-                         || (newThreadMoveVote == bestThreadMoveVote && betterVotingValue))))
+                         || (newThreadMoveVote == bestThreadMoveVote
+                             && newThreadPV.size() > bestThreadPV.size()))))
             bestThread = th.get();
     }
 


### PR DESCRIPTION
### Motivation

- Bring Revolution up-to-date with the Stockfish dev block of 2026-07-03 (SFNNv15 and related topology/attacks/platform updates) while preserving Revolution branding, Book/Experience/Zobrist and local topology adaptations.
- Apply upstream changes that affect NNUE architecture, main network, threat filtering, move sorting, thread selection, Makefile cross-compilation guards and pext-based attacks without introducing false fallbacks or removing local engine data.

### Description

- Update NNUE architecture to SFNNv15 integrated into the local topology (applied with local topology adaptation) and switch the default active net to `nn-0ee0657fb25e.nnue` (files changed: `src/nnue/nnue_architecture.h`, `src/evaluate.h`, `src/Makefile`).
- Port early invalid-threat-pair filtering and related adjustments in feature generation and dirty-threats handling (files changed: `src/nnue/features/full_threats.cpp`, `src/position.cpp`) while preserving ray reuse and P0A/P0E behaviors.
- Enable AVX512 MoveSorter paths behind existing guards and simplify thread selection logic to the upstream approach while keeping local voting/win-loss rules (files changed: `src/movepick.cpp`, `src/thread.cpp`).
- Apply platform/build housekeeping and CI input fixes including Android-on-macOS `TARGET_KERNEL` guards and clang-format workflow input fixes (files changed: `src/Makefile`, `.github/workflows/clang-format.yml`).
- Simplify out pext-specific attack table code while preserving `USE_PEXT`/`-mbmi2` guards and keeping `pext`/`pdep` fallback implementations intact, and ensure `attacks.h`/`types.h` remain coherent (files changed: `src/attacks.cpp`, `src/attacks.h`, `src/types.h`).
- Treat the RISC-V/universal-binary upstream commit as not applicable/partial for Revolution because the local tree lacks the upstream universal packaging/nnz helper surface; no artificial universal packaging was introduced (upstream RISC-V pieces were evaluated and not forcibly merged).

### Testing

- Fetched and verified the upstream Jul 3 commit set and applied topical changes; all nine upstream hashes from 2026-07-03 were accounted for in the audit and closed with the statuses described above.
- Built and validated networks with `make -C src net` which validated `nn-0ee0657fb25e.nnue` successfully, and completed builds for `ARCH=x86-64-sse41-popcnt`, `ARCH=x86-64-avx2` and `ARCH=x86-64-bmi2` with zero fatal compile errors.
- Ran runtime checks including `bench` and UCI smoke tests (MultiPV, invalid-pawn-rank guard, evasion/check positions, `uci`/`isready`) against the produced `Revolution-5.90-140626-*-` binaries, and observed expected outputs and NNUE usage `nn-0ee0657fb25e.nnue` (bench and UCI sequences completed without crashes).
- AVX512/VNNI512 builds were not executed in this environment (recommended but non-blocking) and the RISC-V/universal packaging pieces were considered NOT APPLICABLE on the local tree and therefore not force-applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d82265188327a38bc1e9a274d422)