### PR TITLE
Revolution P0G: apply Stockfish Jul6 NNUE propagation cleanup

### DIFF
--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -22,7 +22,6 @@
 #define NNUE_ARCHITECTURE_H_INCLUDED
 
 #include <cstdint>
-#include <cstring>
 #include <iosfwd>
 
 #include "features/half_ka_v2_hm.h"
@@ -106,12 +105,8 @@ struct NetworkArchitecture {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
               concat_buffer[ceil_to_multiple<IndexType>(FC_0_OUTPUTS * 2 + FC_1_OUTPUTS * 2, 32)];
-            alignas(CacheLineSize) typename decltype(ac_0)::OutputBuffer ac_0_out;
             alignas(CacheLineSize) typename decltype(fc_1)::OutputBuffer fc_1_out;
-            alignas(CacheLineSize) typename decltype(ac_1)::OutputBuffer ac_1_out;
             alignas(CacheLineSize) typename decltype(fc_2)::OutputBuffer fc_2_out;
-
-            Buffer() { std::memset(concat_buffer, 0, sizeof(concat_buffer)); }
         };
 
 #if defined(__clang__) && (__APPLE__)
@@ -125,15 +120,12 @@ struct NetworkArchitecture {
 
         fc_0.propagate(transformedFeatures, buffer.fc_0_out);
         ac_sqr_0.propagate(buffer.fc_0_out, buffer.concat_buffer);
-        ac_0.propagate(buffer.fc_0_out, buffer.ac_0_out);
-        std::memcpy(buffer.concat_buffer + FC_0_OUTPUTS, buffer.ac_0_out,
-                    FC_0_OUTPUTS * sizeof(typename decltype(ac_0)::OutputType));
+        ac_0.propagate(buffer.fc_0_out, buffer.concat_buffer + FC_0_OUTPUTS);
 
         fc_1.propagate(buffer.concat_buffer, buffer.fc_1_out);
         ac_sqr_1.propagate(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2);
-        ac_1.propagate(buffer.fc_1_out, buffer.ac_1_out);
-        std::memcpy(buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS, buffer.ac_1_out,
-                    FC_1_OUTPUTS * sizeof(typename decltype(ac_1)::OutputType));
+        ac_1.propagate(buffer.fc_1_out,
+                       buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
 
         fc_2.propagate(buffer.concat_buffer, buffer.fc_2_out);
 


### PR DESCRIPTION
### Motivation
- Port the no-functional-change semantics of Stockfish commit `eca43a97efd2cf0c9b7153c71b85f35e0fd1f5ca` to the local Revolution SFNNv15 topology by removing redundant temporary activation buffers and copies. 
- Reduce needless memory operations in NNUE propagation while preserving Revolution's local network topology, API signatures and identity.

### Description
- Modified only `src/nnue/nnue_architecture.h` to remove the temporary activation buffers `ac_0_out` and `ac_1_out`. 
- Removed the `Buffer` constructor that zeroed `concat_buffer` via `std::memset` and removed the `#include <cstring>` now unused. 
- Replaced the two `std::memcpy` calls with direct writes by changing `ac_0.propagate(...)` and `ac_1.propagate(...)` to write into `buffer.concat_buffer` at `+ FC_0_OUTPUTS` and `+ FC_0_OUTPUTS * 2 + FC_1_OUTPUTS` respectively. 
- Single implementation commit created: `P0G-SF20260706: remove redundant NNUE activation copies`, and no other files or engine identity/topology were changed.

### Testing
- Verified upstream objects and commit existence with `git fetch upstream` and `git cat-file -e` for the requested hashes, and confirmed ancestry for the official commit. 
- Ran repository audits and pattern searches using `rg` to confirm removed symbols and new propagation calls were present and no prohibited symbols were introduced. 
- Built the requested target with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=gcc` which completed with exit code `0` and reported `0` compiler warnings/errors. 
- Executed `printf "uci
isready
quit
" | src/Revolution-6.0-040526-sse41popcnt` and confirmed `id name Revolution-6.0-040526`, `uciok`, `readyok`, `EvalFile` default and Book/Experience/Syzygy options, and ran `src/Revolution-6.0-040526-sse41popcnt bench 16 1 8 default depth` which completed normally with recorded nodes/time and exit code `0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ca81d775c8327800aae629dd7ea1c)