### PR TITLE
Revolution P0I: apply Stockfish Jul11 version and NMP revert block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 **/*.o
 **/*.s
 src/.depend
+.build_sha.txt
+.build_date.txt
+.build_diffindex.txt
 
 # Built binary
 src/stockfish*

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,7 +37,6 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
-Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)

--- a/src/Makefile
+++ b/src/Makefile
@@ -948,19 +948,30 @@ ifeq ($(syzygy),no)
 	CXXFLAGS += -DNO_TABLEBASES
 endif
 
-### 3.8.1 Try to include git commit sha for versioning
-GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null | cut -c 1-8)
-ifneq ($(GIT_SHA), )
-	CXXFLAGS += -DGIT_SHA=$(GIT_SHA)
+### 3.8.1 Try to include git info for versioning and avoid recompiles if nothing changes
+BUILD_SHA_FILE       := .build_sha.txt
+BUILD_DATE_FILE      := .build_date.txt
+BUILD_DIFFINDEX_FILE := .build_diffindex.txt
+GIT_SHA              := $(shell git rev-parse HEAD 2>/dev/null | cut -c 1-8 || true)
+GIT_DATE             := $(shell git show -s --date=format:%Y%m%d --format=%cd HEAD 2>/dev/null || true)
+GIT_DIFFINDEX        := $(shell git diff-index --quiet HEAD -- 2>/dev/null; [ $$? -eq 1 ] && echo 1 || true)
+COMPILER_DATE        := $(shell date +%Y%m%d 2>/dev/null)
+BUILD_DATE           := $(if $(GIT_DATE),$(GIT_DATE),$(COMPILER_DATE))
+
+define cache_file_contents
+$(shell \
+	if [ ! -f $(1) ] || [ "`cat $(1)`" != "$(2)" ]; then \
+		echo "$(2)" > $(1); \
+	fi)
+endef
+
+ifneq ($(filter $(MAKECMDGOALS),help strip install clean net objclean profileclean format config-sanity),$(MAKECMDGOALS))
+_ := $(call cache_file_contents,$(BUILD_SHA_FILE),$(GIT_SHA))
+_ := $(call cache_file_contents,$(BUILD_DATE_FILE),$(BUILD_DATE))
+_ := $(call cache_file_contents,$(BUILD_DIFFINDEX_FILE),$(GIT_DIFFINDEX))
 endif
 
-### 3.8.2 Try to include git commit date for versioning
-GIT_DATE := $(shell git show -s --date=format:'%Y%m%d' --format=%cd HEAD 2>/dev/null)
-ifneq ($(GIT_DATE), )
-	CXXFLAGS += -DGIT_DATE=$(GIT_DATE)
-endif
-
-### 3.8.3 Try to include architecture
+### 3.8.2 Try to include architecture
 ifneq ($(ARCH), )
 	CXXFLAGS += -DARCH=$(ARCH)
 endif
@@ -1216,6 +1227,7 @@ clean: objclean profileclean
 objclean:
 	@rm -f stockfish stockfish.exe revolution revolution.exe $(EXE_GEN) $(EXE_USE) $(RELEASE_EXE)
 	@find . -type f \( -name '*.o' -o -name '*.d' \) -delete
+	@rm -f $(BUILD_SHA_FILE) $(BUILD_DATE_FILE) $(BUILD_DIFFINDEX_FILE)
 
 # clean auxiliary profiling files
 profileclean:
@@ -1319,9 +1331,8 @@ config-sanity: net
 $(EXE): $(OBJS)
 	+$(CXX) -o $@ $(OBJS) $(LDFLAGS)
 
