### PR TITLE
Revolution P0H: apply Stockfish Jul10 topology block

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,7 @@
 # Post commit formatting fixes
 0fca5605fa2e5e7240fde5e1aae50952b2612231
 08ed4c90db31959521b7ef3186c026edd1e90307
+
+# Ignore commits related to integer type renamings
+dd3e1c4a50fd358c8bf8051c9ef73219669ff6c0
+6e4e03fd282d5e1cba514197bf1ef326c990f0d2

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,7 +13,7 @@ Hisayori Noda (nodchip)
 87flowers
 Aditya (absimaldata)
 Adrian Petrescu (apetresc)
-Adrian (AdrianGHUB15)
+Adrian Ladoni (AdrianGHUB15)
 Ahmed Kerimov (wcdbmv)
 Ajith Chandy Jose (ajithcj)
 AK-Khan02
@@ -37,6 +37,7 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
+Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)
@@ -62,6 +63,7 @@ Clemens L. (rn5f107s2)
 Cody Ho (aesrentai)
 CSTENTOR
 Dale Weiler (graphitemaster)
+Dalton Hanaway (dhanaway)
 Daniel Axtens (daxtens)
 Daniel Dugovic (ddugovic)
 Daniel Monroe (daniel-monroe)
@@ -177,6 +179,7 @@ Michel Van den Bergh (vdbergh)
 Miguel Lahoz (miguel-l)
 Mikael Bäckman (mbootsector)
 Mike Babigian (Farseer)
+Miloslav Macůrek (maelic13)
 Mira
 Miroslav Fontán (Hexik)
 Moez Jellouli (MJZ1977)
@@ -224,6 +227,7 @@ Ron Britvich (Britvich)
 rqs
 Rui Coelho (ruicoelhopedro)
 rustam-cpp
