### PR TITLE
Revolution final rebrand to 6.0-040526

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Revolution-5.90-140626
+# Revolution-6.0-040526
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-5.90-140626** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-6.0-040526** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
-## Revolution-5.90-140626 technical release
+## Revolution-6.0-040526 technical release
 
 This release applies the accepted Stockfish development topology dated 2026-06-06 through 2026-06-10:
 
@@ -15,7 +15,7 @@ This release applies the accepted Stockfish development topology dated 2026-06-0
 - **June 9:** WebAssembly targets, `RelaxedAtomic`, `previousPV` and MultiPV mate-PV correction, plus the timeout harness where applicable.
 - **June 10:** NNUE active-bridge preparation; the HalfKA/Threats accumulator merge; `do_move` reordering with the `materialKey` correction; the stop-search condition when no better move is possible; and Revolution-compatible FEN pawn-rank validation for ranks 1 and 8.
 
-The active NNUE authority remains `nn-af1339a6dea3.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
+The active NNUE authority remains `nn-0ee0657fb25e.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
 
 ## Overview
 
@@ -174,7 +174,7 @@ This distribution of Revolution consists of the following files:
 
 Revolution supports 32-bit and 64-bit CPUs and the same hardware instruction sets as Stockfish. On Unix-like systems you can compile the engine from the `src` directory with:
 
-The UCI `id name` header is the architecture-independent base identity `Revolution-5.90-140626`. Startup, analysis, and informational output uses `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` from `src/Makefile` to expose the compiled architecture. Executable names use the same normalized architecture suffix.
+The UCI `id name` header is the architecture-independent base identity `Revolution-6.0-040526`. Startup, analysis, and informational output uses `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` from `src/Makefile` to expose the compiled architecture. Executable names use the same normalized architecture suffix.
 
 ```
 cd src
@@ -195,12 +195,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Identidad visible de análisis | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution-5.90-140626-sse41popcnt` | `Revolution-5.90-140626-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution-5.90-140626-avx2` | `Revolution-5.90-140626-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution-5.90-140626-bmi2` | `Revolution-5.90-140626-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution-5.90-140626-fma3` | `Revolution-5.90-140626-fma3[.exe]` |
-| `x86-64-avx512` | `Revolution-5.90-140626-avx512` | `Revolution-5.90-140626-avx512[.exe]` |
-| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-5.90-140626-avx512cl` | `Revolution-5.90-140626-avx512cl[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-6.0-040526-sse41popcnt` | `Revolution-6.0-040526-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-6.0-040526-avx2` | `Revolution-6.0-040526-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-6.0-040526-bmi2` | `Revolution-6.0-040526-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-6.0-040526-fma3` | `Revolution-6.0-040526-fma3[.exe]` |
+| `x86-64-avx512` | `Revolution-6.0-040526-avx512` | `Revolution-6.0-040526-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-6.0-040526-avx512cl` | `Revolution-6.0-040526-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 5.90-140626
+RELEASE_TAG ?= 6.0-040526
 
 NNUE_NET = nn-0ee0657fb25e.nnue
 

--- a/src/nnue/evaluate.h
+++ b/src/nnue/evaluate.h
@@ -4,6 +4,6 @@
 // This header is used by src/nnue/net.sh to locate the default NNUE filenames.
 // Keep these in sync with ../evaluate.h.
 
-#define EvalFileDefaultName "nn-af1339a6dea3.nnue"
+#define EvalFileDefaultName "nn-0ee0657fb25e.nnue"
 
 #endif  // REVOLUTION_NNUE_EVALUATE_H_INCLUDED


### PR DESCRIPTION
### Motivation

- Finalise the public release identity so the engine and build artifacts expose the new base name `Revolution-6.0-040526` while preserving architecture suffixes and the approved NNUE network.
- Ensure the documentation and NNUE discovery header reflect the final active net `nn-0ee0657fb25e.nnue` without altering evaluation/search/attacks/book/experience behaviour.

### Description

- Updated release tag in `src/Makefile` to `RELEASE_TAG ?= 6.0-040526` so built executables and compile-time `ENGINE_VERSION` use the new base identity.
- Updated NNUE net discovery header in `src/nnue/evaluate.h` to set `EvalFileDefaultName` to `"nn-0ee0657fb25e.nnue"` to align the embedded/default net with the required final net.
- Updated `README.md` to replace `Revolution-5.90-140626` strings with `Revolution-6.0-040526` and to document the expected architecture-suffixed binaries such as `Revolution-6.0-040526-sse41popcnt`, `Revolution-6.0-040526-avx2`, and `Revolution-6.0-040526-bmi2`.
- Only identity-related strings and documentation were changed; Book, Experience, Zobrist, attacks/types, NNUE architecture, evaluation and search logic were not modified.

### Testing

- Ran `make -C src net` and network validation succeeded for `nn-0ee0657fb25e.nnue` (download/validation path exercised) and the net was accepted by the build scripts.
- Built and tested `ARCH=x86-64-sse41-popcnt`, `ARCH=x86-64-avx2` and `ARCH=x86-64-bmi2` with `make -C src -j build`, producing binaries `src/Revolution-6.0-040526-sse41popcnt`, `src/Revolution-6.0-040526-avx2`, and `src/Revolution-6.0-040526-bmi2` respectively, and all builds completed without errors.
- Executed runtime smoke tests: the integrated `bench` run, `uci`/`isready` handshake, `MultiPV` search (`go depth 8`), and the FEN smoke checks completed and returned expected outputs with `id name Revolution-6.0-040526`, architecture-suffixed public lines (e.g. `Revolution-6.0-040526-sse41popcnt`), and `EvalFile` default set to `nn-0ee0657fb25e.nnue`.
- `git diff --check` and repository identity scans were clean and no unintended files were modified, so the change is ready for SAFE MERGE.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48e84e2d388327b201686d32dc5cde)