-# Force recompilation to ensure version info is up-to-date
-misc.o: FORCE
-FORCE:
+misc.o: misc.cpp $(BUILD_SHA_FILE) $(BUILD_DATE_FILE) $(BUILD_DIFFINDEX_FILE)
+	$(strip $(CXX) $(CPPFLAGS) $(CXXFLAGS) $(if $(GIT_SHA),-DGIT_SHA=$(GIT_SHA)) $(if $(GIT_DATE),-DGIT_DATE=$(GIT_DATE)) $(if $(GIT_DIFFINDEX),-DGIT_DIFFINDEX=$(GIT_DIFFINDEX))) -c -o $@ $<
 
 clang-profile-make:
 	@command -v $(LLVM_PROFDATA) >/dev/null 2>&1 || (echo "ERROR: $(LLVM_PROFDATA) not found"; exit 1)

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -158,6 +158,10 @@ std::string engine_version_info() {
            << std::setw(2) << std::setfill('0') << day;
 #endif
 
+#ifdef GIT_DIFFINDEX
+        ss << "-m";
+#endif
+
         ss << "-";
 
 #ifdef GIT_SHA

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -980,8 +980,8 @@ Value Search::Worker::search(
     {
         assert((ss - 1)->currentMove != Move::null());
 
-        // Null move dynamic reduction based on depth and evaluation margin
-        Depth R = 7 + depth / 3 + std::max(0, (ss->staticEval - beta) / 256);
+        // Null move dynamic reduction based on depth
+        Depth R = 7 + depth / 3;
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);


### PR DESCRIPTION
### Motivation
- Apply the two upstream Stockfish Jul 11 commits (enhance version metadata and revert NMP margin scaling) while preserving Revolution's local topology and identities. 
- Ensure the build only recompiles `misc.o` when version metadata (SHA/date/diff-index) changes and keep `Revolution-6.0-040526` as the fixed UCI id.
- Remove the evaluation-margin term from Null Move Pruning to restore mate finding correctness and remove the temporary AUTHORS credit introduced with that change.

### Description
- Added three build-cache files and ignore rules: `.build_sha.txt`, `.build_date.txt`, `.build_diffindex.txt` and updated `.gitignore` accordingly. 
- Reworked `src/Makefile` to compute `GIT_SHA`, `GIT_DATE` and `GIT_DIFFINDEX` safely, added `cache_file_contents` helper, write/update cache files only on content change, remove unconditional `misc.o: FORCE`, and made `misc.o` depend on the three cache files and propagate `-DGIT_*` macros to `misc.o` only. 
- Modified `src/misc.cpp` so `engine_version_info()` appends `-m` only when `if constexpr (version == "dev")` and when `GIT_DIFFINDEX` is defined, preserving the fixed release identity for non-dev builds. 
- Reverted the NMP margin scaling in `src/search.cpp` to `Depth R = 7 + depth / 3;` leaving all NMP entry conditions and surrounding logic untouched. 
- Removed the single AUTHORS entry `Ayush (ayushthepiro11-design)` that was added alongside the reverted NMP change and kept all other credits and project-specific content intact. 
- Created branch `codex/revolution-p0i-sf20260711` and committed the single implementer commit `P0I-SF20260711: enhance version metadata and revert NMP margin scaling` (HEAD `e5d8b0ae`).

### Testing
- Verified upstream block and ancestry: inspected `upstream/master` entries for `c18feef` and `9a8dd81` and confirmed both objects exist and the required order/ancestry is satisfied. 
- Performed diffs and check: ran `git diff --check` and inspected the diffstat showing `.gitignore`, `AUTHORS`, `src/Makefile`, `src/misc.cpp`, `src/search.cpp` changes with no conflict markers. 
- Build validation: executed three automated builds for `ARCH=x86-64-sse41-popcnt`/`COMP=gcc` — dirty (tree with changes), clean (after commit), and repeat (no-clean) — all completed with exit code 0 and zero `warning:`/`error:` matches. 
- Recompilation verification: confirmed the repeat build did not recompile `misc.cpp` (no `misc.cpp`/`misc.o` lines in repeat build log) and that `src/.build_diffindex.txt` recorded `1` for dirty build and empty for clean build. 
- Runtime/UCI and bench checks: ran UCI probe which returned `id name Revolution-6.0-040526`, `uciok` and `readyok`; ran `bench` which completed successfully (172665 nodes, ~438236 NPS) and returned exit code 0. 
- Mate-in-two regression: executed the official mate-in-2 testcase under timeout and observed a normal run with `bestmove` returned and no crash/assert/error. 
- Preservation probes: searched repository for removed/forbidden artifacts and P0G regressions (no `ac_0_out`, `ac_1_out`, `memset(concat_buffer)` or the two `memcpy` patterns) and verified `nn-0ee0657fb25e.nnue` remains referenced. 
- Hygiene and artifacts: verified `git ls-files` shows zero tracked build/cache artifacts and `git diff --check` is clean. 

All automated checks and builds listed above succeeded; the only external push step failed due to missing interactive GitHub credentials in the environment (`could not read Username`), so the branch is prepared locally and the PR metadata was generated but the remote PR URL was not created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cb13072f8832783328cd07f0f40d5)