+Ryan Hirsch
 Ryan Schmitt
 Ryan Takker
 Sami Kiminki (skiminki)

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -70,7 +70,7 @@ static void init_magics(Magic magics[][2]) {
 
 // Sliding attacks within a rank, indexed by the slider's file and the
 // 8-bit rank occupancy, yielding the 8-bit attack set on that rank
-[[maybe_unused]] constexpr auto RankAttacks = []() {
+constexpr auto RankAttacks = []() {
     std::array<std::array<u8, 256>, FILE_NB> table{};
     for (int file = 0; file < 8; ++file)
         for (int occ = 0; occ < 256; ++occ)
@@ -117,8 +117,7 @@ void init_magics(PieceType pt, Bitboard table[], Magic magics[][2]) {
         m.attacks        = s == SQ_A1 ? table : magics[s - 1][pt - BISHOP].attacks + size;
         size             = 0;
 
-        Bitboard                  b           = 0;
-        [[maybe_unused]] Bitboard prevSliding = -1;
+        Bitboard b = 0;
         do
         {
             occupancy[size] = b;

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -90,10 +90,10 @@ struct alignas(32) DualMagic {
     //
     // When using hyperbola quintessence, file, diagonal and antidiagonal attacks
     // can use a byte reversal rather than a full bit reversal (because all squares
-    // reside in different bytes). Rank atttacks cannot. Thus, for rank attacks
+    // reside in different bytes). Rank attacks cannot. Thus, for rank attacks
     // only, we use a compact lookup table indexed by the 8 bits of the rank's occupancy.
     std::pair<Bitboard, Bitboard> both_attacks_bb(Bitboard occupied) const {
-        // Byteswap within 64-bit elements
+        // Byteswap within 128-bit elements
         const auto bswap = [](__m256i v) {
             return _mm256_shuffle_epi8(v, _mm256_set_epi8(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
                                                           13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
@@ -262,7 +262,7 @@ inline Bitboard attacks_bb(Square s, Color c = COLOR_NB) {
 
 // Returns the attacks by the given piece
 // assuming the board is occupied according to the passed Bitboard.
-// Sliding piece attacks do not continue passed an occupied square.
+// Sliding piece attacks do not continue past an occupied square.
 template<PieceType Pt>
 inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 
@@ -298,7 +298,7 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
 
 // Returns the attacks by the given piece
 // assuming the board is occupied according to the passed Bitboard.
-// Sliding piece attacks do not continue passed an occupied square.
+// Sliding piece attacks do not continue past an occupied square.
 inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
 
     assert(pt != PAWN && is_ok(s));
@@ -310,7 +310,7 @@ inline Bitboard attacks_bb(PieceType pt, Square s, Bitboard occupied) {
     case ROOK :
         return attacks_bb<ROOK>(s, occupied);
     case QUEEN :
-        return attacks_bb<BISHOP>(s, occupied) | attacks_bb<ROOK>(s, occupied);
+        return attacks_bb<QUEEN>(s, occupied);
     default :
         return PseudoAttacks[pt][s];
     }

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -23,7 +23,6 @@
 namespace Stockfish {
 
 u8 PopCnt16[1 << 16];
-u8 SquareDistance[SQUARE_NB][SQUARE_NB];
 
 // Returns an ASCII representation of a bitboard suitable
 // to be printed to standard output. Useful for debugging.
@@ -46,16 +45,10 @@ std::string Bitboards::pretty(Bitboard b) {
     return s;
 }
 
-// Initializes various bitboard tables. It is called at
-// startup and relies on global objects to be already zero-initialized.
+// Initializes the popcount table at startup.
 void Bitboards::init() {
-
     for (unsigned i = 0; i < (1 << 16); ++i)
         PopCnt16[i] = u8(std::bitset<16>(i).count());
-
-    for (Square s1 = SQ_A1; s1 <= SQ_H8; ++s1)
-        for (Square s2 = SQ_A1; s2 <= SQ_H8; ++s2)
-            SquareDistance[s1][s2] = std::max(distance<File>(s1, s2), distance<Rank>(s1, s2));
 }
 
 }  // namespace Stockfish

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -21,9 +21,7 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <cstring>
-#include <cstdlib>
 #include <string>
 
 #include "types.h"
@@ -66,7 +64,6 @@ constexpr Bitboard Rank7BB = Rank1BB << (8 * 6);
 constexpr Bitboard Rank8BB = Rank1BB << (8 * 7);
 
 extern u8 PopCnt16[1 << 16];
-extern u8 SquareDistance[SQUARE_NB][SQUARE_NB];
 
 constexpr Bitboard square_bb(Square s) {
     assert(is_ok(s));
@@ -133,29 +130,7 @@ constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
     return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
 }
 
-// distance() functions return the distance between x and y, defined as the
-// number of steps for a king in x to reach y.
-
-template<typename T1 = Square>
-inline int distance(Square x, Square y);
-
-template<>
-inline int distance<File>(Square x, Square y) {
-    return std::abs(file_of(x) - file_of(y));
-}
-
-template<>
-inline int distance<Rank>(Square x, Square y) {
-    return std::abs(rank_of(x) - rank_of(y));
-}
-
-template<>
-inline int distance<Square>(Square x, Square y) {
-    return SquareDistance[x][y];
-}
-
 inline int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
-
 
 constexpr int constexpr_popcount(Bitboard b) {
     b = b - ((b >> 1) & 0x5555555555555555ULL);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -227,7 +227,7 @@ void Engine::search_clear() {
     tt.clear(threads);
     threads.clear();
 
-    // @TODO wont work with multiple instances
+    // TODO: does not work with multiple instances
     Tablebases::init(options["SyzygyPath"]);  // Free mapped files
 }
 
@@ -276,7 +276,7 @@ void Engine::set_position(const std::string& fen, const std::vector<std::string>
 
 // modifiers
 
-void Engine::set_numa_config_from_option(const std::string& o) {
+bool Engine::set_numa_config_from_option(const std::string& o) {
     if (o == "auto" || o == "system")
     {
         numaContext.set_numa_config(NumaConfig::from_system(DefaultNumaPolicy));
@@ -292,12 +292,16 @@ void Engine::set_numa_config_from_option(const std::string& o) {
     }
     else
     {
-        numaContext.set_numa_config(NumaConfig::from_string(o));
+        auto config = NumaConfig::from_string(o);
+        if (!config)
+            return false;
+        numaContext.set_numa_config(std::move(*config));
     }
 
     // Force reallocation of threads in case affinities need to change.
     resize_threads();
     threads.ensure_network_replicated();
+    return true;
 }
 
 void Engine::resize_threads() {

--- a/src/engine.h
+++ b/src/engine.h
@@ -71,7 +71,7 @@ class Engine {
 
     // modifiers
 
-    void set_numa_config_from_option(const std::string& o);
+    bool set_numa_config_from_option(const std::string& o);
     void resize_threads();
     void set_tt_size(usize mb);
     void set_ponderhit(bool);

--- a/src/history.h
+++ b/src/history.h
@@ -54,7 +54,10 @@ static_assert((CORRHIST_BASE_SIZE & (CORRHIST_BASE_SIZE - 1)) == 0,
 // when we update values with the << operator
 template<typename T, int D, bool Shared = false>
 struct StatsEntry {
-    static_assert(std::is_arithmetic_v<T>, "Not an arithmetic type");
+    static_assert(std::is_integral_v<T> && std::is_signed_v<T>, "Not a signed integer type");
+    static_assert(D > 0 && D <= std::numeric_limits<T>::max()
+                    && D <= std::numeric_limits<int>::max() / D,
+                  "D can lead to overflows");
 
    private:
     std::conditional_t<Shared, RelaxedAtomic<T>, T> entry;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <cassert>
 #include <cctype>
+#include <cerrno>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -505,10 +506,14 @@ void start_logger(const std::string& fname) { Logger::start(fname); }
     #define GETCWD getcwd
 #endif
 
-usize str_to_size_t(const std::string& s) {
-    unsigned long long value = std::stoull(s);
-    if (value > std::numeric_limits<usize>::max())
-        std::exit(EXIT_FAILURE);
+std::optional<usize> str_to_size_t(const std::string& s) {
+    if (s.empty() || s[0] == '-')
+        return std::nullopt;
+    errno                           = 0;
+    char*                    endptr = nullptr;
+    const unsigned long long value  = std::strtoull(s.c_str(), &endptr, 10);
+    if (errno == ERANGE || *endptr != '\0' || value > std::numeric_limits<usize>::max())
+        return std::nullopt;
     return static_cast<usize>(value);
 }
 

--- a/src/misc.h
+++ b/src/misc.h
@@ -135,7 +135,7 @@ void prefetch(const void* addr) {
 
 void start_logger(const std::string& fname);
 
-usize str_to_size_t(const std::string& s);
+std::optional<usize> str_to_size_t(const std::string& s);
 
 #if defined(__linux__)
 

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -190,7 +190,7 @@ MovePicker::MovePicker(const Position& p, Move ttm, int th, const CapturePieceTo
 
 // Assigns a numerical value to each move in a list, used for sorting.
 // Captures are ordered by Most Valuable Victim (MVV), preferring captures
-// with a good history. Quiets moves are ordered using the history tables.
+// with a good history. Quiet moves are ordered using the history tables.
 template<GenType Type>
 ExtMove* MovePicker::score(MoveList<Type>& ml) {
 

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -40,7 +40,7 @@
 
 namespace Stockfish::Eval::NNUE::Layers {
 
-#if defined(USE_SSSE3) || defined(USE_NEON_DOTPROD)
+#if defined(USE_SSSE3) || defined(USE_NEON_DOTPROD) || defined(USE_LSX) || defined(USE_LASX)
     #define ENABLE_SEQ_OPT
 #endif
 
@@ -49,10 +49,8 @@ namespace Stockfish::Eval::NNUE::Layers {
 #ifndef ENABLE_SEQ_OPT
 
 template<IndexType InputDimensions, IndexType PaddedInputDimensions, IndexType OutputDimensions>
-static void affine_transform_non_ssse3(i32*       output,
-                                       const i8*  weights,
-                                       const i32* biases,
-                                       const u8* input) {
+static void
+affine_transform_non_ssse3(i32* output, const i8* weights, const i32* biases, const u8* input) {
     #if defined(USE_SSE2) || defined(USE_NEON)
         #if defined(USE_SSE2)
     // At least a multiple of 16, with SSE2.
@@ -107,6 +105,26 @@ static void affine_transform_non_ssse3(i32*       output,
 
         #endif
     }
+    #elif defined(USE_RVV)
+    for (IndexType i = 0; i < OutputDimensions; ++i)
+    {
+        const i8*  row  = &weights[i * PaddedInputDimensions];
+        vint32m1_t vsum = __riscv_vmv_v_x_i32m1(0, __riscv_vsetvlmax_e32m1());
+
+        for (usize j = 0; j < InputDimensions;)
+        {
+            usize vl = __riscv_vsetvl_e8m4(InputDimensions - j);
+
+            vint8m4_t  w    = __riscv_vle8_v_i8m4(&row[j], vl);
+            vuint8m4_t x    = __riscv_vle8_v_u8m4(&input[j], vl);
+            vint16m8_t prod = __riscv_vwmulsu_vv_i16m8(w, x, vl);
+
+            vsum = __riscv_vwredsum_vs_i16m8_i32m1(prod, vsum, vl);
+            j += vl;
+        }
+
+        output[i] = biases[i] + __riscv_vmv_x_s_i32m1_i32(vsum);
+    }
     #else
     std::memcpy(output, biases, sizeof(i32) * OutputDimensions);
 
@@ -115,7 +133,7 @@ static void affine_transform_non_ssse3(i32*       output,
         if (input[i])
         {
             const i8* w  = &weights[i];
-            const int          in = input[i];
+            const int in = input[i];
             for (IndexType j = 0; j < OutputDimensions; ++j)
                 output[j] += w[j * PaddedInputDimensions] * in;
         }
@@ -201,10 +219,12 @@ class AffineTransform {
     #if defined(USE_AVX512)
             using vec_t = __m512i;
         #define vec_set_32 _mm512_set1_epi32
+        #define vec_add_32 _mm512_add_epi32
         #define vec_add_dpbusd_32 SIMD::m512_add_dpbusd_epi32
     #elif defined(USE_AVX2)
             using vec_t = __m256i;
         #define vec_set_32 _mm256_set1_epi32
+        #define vec_add_32 _mm256_add_epi32
         #define vec_add_dpbusd_32 SIMD::m256_add_dpbusd_epi32
     #elif defined(USE_SSSE3)
             using vec_t = __m128i;
@@ -216,6 +236,16 @@ class AffineTransform {
         #define vec_add_dpbusd_32(acc, a, b) \
             SIMD::dotprod_m128_add_dpbusd_epi32(acc, vreinterpretq_s8_s32(a), \
                                                 vreinterpretq_s8_s32(b))
+    #elif defined(USE_LASX)
+            using vec_t = __m256i;
+        #define vec_set_32 __lasx_xvreplgr2vr_w
+        #define vec_add_32 __lasx_xvadd_w
+        #define vec_add_dpbusd_32 SIMD::lasx_m256_add_dpbusd_epi32
+    #elif defined(USE_LSX)
+            using vec_t = __m128i;
+        #define vec_set_32 __lsx_vreplgr2vr_w
+        #define vec_add_32 __lsx_vadd_w
+        #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
     #endif
 
             static constexpr IndexType OutputSimdWidth = sizeof(vec_t) / sizeof(OutputType);
@@ -223,26 +253,58 @@ class AffineTransform {
             static_assert(OutputDimensions % OutputSimdWidth == 0);
 
             constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / 4;
-            constexpr IndexType NumRegs   = OutputDimensions / OutputSimdWidth;
+            constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
+
+    #if defined(USE_VNNI) || defined(USE_NEON_DOTPROD)
+            constexpr IndexType NumRegs = 2 * NumAccums;
+    #else
+            constexpr IndexType NumRegs = NumAccums;
+    #endif
 
             const vec_t* biasvec = reinterpret_cast<const vec_t*>(biases);
             vec_t        acc[NumRegs];
-            for (IndexType k = 0; k < NumRegs; ++k)
+            for (IndexType k = 0; k < NumAccums; ++k)
                 acc[k] = biasvec[k];
+            for (IndexType k = NumAccums; k < NumRegs; ++k)
+                acc[k] = vec_set_32(0);
 
-            for (IndexType i = 0; i < NumChunks; ++i)
+            IndexType i = 0;
+    #if defined(USE_VNNI) || defined(USE_NEON_DOTPROD)
+            for (; i < NumChunks; i += 2)
             {
-                const vec_t in0 =
-                  vec_set_32(load_as<i32>(input + i * sizeof(i32)));
-                const auto col0 =
+                const vec_t in0 = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
+                const vec_t in1 = vec_set_32(load_as<i32>(input + (i + 1) * sizeof(i32)));
+                const auto  col0 =
+                  reinterpret_cast<const vec_t*>(&weights[i * OutputDimensions * 4]);
+                const auto col1 =
+                  reinterpret_cast<const vec_t*>(&weights[(i + 1) * OutputDimensions * 4]);
+
+                for (IndexType k = 0; k < NumAccums; ++k)
+                {
+                    vec_add_dpbusd_32(acc[k], in0, col0[k]);
+                    vec_add_dpbusd_32(acc[k + NumAccums], in1, col1[k]);
+                }
+            }
+
+            for (IndexType k = 0; k < NumAccums; ++k)
+        #if defined(USE_NEON_DOTPROD)
+                acc[k] = vaddq_s32(acc[k], acc[k + NumAccums]);
+        #else
+                acc[k] = vec_add_32(acc[k], acc[k + NumAccums]);
+        #endif
+    #endif
+            for (; i < NumChunks; ++i)
+            {
+                const vec_t in0 = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
+                const auto  col0 =
                   reinterpret_cast<const vec_t*>(&weights[i * OutputDimensions * 4]);
 
-                for (IndexType k = 0; k < NumRegs; ++k)
+                for (IndexType k = 0; k < NumAccums; ++k)
                     vec_add_dpbusd_32(acc[k], in0, col0[k]);
             }
 
             vec_t* outptr = reinterpret_cast<vec_t*>(output);
-            for (IndexType k = 0; k < NumRegs; ++k)
+            for (IndexType k = 0; k < NumAccums; ++k)
                 outptr[k] = acc[k];
 
     #undef vec_set_32
@@ -269,6 +331,16 @@ class AffineTransform {
             SIMD::dotprod_m128_add_dpbusd_epi32(acc, vreinterpretq_s8_s32(a), \
                                                 vreinterpretq_s8_s32(b))
         #define vec_hadd SIMD::neon_m128_hadd
+    #elif defined(USE_LASX)
+            using vec_t = __m256i;
+        #define vec_setzero() __lasx_xvldi(0)
+        #define vec_add_dpbusd_32 SIMD::lasx_m256_add_dpbusd_epi32
+        #define vec_hadd SIMD::lasx_m256_hadd
+    #elif defined(USE_LSX)
+            using vec_t = __m128i;
+        #define vec_setzero() __lsx_vldi(0)
+        #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
+        #define vec_hadd SIMD::lsx_m128_hadd
     #endif
 
             const auto inputVector = reinterpret_cast<const vec_t*>(input);

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -286,9 +286,11 @@ class AffineTransformSparseInput {
         constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
         constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
         // If we're using high-latency dot product instructions, split the accumulators
-        // to create 3 separate dependency chains and merge at the end
+        // into separate dependency chains and merge at the end
         constexpr IndexType NumRegs =
-    #if defined(USE_VNNI)
+    #if defined(USE_AVXVNNI)
+          2 * NumAccums;
+    #elif defined(USE_VNNI)
           3 * NumAccums;
     #else
           NumAccums;
@@ -309,7 +311,29 @@ class AffineTransformSparseInput {
 
         // convince GCC to not do weird pointer arithmetic in the following loop
         const i8* weights_cp = weights;
-    #if defined(USE_VNNI)
+    #if defined(USE_AVXVNNI)
+        for (IndexType k = NumAccums; k < NumRegs; ++k)
+            acc[k] = vec_zero();
+
+        while (start < end - 1)
+        {
+            const isize i0 = *start++;
+            const isize i1 = *start++;
+            const invec_t in0 = vec_set_32(load_as<i32>(input + i0 * sizeof(i32)));
+            const invec_t in1 = vec_set_32(load_as<i32>(input + i1 * sizeof(i32)));
+            const auto col0 =
+              reinterpret_cast<const invec_t*>(&weights_cp[i0 * OutputDimensions * ChunkSize]);
+            const auto col1 =
+              reinterpret_cast<const invec_t*>(&weights_cp[i1 * OutputDimensions * ChunkSize]);
+            for (IndexType k = 0; k < NumAccums; ++k)
+            {
+                vec_add_dpbusd_32(acc[k], in0, col0[k]);
+                vec_add_dpbusd_32(acc[k + NumAccums], in1, col1[k]);
+            }
+        }
+        for (IndexType k = 0; k < NumAccums; ++k)
+            acc[k] = vec_add_32(acc[k], acc[k + NumAccums]);
+    #elif defined(USE_VNNI)
         for (IndexType k = NumAccums; k < NumRegs; ++k)
             acc[k] = vec_zero();
 

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -129,7 +129,7 @@ static_assert(std::is_same_v<ActiveAccumulatorCache,
                              AccumulatorCaches::Cache<TransformedFeatureDimensionsBig>>);
 
 
-}  // namespace Stockfish
+}  // namespace Stockfish::Eval::NNUE
 
 template<typename ArchT, typename FeatureTransformerT>
 struct std::hash<Stockfish::Eval::NNUE::Network<ArchT, FeatureTransformerT>> {

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -279,7 +279,7 @@ class FeatureTransformer {
             // means our pairwise product is zero. If we perform packus and
             // remove the lower-side clip for the second element, then our
             // product before packus will be negative, and is zeroed on pack.
-            // The two operation produce equivalent results, but the second
+            // The two operations produce equivalent results, but the second
             // one (using packus) saves one max operation per pair.
 
             // But here we run into a problem: mullo does not preserve the

--- a/src/numa.h
+++ b/src/numa.h
@@ -664,7 +664,7 @@ class NumaConfig {
     // ','-separated cpu indices
     // supports "first-last" range syntax for cpu indices
     // For example "0-15,128-143:16-31,144-159:32-47,160-175:48-63,176-191"
-    static NumaConfig from_string(const std::string& s) {
+    static std::optional<NumaConfig> from_string(const std::string& s) {
         NumaConfig cfg = empty();
 
         NumaIndex n = 0;
@@ -676,12 +676,15 @@ class NumaConfig {
                 for (auto idx : indices)
                 {
                     if (!cfg.add_cpu_to_node(n, CpuIndex(idx)))
-                        std::exit(EXIT_FAILURE);
+                        return std::nullopt;
                 }
 
                 n += 1;
             }
         }
+
+        if (n == 0)  // failed to parse any nodes
+            return std::nullopt;
 
         cfg.customAffinity = true;
 
@@ -1041,16 +1044,22 @@ class NumaConfig {
             auto parts = split(ss, "-");
             if (parts.size() == 1)
             {
-                const CpuIndex c = CpuIndex{str_to_size_t(std::string(parts[0]))};
-                indices.emplace_back(c);
+                auto c = str_to_size_t(std::string(parts[0]));
+                if (c.has_value())
+                    indices.emplace_back(*c);
             }
             else if (parts.size() == 2)
             {
-                const CpuIndex cfirst = CpuIndex{str_to_size_t(std::string(parts[0]))};
-                const CpuIndex clast  = CpuIndex{str_to_size_t(std::string(parts[1]))};
-                for (usize c = cfirst; c <= clast; ++c)
+                constexpr usize MaxIndices = 1 << 20;  // prevent oom
+
+                auto cfirst = str_to_size_t(std::string(parts[0]));
+                auto clast  = str_to_size_t(std::string(parts[1]));
+                if (cfirst.has_value() && clast.has_value() && *clast - *cfirst < MaxIndices)
                 {
-                    indices.emplace_back(c);
+                    for (usize c = *cfirst; c <= *clast; ++c)
+                    {
+                        indices.emplace_back(c);
+                    }
                 }
             }
         }

--- a/src/position.h
+++ b/src/position.h
@@ -180,6 +180,7 @@ class Position {
     int   rule50_count() const;
     Value non_pawn_material(Color c) const;
     Value non_pawn_material() const;
+    bool  dtz_is_dtm() const;  // Pawnless && (3-men || 4-men-minors-only)
 
     // Position consistency check, for debugging
     bool pos_is_ok() const;
@@ -346,6 +347,11 @@ inline int Position::game_ply() const { return gamePly; }
 inline int Position::rule50_count() const { return st->rule50; }
 
 inline bool Position::is_chess960() const { return chess960; }
+
+inline bool Position::dtz_is_dtm() const {
+    return !count<PAWN>()
+        && (count<ALL_PIECES>() == 3 || (count<ALL_PIECES>() == 4 && !pieces(QUEEN, ROOK)));
+}
 
 inline bool Position::capture(Move m) const {
     assert(m.is_ok());

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -244,7 +244,7 @@ void Search::Worker::start_searching() {
 
     // Send again PV info if we have a new best thread
     if (bestThread != this)
-        main_manager()->pv(*bestThread, threads, tt, bestThread->completedDepth);
+        main_manager()->output_pv(*bestThread, threads, tt, bestThread->completedDepth);
 
     Experience::on_search_complete(bestThread->rootPos,
                                    bestThread->rootMoves,
@@ -406,7 +406,7 @@ void Search::Worker::iterative_deepening() {
                 // at nodes > 10M (rather than depth N, which can be reached quickly)
                 if (mainThread && multiPV == 1 && (bestValue <= alpha || bestValue >= beta)
                     && nodes > 10000000)
-                    main_manager()->pv(*this, threads, tt, rootDepth);
+                    main_manager()->output_pv(*this, threads, tt, rootDepth);
 
                 // In case of failing low/high increase aspiration window and re-search,
                 // otherwise exit the loop.
@@ -485,7 +485,7 @@ void Search::Worker::iterative_deepening() {
             std::stable_sort(rootMoves.begin() + pvFirst, rootMoves.begin() + pvIdx + 1);
 
             if (mainThread && !threads.stop && (pvIdx + 1 == multiPV || nodes > 10000000))
-                main_manager()->pv(*this, threads, tt, rootDepth);
+                main_manager()->output_pv(*this, threads, tt, rootDepth);
 
             if (threads.stop)
                 break;
@@ -581,7 +581,8 @@ void Search::Worker::iterative_deepening() {
 
             // Cap used time in case of a single legal move for a better viewer experience
             if (rootMoves.size() == 1)
-                totalTime = std::min(502.0, totalTime);
+                // Cap used time to 0.5s for a better viewer experience
+                totalTime = std::min(500.0, totalTime);
 
             auto elapsedTime = elapsed();
 
@@ -979,8 +980,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        // Null move dynamic reduction based on depth and evaluation margin
+        Depth R = 7 + depth / 3 + std::max(0, (ss->staticEval - beta) / 256);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);
@@ -1391,12 +1392,32 @@ moves_loop:  // When in check, search starts here
 
             rm.effort += nodes - nodeCount;
 
-            rm.averageScore =
-              rm.averageScore != -VALUE_INFINITE ? (value + rm.averageScore) / 2 : value;
+            u64 N      = nodes - nodeCount;
+            u64 E_prev = std::max(u64(1), rm.effort - N);
 
-            rm.meanSquaredScore = rm.meanSquaredScore != -VALUE_INFINITE * VALUE_INFINITE
-                                  ? (value * std::abs(value) + rm.meanSquaredScore) / 2
-                                  : value * std::abs(value);
+            // Dynamic EMA parameters for root move
+            constexpr u64 Scale          = 32;
+            constexpr u64 ChiNumerator   = 3;
+            constexpr u64 ChiDenominator = 2;   // Chi = 3/2 = 1.5
+            constexpr u64 MinWeight      = 12;  // 37.5% minimum weight
+            constexpr u64 MaxWeight      = 24;  // 75% maximum weight
+
+            u64 w     = std::clamp((Scale * N * ChiDenominator)
+                                     / (N * ChiDenominator + ChiNumerator * E_prev),
+                                   MinWeight, MaxWeight);
+            u64 w_mss = std::min(w, u64(16));
+            i64 v2    = i64(value) * std::abs(value);
+
+            if (rm.averageScore == -VALUE_INFINITE)
+                rm.averageScore = value;
+            else
+                rm.averageScore = Value((value * w + rm.averageScore * (Scale - w)) / Scale);
+
+            if (rm.meanSquaredScore == -VALUE_INFINITE * VALUE_INFINITE)
+                rm.meanSquaredScore = value * std::abs(value);
+            else
+                rm.meanSquaredScore =
+                  Value((v2 * w_mss + int64_t(rm.meanSquaredScore) * (Scale - w_mss)) / Scale);
 
             // PV move or new best move?
             if (moveCount == 1 || value > alpha)
@@ -2008,9 +2029,16 @@ void update_quiet_histories(
 Move Skill::pick_best(const RootMoves& rootMoves, usize multiPV) {
     static PRNG rng(now());  // PRNG sequence should be non-deterministic
 
-    // RootMoves are already sorted by score in descending order
-    Value  topScore = rootMoves[0].score;
-    int    delta    = std::min(topScore - rootMoves[multiPV - 1].score, int(PawnValue));
+    // With tablebases at the root, rootMoves are ordered by tbRank rather than by
+    // score, so compute the score range explicitly to keep 'delta' non-negative.
+    Value topScore = rootMoves[0].score;
+    Value minScore = rootMoves[0].score;
+    for (usize i = 1; i < multiPV; ++i)
+    {
+        topScore = std::max(topScore, rootMoves[i].score);
+        minScore = std::min(minScore, rootMoves[i].score);
+    }
+    int    delta    = std::min(topScore - minScore, int(PawnValue));
     int    maxScore = -VALUE_INFINITE;
     double weakness = 120 - 2 * level;
 
@@ -2206,7 +2234,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
           << sync_endl;
 }
 
-void SearchManager::pv(Search::Worker&           worker,
+void SearchManager::output_pv(Search::Worker&           worker,
                        const ThreadPool&         threads,
                        const TranspositionTable& tt,
                        Depth                     depth) {

--- a/src/search.h
+++ b/src/search.h
@@ -250,10 +250,10 @@ class SearchManager: public ISearchManager {
 
     void check_time(Search::Worker& worker) override;
 
-    void pv(Search::Worker&           worker,
-            const ThreadPool&         threads,
-            const TranspositionTable& tt,
-            Depth                     depth);
+    void output_pv(Search::Worker&           worker,
+                   const ThreadPool&         threads,
+                   const TranspositionTable& tt,
+                   Depth                     depth);
 
     Stockfish::TimeManagement tm;
     double                    originalTimeAdjust;
@@ -321,7 +321,8 @@ class Worker {
 
     // This is the main search function, for both PV and non-PV nodes
     template<NodeType nodeType>
-    Value search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, bool cutNode);
+    Value
+    search(Position& pos, Stack* ss, Value alpha, Value beta, Depth depth, const bool cutNode);
 
     // Quiescence search function, which is called by the main search
     template<NodeType nodeType>

--- a/src/shm.h
+++ b/src/shm.h
@@ -39,11 +39,6 @@
     #include "shm_linux.h"
 #endif
 
-#if defined(__ANDROID__)
-    #include <limits.h>
-    #define SF_MAX_SEM_NAME_LEN NAME_MAX
-#endif
-
 #include "types.h"
 
 #include "memory.h"

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1758,6 +1758,9 @@ Config Tablebases::rank_root_moves(const OptionsMap&  options,
 
     if (config.cardinality >= popcount(pos.pieces()) && !pos.can_castle(ANY_CASTLING))
     {
+        // Use DTZ to rank the moves if checkmate is the only zeroing move
+        rankDTZ = rankDTZ || pos.dtz_is_dtm();
+
         // Rank moves using DTZ tables
         config.rootInTB = root_probe(pos, rootMoves, options["Syzygy50MoveRule"], rankDTZ);
 

--- a/src/types.h
+++ b/src/types.h
@@ -59,7 +59,7 @@
 // _WIN32                  Building on Windows (any)
 // _WIN64                  Building on Windows 64 bit
 
-// Enforce minimum GCC version
+    // Enforce minimum GCC version
     #if defined(__GNUC__) && !defined(__clang__) \
       && (__GNUC__ < 9 || (__GNUC__ == 9 && __GNUC_MINOR__ < 3))
         #error "Stockfish requires GCC 9.3 or later for correct compilation"
@@ -241,6 +241,10 @@ constexpr bool is_mated(Value value) {
 }
 
 constexpr bool is_mate_or_mated(Value value) { return is_mate(value) || is_mated(value); }
+
+constexpr Value mate_in(int ply) { return VALUE_MATE - ply; }
+
+constexpr Value mated_in(int ply) { return -VALUE_MATE + ply; }
 
 // In the code, we make the assumption that these values
 // are such that non_pawn_material() can be used to uniquely
@@ -428,10 +432,6 @@ constexpr Piece operator~(Piece pc) { return Piece(pc ^ 8); }
 constexpr CastlingRights operator&(Color c, CastlingRights cr) {
     return CastlingRights((c == WHITE ? WHITE_CASTLING : BLACK_CASTLING) & cr);
 }
-
-constexpr Value mate_in(int ply) { return VALUE_MATE - ply; }
-
-constexpr Value mated_in(int ply) { return -VALUE_MATE + ply; }
 
 constexpr Square make_square(File f, Rank r) { return Square((r << 3) + f); }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -106,6 +106,7 @@ void UCIEngine::loop() {
             && !getline(std::cin, cmd))  // Wait for an input or an end-of-file (EOF) indication
             cmd = "quit";
 
+        currentCmd = cmd;
         std::istringstream is(cmd);
 
         token.clear();  // Avoid a stale if getline() returns nothing or a blank line
@@ -212,9 +213,13 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
     limits.startTime = now();  // The search starts as early as possible
 
     while (is >> token)
+    {
         if (token == "searchmoves")  // Needs to be the last command on the line
+        {
             while (is >> token)
                 limits.searchmoves.push_back(to_lower(token));
+            break;
+        }
 
         else if (token == "wtime")
             is >> limits.time[WHITE];
@@ -240,6 +245,10 @@ Search::LimitsType UCIEngine::parse_limits(std::istream& is) {
             limits.infinite = 1;
         else if (token == "ponder")
             limits.ponderMode = true;
+
+        if (is.fail())
+            terminate_on_critical_error("Invalid argument for '" + token + "'");
+    }
 
     return limits;
 }
@@ -274,6 +283,7 @@ void UCIEngine::bench(std::istream& args) {
 
     for (const auto& cmd : list)
     {
+        currentCmd = cmd;
         std::istringstream is(cmd);
         is >> std::skipws >> token;
 
@@ -356,6 +366,7 @@ void UCIEngine::benchmark(std::istream& args) {
     // Warmup
     for (const auto& cmd : setup.commands)
     {
+        currentCmd = cmd;
         std::istringstream is(cmd);
         is >> std::skipws >> token;
 
@@ -407,6 +418,7 @@ void UCIEngine::benchmark(std::istream& args) {
 
     for (const auto& cmd : setup.commands)
     {
+        currentCmd = cmd;
         std::istringstream is(cmd);
         is >> std::skipws >> token;
 
@@ -634,7 +646,7 @@ std::string UCIEngine::move(Move m, bool chess960) {
 
 
 std::string UCIEngine::to_lower(std::string str) {
-    std::transform(str.begin(), str.end(), str.begin(), [](auto c) { return std::tolower(c); });
+    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c) { return std::tolower(c); });
 
     return str;
 }
@@ -694,6 +706,11 @@ void UCIEngine::on_bestmove(std::string_view bestmove, std::string_view ponder) 
     if (!ponder.empty())
         std::cout << " ponder " << ponder;
     std::cout << sync_endl;
+}
+
+void UCIEngine::terminate_on_critical_error(const std::string& message) {
+    sync_cout << "info string CRITICAL ERROR: Command `" << currentCmd
+              << "` failed. Reason: " << message << sync_endl;
 }
 
 }  // namespace Stockfish

--- a/src/uci.h
+++ b/src/uci.h
@@ -49,13 +49,14 @@ class UCIEngine {
     static std::string to_lower(std::string str);
     static Move        to_move(const Position& pos, std::string str);
 
-    static Search::LimitsType parse_limits(std::istream& is);
+    Search::LimitsType parse_limits(std::istream& is);
 
     auto& engine_options() { return engine.get_options(); }
 
    private:
     Engine      engine;
     CommandLine cli;
+    std::string currentCmd;
 
     static void print_info_string(std::string_view str);
 
@@ -72,6 +73,7 @@ class UCIEngine {
     static void on_bestmove(std::string_view bestmove, std::string_view ponder);
 
     void init_search_update_listeners();
+    void terminate_on_critical_error(const std::string& message);
 };
 
 }  // namespace Stockfish

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
@@ -34,7 +35,7 @@ bool CaseInsensitiveLess::operator()(const std::string& s1, const std::string& s
 
     return std::lexicographical_compare(
       s1.begin(), s1.end(), s2.begin(), s2.end(),
-      [](char c1, char c2) { return std::tolower(c1) < std::tolower(c2); });
+      [](unsigned char c1, unsigned char c2) { return std::tolower(c1) < std::tolower(c2); });
 }
 
 void OptionsMap::add_info_listener(InfoListener&& message_func) { info = std::move(message_func); }
@@ -144,6 +145,16 @@ bool Option::operator==(const char* s) const {
 
 bool Option::operator!=(const char* s) const { return !(*this == s); }
 
+static bool value_in_range(const std::string& v, int min, int max) {
+    if (v.empty())
+        return false;
+    errno                  = 0;
+    char*           end    = nullptr;
+    const long long result = std::strtoll(v.c_str(), &end, 10);
+    if (errno == ERANGE || *end != '\0')
+        return false;
+    return result >= min && result <= max;
+}
 
 // Updates currentValue and triggers on_change() action. It's up to
 // the GUI to check for option's limits, but we could receive the new value
@@ -154,7 +165,7 @@ Option& Option::operator=(const std::string& v) {
 
     if ((type != "button" && type != "string" && v.empty())
         || (type == "check" && v != "true" && v != "false")
-        || (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
+        || (type == "spin" && !value_in_range(v, min, max)))
         return *this;
 
     if (type == "combo")


### PR DESCRIPTION
### Motivation

- Aplicar y auditar el bloque autorizado de Stockfish del 10 de julio de 2026 sobre la topología local de Revolution preservando el estado P0G y sin introducir commits posteriores ni reverts no autorizados.
- Transportar correcciones CLI/search/NNUE que mejoran robustez de parseo, seguridad NUMA y rendimiento NNUE sin sustituir redes, archivos Zobrist, Experience o Book.
- Evitar reintroducir las copias eliminadas por P0G en `nnue_architecture.h` y mantener la identidad y configuración de Revolution.

### Description

- Puerto y adaptación local de los ocho commits oficiales: limpiezas menores, endurecimiento del CLI (parsing seguro de enteros con `std::optional`, `currentCmd`, detección de argumentos inválidos y `terminate_on_critical_error`), y validaciones `tolower` usando `unsigned char` (varios ficheros: `src/misc.*`, `src/uci.*`, `src/ucioption.*`).
- Split NEON denso y AVX‑VNNI sparse en las rutas NNUE: `src/nnue/layers/affine_transform.h` y `src/nnue/layers/affine_transform_sparse_input.h` adaptadas para dos cadenas en NEON y AVX‑VNNI y tres cadenas para AVX‑512/other VNNI según la topología local, preservando SFNNv15 y formatos de red.
- Correcciones en búsqueda y heurísticas: `Skill::pick_best()` ahora calcula explícitamente `topScore`/`minScore` y garantiza `delta >= 0`; se añadió EMA dinámica de root score y meanSquaredScore con cálculo seguro en 64 bits; NMP reducido dinámicamente con la fórmula del bloque Jul10; se ajustó cap de tiempo único a `500.0` ms.
- Robustez NUMA y utilidades: `NumaConfig::from_string()` devuelve `std::optional` y evita `std::exit`, `str_to_size_t()` ahora devuelve `std::optional<usize>` y rechaza entradas inválidas; `StatsEntry` recibe `static_assert` más restrictivo para garantizar tipos enteros y evitar overflow; se eliminó el almacenado/uso global de `SquareDistance` en favor de la topología local.
- Cambios de interfaz local mínimos: adaptación de firmas y retornos donde fue necesario (`Engine::set_numa_config_from_option` devuelve `bool`, `UCIEngine::parse_limits` no es estática) y renombrado de `pv()` → `output_pv()` en `SearchManager` para mantener semántica upstream adaptada.
- Preservaciones: no se modificaron `src/experience.*`, libros, redes `.nnue` ni archivos Zobrist; P0G (eliminación de copias NNUE y escritura directa en `concat_buffer`) permanece intacto; identidad y `EvalFileDefaultName` inalterados.

### Testing

- Verificaciones Git/Upstream: confirmado que `00f96d22...` (P0G) está en el baseline `origin/main`, verificadas las ocho revisiones oficiales y que el último hash pertenece al árbol autorizado; todos los objetos oficiales existen.
- Compilación: `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=gcc` completó con éxito; log auditado y búsqueda de `warning:`/`error:` devolvió cero coincidencias.
- Binario y UCI: generado exactamente un binario `src/Revolution-6.0-040526-sse41popcnt`; `printf "uci
isready
quit
" | <BIN>` devolvió `id name Revolution-6.0-040526`, `uciok` y `readyok`, y la opción `EvalFile` por defecto `nn-0ee0657fb25e.nnue` estuvo presente.
- Ejecución funcional: `bench 16 1 8 default depth` terminó con código 0 y valores razonables (nodos y NPS), la prueba `UCI_LimitStrength` (depth 6) produjo una `bestmove` legal sin crash ni `bestmove (none)`, y la prueba de `NumaPolicy` inválida fue rechazada/ignoradacon control sin romper la configuración.
- Higiene: `git diff --check` limpio, sin marcadores de conflicto, sin artefactos versionados añadidos; se creó un único commit de implementación `P0H-SF20260710: apply Jul10 CLI search and affine updates` y se prepararon los metadatos del PR (título y cuerpo) en la rama `codex/revolution-p0h-sf20260710`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cacd82b848327a9c8a5feca18769b)