### PR TITLE
Revolution P0K: apply Stockfish Jul20 topology block

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 6.0-040526
 
-NNUE_NET = nn-0ee0657fb25e.nnue
+NNUE_NET = nn-89cb98a217f7.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -86,16 +86,16 @@ SRCS = attacks.cpp benchmark.cpp bitboard.cpp evaluate.cpp main.cpp \
 	misc.cpp movegen.cpp movepick.cpp position.cpp \
 	search.cpp thread.cpp timeman.cpp tt.cpp uci.cpp ucioption.cpp tune.cpp syzygy/tbprobe.cpp \
 	nnue/nnue_accumulator.cpp nnue/nnue_misc.cpp nnue/network.cpp \
-	nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp \
+	nnue/features/half_ka_v2_hm.cpp nnue/features/full_threats.cpp nnue/features/pp_3wide.cpp \
 	book/book_manager.cpp book/book_utils.cpp \
 	experience.cpp engine.cpp score.cpp memory.cpp
 
 HEADERS = attacks.h benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.h history.h \
-		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h \
+		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h nnue/features/pp_3wide.h \
 		nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
 		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
-		position.h search.h syzygy/tbprobe.h thread.h thread_win32_osx.h timeman.h \
+		position.h search.h syzygy/tbprobe.h thread.h thread_native.h timeman.h \
 		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h \
 		experience.h experience_compat.h experience_zobrist.h
 
@@ -720,31 +720,27 @@ else ifeq ($(COMP),mingw)
 	CXXFLAGS += -fno-ipa-cp-clone
 endif
 
-### On mingw use Windows threads, otherwise POSIX
-ifneq ($(comp),mingw)
-	CXXFLAGS += -DUSE_PTHREADS
-	# On Android Bionic's C library comes with its own pthread implementation bundled in
-	ifneq ($(OS),Android)
-		# Haiku has pthreads in its libroot, so only link it in on other platforms
-		ifneq ($(KERNEL),Haiku)
-			ifneq ($(COMP),ndk)
-			ifneq ($(arch),wasm32)
-				LDFLAGS += -lpthread
+# On Android Bionic's C library comes with its own pthread implementation bundled in
+ifneq ($(OS),Android)
+	# Haiku has pthreads in its libroot, so only link it in on other platforms
+	ifneq ($(KERNEL),Haiku)
+		ifneq ($(COMP),ndk)
+		ifneq ($(arch),wasm32)
+			LDFLAGS += -lpthread
 
-				add_lrt = yes
-				ifeq ($(target_windows),yes)
-					add_lrt = no
-				endif
-
-				ifeq ($(TARGET_KERNEL),Darwin)
-					add_lrt = no
-				endif
-
-				ifeq ($(add_lrt),yes)
-					LDFLAGS += -lrt
-				endif
+			add_lrt = yes
+			ifeq ($(target_windows),yes)
+				add_lrt = no
 			endif
+
+			ifeq ($(TARGET_KERNEL),Darwin)
+				add_lrt = no
 			endif
+
+			ifeq ($(add_lrt),yes)
+				LDFLAGS += -lrt
+			endif
+		endif
 		endif
 	endif
 endif

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -24,15 +24,17 @@
 
 namespace Stockfish::Attacks {
 
+#ifdef USE_DUAL_HYPERBOLA_QUINT
+alignas(64) DualMagic DualMagics[SQUARE_NB];
+#endif
+
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
 
 namespace {
 
-#ifdef USE_DUAL_HYPERBOLA_QUINT
-alignas(64) DualMagic DualMagics[SQUARE_NB];
-#else
+#ifndef USE_DUAL_HYPERBOLA_QUINT
 alignas(64) Magic Magics[SQUARE_NB][2];
 #endif
 
@@ -187,28 +189,11 @@ void init() {
     }
 }
 
-#ifdef USE_DUAL_HYPERBOLA_QUINT
-const DualMagic& dual_magic(Square s) { return DualMagics[s]; }
-#else
+#ifndef USE_DUAL_HYPERBOLA_QUINT
 const Magic& magic(Square s, PieceType pt) {
     assert((pt == BISHOP || pt == ROOK) && is_ok(s));
     return Magics[s][pt - BISHOP];
 }
 #endif
-
-Bitboard line_bb(Square s1, Square s2) {
-    assert(is_ok(s1) && is_ok(s2));
-    return LineBB[s1][s2];
-}
-
-Bitboard between_bb(Square s1, Square s2) {
-    assert(is_ok(s1) && is_ok(s2));
-    return BetweenBB[s1][s2];
-}
-
-Bitboard ray_pass_bb(Square s1, Square s2) {
-    assert(is_ok(s1) && is_ok(s2));
-    return RayPassBB[s1][s2];
-}
 
 }  // namespace Stockfish::Attacks

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <array>
 #include <initializer_list>
+#include <utility>
 
 #include "types.h"
 #include "bitboard.h"
@@ -123,7 +124,9 @@ struct alignas(32) DualMagic {
     }
 };
 
-const DualMagic& dual_magic(Square s);
+extern DualMagic DualMagics[SQUARE_NB];
+
+inline const DualMagic& dual_magic(Square s) { return DualMagics[s]; }
 
 #else
 // Magic holds all magic bitboards relevant data for a single square
@@ -156,9 +159,20 @@ extern Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 extern Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
 
-Bitboard line_bb(Square s1, Square s2);
-Bitboard between_bb(Square s1, Square s2);
-Bitboard ray_pass_bb(Square s1, Square s2);
+inline Bitboard line_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return LineBB[s1][s2];
+}
+
+inline Bitboard between_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return BetweenBB[s1][s2];
+}
+
+inline Bitboard ray_pass_bb(Square s1, Square s2) {
+    assert(is_ok(s1) && is_ok(s2));
+    return RayPassBB[s1][s2];
+}
 
 // Returns the bitboard of target square for the given step
 // from the given square. If the step is off the board, returns empty bitboard.
@@ -293,6 +307,14 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     default :
         return PseudoAttacks[Pt][s];
     }
+#endif
+}
+
+inline std::pair<Bitboard, Bitboard> both_attacks_bb(Square s, Bitboard occupied) {
+#ifdef USE_DUAL_HYPERBOLA_QUINT
+    return dual_magic(s).both_attacks_bb(occupied);
+#else
+    return {attacks_bb<BISHOP>(s, occupied), attacks_bb<ROOK>(s, occupied)};
 #endif
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -20,6 +20,7 @@
 #define BITBOARD_H_INCLUDED
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <string>
 #include <type_traits>
@@ -127,8 +128,23 @@ constexpr Bitboard pawn_single_push_bb(Color c, Bitboard b) {
     return c == WHITE ? shift<NORTH>(b) : shift<SOUTH>(b);
 }
 
-constexpr int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
+inline constexpr auto PawnPairBB = []() {
+    std::array<Bitboard, SQUARE_NB> result{};
+    for (Square s = SQ_A1; s <= SQ_H8; ++s)
+    {
+        Bitboard file  = file_bb(s);
+        Bitboard files = file | shift<EAST>(file) | shift<WEST>(file);
+        result[s]      = files & ~(Rank1BB | Rank8BB) & ~square_bb(s);
+    }
+    return result;
+}();
 
+// Returns the squares that can host a pawn forming a "pawn pair" with a pawn
+// on s: own file plus adjacent files, restricted to ranks 2-7, excluding s.
+// The geometry is color-independent.
+constexpr Bitboard pawn_pair_bb(Square s) { return PawnPairBB[s]; }
+
+constexpr int edge_distance(File f) { return std::min(f, File(FILE_H - f)); }
 
 template<typename T>
 constexpr int constexpr_popcount(T v) {

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-0ee0657fb25e.nnue"
+#define EvalFileDefaultName "nn-89cb98a217f7.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -520,7 +520,8 @@ std::optional<usize> str_to_size_t(const std::string& s) {
     errno                           = 0;
     char*                    endptr = nullptr;
     const unsigned long long value  = std::strtoull(s.c_str(), &endptr, 10);
-    if (errno == ERANGE || *endptr != '\0' || value > std::numeric_limits<usize>::max())
+    if (errno == ERANGE || (*endptr != '\0' && !std::isspace(*endptr))
+        || value > std::numeric_limits<usize>::max())
         return std::nullopt;
     return static_cast<usize>(value);
 }
@@ -554,7 +555,8 @@ std::string CommandLine::get_binary_directory(std::string argv0) {
 
     if (const DWORD length = GetModuleFileNameW(nullptr, path, MaxPath))
     {
-        const int size = WideCharToMultiByte(CP_UTF8, 0, path, length, nullptr, 0, nullptr, nullptr);
+        const int size =
+          WideCharToMultiByte(CP_UTF8, 0, path, length, nullptr, 0, nullptr, nullptr);
         if (size > 0)
         {
             argv0.resize(size);

--- a/src/nnue/features/full_threats.cpp
+++ b/src/nnue/features/full_threats.cpp
@@ -21,7 +21,6 @@
 #include "full_threats.h"
 
 #include <array>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <initializer_list>
@@ -73,7 +72,7 @@ constexpr auto make_piece_indices_piece() {
 
     for (Square from = SQ_A1; from <= SQ_H8; ++from)
     {
-        Bitboard attacks = PawnPushOrAttacks[C][from];
+        Bitboard attacks = PseudoAttacks[C][from];
 
         for (Square to = SQ_A1; to <= SQ_H8; ++to)
         {
@@ -137,7 +136,7 @@ constexpr auto init_threat_offsets() {
             else if (from >= SQ_A2 && from <= SQ_H7)
             {
                 Bitboard attacks =
-                  (pieceIdx < 8) ? PawnPushOrAttacks[WHITE][from] : PawnPushOrAttacks[BLACK][from];
+                  (pieceIdx < 8) ? PseudoAttacks[WHITE][from] : PseudoAttacks[BLACK][from];
                 cumulativePieceOffset += constexpr_popcount(attacks);
             }
         }
@@ -210,9 +209,8 @@ inline sf_always_inline IndexType FullThreats::make_index(
 void FullThreats::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
     Square   ksq      = pos.square<KING>(perspective);
     Bitboard occupied = pos.pieces();
-    Bitboard pawns    = pos.pieces(PAWN);
 
-    const Bitboard pawnTargets        = pos.pieces(PAWN, KNIGHT, ROOK);
+    const Bitboard pawnTargets        = pos.pieces(KNIGHT, ROOK);
     const Bitboard minorSliderTargets = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK);
     const Bitboard queenTargets       = pos.pieces(PAWN, KNIGHT, BISHOP, ROOK, QUEEN);
 
@@ -255,19 +253,6 @@ void FullThreats::append_active_indices(Color perspective, const Position& pos, 
                         active.push_back(index);
                 }
 
-                // Set of pawns which are prevented from movement by a pawn in front of them
-                Bitboard pushers = pawn_single_push_bb(~c, pawns) & pos.pieces(c, PAWN);
-                while (pushers)
-                {
-                    Square from     = pop_lsb(pushers);
-                    Square to       = from + pawn_push(c);
-                    Piece  attacked = pos.piece_on(to);
-                    assert(type_of(attacked) == PAWN);
-
-                    IndexType index = make_index(perspective, attacker, from, to, attacked, ksq);
-                    if (index < Dimensions)
-                        active.push_back(index);
-                }
             }
             else
             {

--- a/src/nnue/features/full_threats.h
+++ b/src/nnue/features/full_threats.h
@@ -29,16 +29,18 @@ class Position;
 
 namespace Stockfish::Eval::NNUE::Features {
 
-static constexpr int numValidTargets[PIECE_NB] = {0, 6, 10, 8, 8, 10, 0, 0,
-                                                  0, 6, 10, 8, 8, 10, 0, 0};
+// Pawn diagonal threats only target knights and rooks (pawn-pawn relationships
+// are handled by the PP_3Wide feature set), so pawns have 4 valid targets.
+static constexpr int numValidTargets[PIECE_NB] = {0, 4, 10, 8, 8, 10, 0, 0,
+                                                  0, 4, 10, 8, 8, 10, 0, 0};
 
 class FullThreats {
    public:
     // Hash value embedded in the evaluation file
-    static constexpr u32 HashValue = 0x8f234cb8u;
+    static constexpr u32 HashValue = 0x2e6b9d04u;
 
     // Number of feature dimensions
-    static constexpr IndexType Dimensions = 60720;
+    static constexpr IndexType Dimensions = 59808;
 
     // clang-format off
     // Orient a square according to perspective (rotates by 180 for black)
@@ -54,7 +56,7 @@ class FullThreats {
     };
 
     static constexpr int map[PIECE_TYPE_NB-2][PIECE_TYPE_NB-2] = {
-      { 0,  1, -1,  2, -1, -1},
+      {-1,  0, -1,  1, -1, -1},
       { 0,  1,  2,  3,  4, -1},
       { 0,  1,  2,  3, -1, -1},
       { 0,  1,  2,  3, -1, -1},
@@ -65,7 +67,7 @@ class FullThreats {
 
     // Maximum number of simultaneously active features.
     static constexpr IndexType MaxActiveDimensions = 128;
-    using IndexList                                = ValueList<IndexType, MaxActiveDimensions>;
+    using IndexList = ValueList<u16, 256>;
     using DiffType                                 = DirtyThreats;
 
     static IndexType

--- a/src/nnue/features/pp_3wide.cpp
+++ b/src/nnue/features/pp_3wide.cpp
@@ -1,0 +1,171 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "pp_3wide.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+
+#include "full_threats.h"
+#include "../../bitboard.h"
+#include "../../misc.h"
+#include "../../position.h"
+#include "../../types.h"
+#include "../nnue_common.h"
+
+namespace Stockfish::Eval::NNUE::Features {
+
+constexpr IndexType make_pawn_id(Color color, Square square) {
+    assert(square >= SQ_A2 && square <= SQ_H7);
+    return 48 * int(color) + square - SQ_A2;
+}
+
+#ifdef USE_AVX512ICL
+static inline __m256i pp_idx_epi16(__m256i a, __m256i b) {
+    const __m256i hi   = _mm256_max_epu16(a, b);
+    const __m256i lo   = _mm256_min_epu16(a, b);
+    const __m256i prod = _mm256_mullo_epi16(hi, _mm256_sub_epi16(hi, _mm256_set1_epi16(1)));
+    return _mm256_add_epi16(_mm256_add_epi16(_mm256_srli_epi16(prod, 1), lo),
+                            _mm256_set1_epi16(i16(PP_3Wide::IndexBase)));
+}
+#endif
+
+inline sf_always_inline IndexType PP_3Wide::make_index(
+  Color perspective, Color color, Square from, Square to, Color pairedColor, Square ksq) {
+    const i8 orientation   = FullThreats::OrientTBL[ksq] ^ (56 * perspective);
+    unsigned from_oriented = u8(from) ^ orientation;
+    unsigned to_oriented   = u8(to) ^ orientation;
+
+    Color color_oriented       = Color(color ^ perspective);
+    Color pairedColor_oriented = Color(pairedColor ^ perspective);
+
+    assert(from_oriented >= SQ_A2 && from_oriented <= SQ_H7);
+    assert(to_oriented >= SQ_A2 && to_oriented <= SQ_H7);
+
+    const IndexType idA = make_pawn_id(color_oriented, Square(from_oriented));
+    const IndexType idB = make_pawn_id(pairedColor_oriented, Square(to_oriented));
+    const IndexType hi  = std::max(idA, idB);
+    const IndexType lo  = std::min(idA, idB);
+
+    return hi * (hi - 1) / 2 + lo + IndexBase;
+}
+
+void PP_3Wide::append_active_indices(Color perspective, const Position& pos, IndexList& active) {
+    const Square   ksq   = pos.square<KING>(perspective);
+    const Bitboard white = pos.pieces(WHITE, PAWN);
+    const Bitboard black = pos.pieces(BLACK, PAWN);
+
+    Bitboard bb = white;
+    while (bb)
+    {
+        Square         from = pop_lsb(bb);
+        const Bitboard band = pawn_pair_bb(from);
+        for (Bitboard ww = band & bb; ww;)
+            active.push_back(make_index(perspective, WHITE, from, pop_lsb(ww), WHITE, ksq));
+        for (Bitboard wb = band & black; wb;)
+            active.push_back(make_index(perspective, WHITE, from, pop_lsb(wb), BLACK, ksq));
+    }
+
+    bb = black;
+    while (bb)
+    {
+        Square         from = pop_lsb(bb);
+        const Bitboard band = pawn_pair_bb(from);
+        for (Bitboard bbk = band & bb; bbk;)
+            active.push_back(make_index(perspective, BLACK, from, pop_lsb(bbk), BLACK, ksq));
+    }
+}
+
+void PP_3Wide::append_changed_indices(Color                                    perspective,
+                                      Square                                   ksq,
+                                      const DiffType&                          diff,
+                                      IndexList&                               removed,
+                                      IndexList&                               added,
+                                      [[maybe_unused]] const ThreatWeightType* prefetchBase,
+                                      [[maybe_unused]] IndexType               prefetchStride) {
+
+    const Bitboard whiteBefore = diff.before[WHITE];
+    const Bitboard blackBefore = diff.before[BLACK];
+    const Bitboard whiteAfter  = diff.after[WHITE];
+    const Bitboard blackAfter  = diff.after[BLACK];
+
+    if (whiteBefore == whiteAfter && blackBefore == blackAfter)
+        return;
+
+#ifdef USE_AVX512ICL
+    const u8      orientation = u8(FullThreats::OrientTBL[ksq]) ^ u8(56 * perspective);
+    const __m512i iota        = AllSquares;
+    const __m512i adjusted =
+      _mm512_sub_epi8(_mm512_xor_si512(iota, _mm512_set1_epi8(orientation)), _mm512_set1_epi8(8));
+
+    auto generate = [&](Bitboard updatedW, Bitboard updatedB, Bitboard pawnsW, Bitboard pawnsB,
+                        IndexList& out) {
+        const Bitboard friendly = perspective == WHITE ? pawnsW : pawnsB;
+        const Bitboard enemy    = perspective == WHITE ? pawnsB : pawnsW;
+        const __m512i  ids      = _mm512_mask_blend_epi8(
+          friendly, _mm512_add_epi8(adjusted, _mm512_set1_epi8(48)), adjusted);
+
+        const Bitboard unchanged = (pawnsW | pawnsB) & ~(updatedW | updatedB);
+        for (Bitboard u = updatedW | updatedB; u;)
+        {
+            const Square   a        = pop_lsb(u);
+            const Bitboard partners = pawn_pair_bb(a) & (unchanged | u);
+            const int      n        = popcount(partners);
+            if (!n)
+                continue;
+
+            const u16     colorOff = (enemy & a) ? 48 : 0;
+            const u16     aId      = u16(((u8(a) ^ orientation) - 8) + colorOff);
+            const __m256i pids     = _mm256_cvtepu8_epi16(
+              _mm512_castsi512_si128(_mm512_maskz_compress_epi8(partners, ids)));
+            const __m256i feats = pp_idx_epi16(_mm256_set1_epi16(aId), pids);
+
+            u16* w = out.make_space(n);
+            _mm256_storeu_epi16(w, feats);
+        }
+    };
+#else
+    auto generate = [&](Bitboard updatedW, Bitboard updatedB, Bitboard pawnsW, Bitboard pawnsB,
+                        IndexList& out) {
+        auto push = [&](IndexType index) {
+            if (prefetchBase)
+                prefetch<PrefetchRw::READ, PrefetchLoc::LOW>(reinterpret_cast<const void*>(
+                  reinterpret_cast<uintptr_t>(prefetchBase) + index * prefetchStride));
+            out.push_back(index);
+        };
+        const Bitboard unchanged = (pawnsW | pawnsB) & ~(updatedW | updatedB);
+        for (Bitboard u = updatedW | updatedB; u;)
+        {
+            const Square   a    = pop_lsb(u);
+            const Bitboard mask = pawn_pair_bb(a) & (unchanged | u);
+            const Color    aCol = (pawnsB & a) ? BLACK : WHITE;
+            for (Bitboard pb = pawnsB & mask; pb;)
+                push(make_index(perspective, aCol, a, pop_lsb(pb), BLACK, ksq));
+            for (Bitboard pw = pawnsW & mask; pw;)
+                push(make_index(perspective, aCol, a, pop_lsb(pw), WHITE, ksq));
+        }
+    };
+#endif
+
+    generate(whiteAfter & ~whiteBefore, blackAfter & ~blackBefore, whiteAfter, blackAfter, added);
+    generate(whiteBefore & ~whiteAfter, blackBefore & ~blackAfter, whiteBefore, blackBefore,
+             removed);
+}
+
+}  // namespace Stockfish::Eval::NNUE::Features

--- a/src/nnue/features/pp_3wide.h
+++ b/src/nnue/features/pp_3wide.h
@@ -1,0 +1,61 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NNUE_FEATURES_PP_3WIDE_INCLUDED
+#define NNUE_FEATURES_PP_3WIDE_INCLUDED
+
+#include "../../misc.h"
+#include "../../types.h"
+#include "../nnue_common.h"
+
+namespace Stockfish {
+class Position;
+}
+
+namespace Stockfish::Eval::NNUE::Features {
+
+class PP_3Wide {
+   public:
+    static constexpr u32 HashValue = 0x86f2b1ddu;
+
+    static constexpr IndexType PawnIds    = COLOR_NB * 48;
+    static constexpr IndexType Dimensions = PawnIds * (PawnIds - 1) / 2;
+
+    // Pawn pair feature indices are concatenated to threats, so this must equal ThreatFeatureSet::Dimensions;
+    // see nnue_feature_transformer.h
+    static constexpr IndexType IndexBase = 59808;
+    using IndexList                      = ValueList<u16, 256>;
+    using DiffType                       = DirtyPawnPairs;
+
+    static IndexType make_index(
+      Color perspective, Color color, Square from, Square to, Color pairedColor, Square ksq);
+
+    static void append_active_indices(Color perspective, const Position& pos, IndexList& active);
+
+    static void append_changed_indices(Color                   perspective,
+                                       Square                  ksq,
+                                       const DiffType&         diff,
+                                       IndexList&              removed,
+                                       IndexList&              added,
+                                       const ThreatWeightType* prefetchBase   = nullptr,
+                                       IndexType               prefetchStride = 0);
+};
+
+}  // namespace Stockfish::Eval::NNUE::Features
+
+#endif  // #ifndef NNUE_FEATURES_PP_3WIDE_INCLUDED

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -57,17 +57,19 @@ AccumulatorState& AccumulatorStack::mut_latest() noexcept { return accumulators[
 void AccumulatorStack::reset() noexcept {
     accumulators[0].dirtyPiece = {};
     new (&accumulators[0].dirtyThreats) DirtyThreats;
+    new (&accumulators[0].dirtyPawnPairs) DirtyPawnPairs;
     accumulators[0].computed.fill(false);
     size = 1;
 }
 
-std::pair<DirtyPiece&, DirtyThreats&> AccumulatorStack::push() noexcept {
+Dirties& AccumulatorStack::push() noexcept {
     assert(size < MaxSize);
     auto& st = accumulators[size];
     st.computed.fill(false);
     new (&st.dirtyThreats) DirtyThreats;
+    new (&st.dirtyPawnPairs) DirtyPawnPairs;
     size++;
-    return {st.dirtyPiece, st.dirtyThreats};
+    return st;
 }
 
 void AccumulatorStack::pop() noexcept {
@@ -178,7 +180,7 @@ void apply_combined(Color                              perspective,
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
     const auto* psqWeights    = &featureTransformer.weights[0];
-    const auto* threatWeights = &featureTransformer.threatWeights[0];
+    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
 
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
@@ -208,7 +210,7 @@ void apply_combined(Color                              perspective,
         for (int i = 0; i < thrRemoved.ssize(); ++i)
         {
             auto* column = reinterpret_cast<const vec_i8_t*>(
-              &threatWeights[thrRemoved[i] * Dimensions + tileOff]);
+              &threatAndPpWeights[thrRemoved[i] * Dimensions + tileOff]);
 
     #ifdef USE_NEON
             for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
@@ -224,8 +226,8 @@ void apply_combined(Color                              perspective,
 
         for (int i = 0; i < thrAdded.ssize(); ++i)
         {
-            auto* column =
-              reinterpret_cast<const vec_i8_t*>(&threatWeights[thrAdded[i] * Dimensions + tileOff]);
+            auto* column = reinterpret_cast<const vec_i8_t*>(
+              &threatAndPpWeights[thrAdded[i] * Dimensions + tileOff]);
 
     #ifdef USE_NEON
             for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
@@ -271,7 +273,8 @@ void apply_combined(Color                              perspective,
         for (int i = 0; i < thrRemoved.ssize(); ++i)
         {
             auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
+              &featureTransformer
+                 .threatAndPpPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
             for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
         }
@@ -279,7 +282,7 @@ void apply_combined(Color                              perspective,
         for (int i = 0; i < thrAdded.ssize(); ++i)
         {
             auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
+              &featureTransformer.threatAndPpPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
             for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
         }
@@ -315,18 +318,18 @@ void apply_combined(Color                              perspective,
     {
         const IndexType offset = Dimensions * index;
         for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] -= featureTransformer.threatWeights[offset + j];
+            toAcc[j] -= featureTransformer.threatAndPpWeights[offset + j];
         for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] -= featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
+            toPsqtAcc[k] -= featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
     }
 
     for (const auto index : thrAdded)
     {
         const IndexType offset = Dimensions * index;
         for (IndexType j = 0; j < Dimensions; ++j)
-            toAcc[j] += featureTransformer.threatWeights[offset + j];
+            toAcc[j] += featureTransformer.threatAndPpWeights[offset + j];
         for (usize k = 0; k < PSQTBuckets; ++k)
-            toPsqtAcc[k] += featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
+            toPsqtAcc[k] += featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
     }
 
 #endif
@@ -349,22 +352,27 @@ void update_accumulator_incremental(Color                     perspective,
     PSQFeatureSet::IndexList    psqRemoved, psqAdded;
     ThreatFeatureSet::IndexList thrRemoved, thrAdded;
 
-    const auto& dirtyPiece   = Forward ? target_state.dirtyPiece : computed.dirtyPiece;
-    const auto& dirtyThreats = Forward ? target_state.dirtyThreats : computed.dirtyThreats;
+    const auto& dirtyPiece     = Forward ? target_state.dirtyPiece : computed.dirtyPiece;
+    const auto& dirtyThreats   = Forward ? target_state.dirtyThreats : computed.dirtyThreats;
+    const auto& dirtyPawnPairs = Forward ? target_state.dirtyPawnPairs : computed.dirtyPawnPairs;
 
-    const auto* pfBase   = &featureTransformer.threatWeights[0];
-    IndexType   pfStride = ActiveFeatureTransformer::OutputDimensions;
+    const auto* threatPpBase = &featureTransformer.threatAndPpWeights[0];
+    IndexType   pfStride     = ActiveFeatureTransformer::OutputDimensions;
 
     if constexpr (Forward)
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrRemoved,
-                                                 thrAdded, pfBase, pfStride);
+                                                 thrAdded, threatPpBase, pfStride);
+        PairFeatureSet::append_changed_indices(perspective, ksq, dirtyPawnPairs, thrRemoved,
+                                               thrAdded, threatPpBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqRemoved, psqAdded);
     }
     else
     {
         ThreatFeatureSet::append_changed_indices(perspective, ksq, dirtyThreats, thrAdded,
-                                                 thrRemoved, pfBase, pfStride);
+                                                 thrRemoved, threatPpBase, pfStride);
+        PairFeatureSet::append_changed_indices(perspective, ksq, dirtyPawnPairs, thrAdded,
+                                               thrRemoved, threatPpBase, pfStride);
         PSQFeatureSet::append_changed_indices(perspective, ksq, dirtyPiece, psqAdded, psqRemoved);
     }
 
@@ -498,6 +506,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
     ThreatFeatureSet::IndexList active;
     ThreatFeatureSet::append_active_indices(perspective, pos, active);
+    PairFeatureSet::append_active_indices(perspective, pos, active);
 
     accumulator.computed[perspective] = true;
 
@@ -506,7 +515,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
     psqt_vec_t psqt[Tiling::NumPsqtRegs];
 
     const auto* weights       = &featureTransformer.weights[0];
-    const auto* threatWeights = &featureTransformer.threatWeights[0];
+    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
 
     for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
     {
@@ -537,8 +546,8 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         for (int i = 0; i < active.ssize(); ++i)
         {
-            auto* column =
-              reinterpret_cast<const vec_i8_t*>(&threatWeights[active[i] * Dimensions + tileOff]);
+            auto* column = reinterpret_cast<const vec_i8_t*>(
+              &threatAndPpWeights[active[i] * Dimensions + tileOff]);
 
     #ifdef USE_NEON
             for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
@@ -587,7 +596,7 @@ void update_accumulator_refresh_cache(Color                     perspective,
         for (int i = 0; i < active.ssize(); ++i)
         {
             auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
-              &featureTransformer.threatPsqtWeights[active[i] * PSQTBuckets + psqtTileOff]);
+              &featureTransformer.threatAndPpPsqtWeights[active[i] * PSQTBuckets + psqtTileOff]);
             for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
                 psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
         }
@@ -628,11 +637,11 @@ void update_accumulator_refresh_cache(Color                     perspective,
 
         for (IndexType j = 0; j < Dimensions; ++j)
             accumulator.accumulation[perspective][j] +=
-              featureTransformer.threatWeights[offset + j];
+              featureTransformer.threatAndPpWeights[offset + j];
 
         for (usize k = 0; k < PSQTBuckets; ++k)
             accumulator.psqtAccumulation[perspective][k] +=
-              featureTransformer.threatPsqtWeights[index * PSQTBuckets + k];
+              featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
     }
 
 #endif

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -24,7 +24,6 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
-#include <utility>
 
 #include "../types.h"
 #include "../misc.h"
@@ -91,10 +90,14 @@ struct AccumulatorCaches {
     };
 
     template<typename Network>
-    void init_big(const Network& network) { big.clear(network); }
+    void init_big(const Network& network) {
+        big.clear(network);
+    }
 
     template<typename Network>
-    void clear_big(const Network& network) { big.clear(network); }
+    void clear_big(const Network& network) {
+        big.clear(network);
+    }
 
     Cache<TransformedFeatureDimensionsBig> big;
 };
@@ -103,10 +106,7 @@ using ActiveAccumulatorCache = AccumulatorCaches::Cache<ActiveTransformedFeature
 using ActiveAccumulatorCaches = AccumulatorCaches;
 
 
-struct AccumulatorState: public Accumulator<ActiveTransformedFeatureDimensions> {
-    DirtyPiece   dirtyPiece;
-    DirtyThreats dirtyThreats;
-};
+struct AccumulatorState: public Accumulator<ActiveTransformedFeatureDimensions>, Dirties {};
 
 using ActiveAccumulator = Accumulator<ActiveTransformedFeatureDimensions>;
 using ActivePSQAccumulatorState = AccumulatorState;
@@ -119,7 +119,7 @@ class AccumulatorStack {
     [[nodiscard]] const AccumulatorState& latest() const noexcept;
 
     void                                  reset() noexcept;
-    std::pair<DirtyPiece&, DirtyThreats&> push() noexcept;
+    Dirties& push() noexcept;
     void                                  pop() noexcept;
 
     void evaluate(const Position&           pos,

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -26,6 +26,7 @@
 
 #include "features/half_ka_v2_hm.h"
 #include "features/full_threats.h"
+#include "features/pp_3wide.h"
 #include "layers/affine_transform.h"
 #include "layers/affine_transform_sparse_input.h"
 #include "layers/clipped_relu.h"
@@ -36,6 +37,7 @@ namespace Stockfish::Eval::NNUE {
 
 // Input features used in evaluation function
 using ThreatFeatureSet = Features::FullThreats;
+using PairFeatureSet   = Features::PP_3Wide;
 using PSQFeatureSet    = Features::HalfKAv2_hm;
 
 // Number of input feature dimensions after conversion
@@ -138,8 +140,7 @@ struct NetworkArchitecture {
                                 buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
 #else
         ac_sqr_1.propagate(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2);
-        ac_1.propagate(buffer.fc_1_out,
-                       buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
+        ac_1.propagate(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
 #endif
 
         fc_2.propagate(buffer.concat_buffer, buffer.fc_2_out);

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -174,12 +174,9 @@ inline void write_little_endian(std::ostream& stream, const IntType* values, usi
 // Read N signed integers from the stream s, putting them in the array out.
 // The stream is assumed to be compressed using the signed LEB128 format.
 // See https://en.wikipedia.org/wiki/LEB128 for a description of the compression scheme.
-template<typename BufType, typename IntType, usize Count>
-inline void read_leb_128_detail(std::istream&               stream,
-                                std::array<IntType, Count>& out,
-                                u32&              bytes_left,
-                                BufType&                    buf,
-                                u32&              buf_pos) {
+template<typename BufType, typename IntType>
+inline void read_leb_128_detail(
+  std::istream& stream, IntType* out, usize Count, u32& bytes_left, BufType& buf, u32& buf_pos) {
 
     static_assert(std::is_signed_v<IntType>, "Not implemented for unsigned types");
     static_assert(sizeof(IntType) <= 4, "Not implemented for types larger than 32 bit");
@@ -220,7 +217,24 @@ inline void read_leb_128(std::istream& stream, Arrays&... outs) {
     std::array<u8, 8192> buf;
     u32                  buf_pos = u32(buf.size());
 
-    (read_leb_128_detail(stream, outs, bytes_left, buf, buf_pos), ...);
+    (read_leb_128_detail(stream, outs.data(), outs.size(), bytes_left, buf, buf_pos), ...);
+
+    assert(bytes_left == 0);
+}
+
+
+template<typename IntType>
+inline void read_leb_128(std::istream& stream, IntType* out, usize expected) {
+    // Check the presence of our LEB128 magic string
+    char leb128MagicString[Leb128MagicStringSize];
+    stream.read(leb128MagicString, Leb128MagicStringSize);
+    assert(strncmp(Leb128MagicString, leb128MagicString, Leb128MagicStringSize) == 0);
+
+    auto                 bytes_left = read_little_endian<u32>(stream);
+    std::array<u8, 8192> buf;
+    u32                  buf_pos = u32(buf.size());
+
+    read_leb_128_detail(stream, out, expected, bytes_left, buf, buf_pos);
 
     assert(bytes_left == 0);
 }
@@ -230,8 +244,8 @@ inline void read_leb_128(std::istream& stream, Arrays&... outs) {
 // This takes N integers from array values, compresses them with
 // the LEB128 algorithm and writes the result on the stream s.
 // See https://en.wikipedia.org/wiki/LEB128 for a description of the compression scheme.
-template<typename IntType, usize Count>
-inline void write_leb_128(std::ostream& stream, const std::array<IntType, Count>& values) {
+template<typename IntType>
+inline void write_leb_128(std::ostream& stream, const IntType* values, usize Count) {
 
     // Write our LEB128 magic string
     stream.write(Leb128MagicString, Leb128MagicStringSize);
@@ -288,6 +302,11 @@ inline void write_leb_128(std::ostream& stream, const std::array<IntType, Count>
     }
 
     flush();
+}
+
+template<typename IntType, usize Count>
+inline void write_leb_128(std::ostream& stream, const std::array<IntType, Count>& values) {
+    write_leb_128(stream, values.data(), Count);
 }
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -38,8 +38,7 @@ namespace Stockfish::Eval::NNUE {
 
 // Returns the inverse of a permutation
 template<usize Len>
-constexpr std::array<usize, Len>
-invert_permutation(const std::array<usize, Len>& order) {
+constexpr std::array<usize, Len> invert_permutation(const std::array<usize, Len>& order) {
     std::array<usize, Len> inverse{};
     for (usize i = 0; i < order.size(); i++)
         inverse[order[i]] = i;
@@ -92,8 +91,9 @@ class FeatureTransformer {
     // Number of input/output dimensions
     static constexpr IndexType InputDimensions       = PSQFeatureSet::Dimensions;
     static constexpr IndexType ThreatInputDimensions = ThreatFeatureSet::Dimensions;
+    static constexpr IndexType PairInputDimensions   = PairFeatureSet::Dimensions;
     static constexpr IndexType TotalInputDimensions =
-      InputDimensions + (UseThreats ? ThreatInputDimensions : 0);
+      InputDimensions + (UseThreats ? ThreatInputDimensions + PairInputDimensions : 0);
     static constexpr IndexType OutputDimensions = HalfDimensions;
 
     // Size of forward propagation buffer
@@ -134,7 +134,8 @@ class FeatureTransformer {
 
     // Hash value embedded in the evaluation file
     static constexpr u32 get_hash_value() {
-        return (UseThreats ? combine_hash({ThreatFeatureSet::HashValue, PSQFeatureSet::HashValue})
+        return (UseThreats ? combine_hash({ThreatFeatureSet::HashValue, PairFeatureSet::HashValue,
+                                           PSQFeatureSet::HashValue})
                            : PSQFeatureSet::HashValue)
              ^ (OutputDimensions * 2);
     }
@@ -144,7 +145,7 @@ class FeatureTransformer {
         permute<16>(weights, PackusEpi16Order);
 
         if constexpr (UseThreats)
-            permute<8>(threatWeights, PackusEpi16Order);
+            permute<8>(threatAndPpWeights, PackusEpi16Order);
     }
 
     void unpermute_weights() {
@@ -152,7 +153,22 @@ class FeatureTransformer {
         permute<16>(weights, InversePackusEpi16Order);
 
         if constexpr (UseThreats)
-            permute<8>(threatWeights, InversePackusEpi16Order);
+            permute<8>(threatAndPpWeights, InversePackusEpi16Order);
+    }
+
+    auto threatWeights() { return threatAndPpWeights.data(); }
+    auto threatWeights() const { return threatAndPpWeights.data(); }
+    auto ppWeights() { return &threatAndPpWeights[ThreatFeatureSet::Dimensions * HalfDimensions]; }
+    auto ppWeights() const {
+        return &threatAndPpWeights[ThreatFeatureSet::Dimensions * HalfDimensions];
+    }
+    auto threatPsqtWeights() { return threatAndPpPsqtWeights.data(); }
+    auto threatPsqtWeights() const { return threatAndPpPsqtWeights.data(); }
+    auto ppPsqtWeights() {
+        return &threatAndPpPsqtWeights[ThreatFeatureSet::Dimensions * PSQTBuckets];
+    }
+    auto ppPsqtWeights() const {
+        return &threatAndPpPsqtWeights[ThreatFeatureSet::Dimensions * PSQTBuckets];
     }
 
     // Read network parameters
@@ -161,9 +177,12 @@ class FeatureTransformer {
 
         if constexpr (UseThreats)
         {
-            read_little_endian<ThreatWeightType>(stream, threatWeights.data(),
+            read_little_endian<ThreatWeightType>(stream, threatWeights(),
                                                  ThreatInputDimensions * HalfDimensions);
-            read_leb_128(stream, threatPsqtWeights);
+            read_leb_128(stream, threatPsqtWeights(), ThreatFeatureSet::Dimensions * PSQTBuckets);
+            read_little_endian<ThreatWeightType>(stream, ppWeights(),
+                                                 PairInputDimensions * HalfDimensions);
+            read_leb_128(stream, ppPsqtWeights(), PairFeatureSet::Dimensions * PSQTBuckets);
 
             read_leb_128(stream, weights);
             read_leb_128(stream, psqtWeights);
@@ -189,9 +208,14 @@ class FeatureTransformer {
 
         if constexpr (UseThreats)
         {
-            write_little_endian<ThreatWeightType>(stream, copy->threatWeights.data(),
+            write_little_endian<ThreatWeightType>(stream, copy->threatWeights(),
                                                   ThreatInputDimensions * HalfDimensions);
-            write_leb_128<PSQTWeightType>(stream, copy->threatPsqtWeights);
+            write_leb_128<PSQTWeightType>(stream, copy->threatPsqtWeights(),
+                                          ThreatFeatureSet::Dimensions * PSQTBuckets);
+            write_little_endian<ThreatWeightType>(stream, copy->ppWeights(),
+                                                  PairInputDimensions * HalfDimensions);
+            write_leb_128<PSQTWeightType>(stream, copy->ppPsqtWeights(),
+                                          PairFeatureSet::Dimensions * PSQTBuckets);
 
             write_leb_128<WeightType>(stream, copy->weights);
             write_leb_128<PSQTWeightType>(stream, copy->psqtWeights);
@@ -214,8 +238,8 @@ class FeatureTransformer {
 
         if constexpr (UseThreats)
         {
-            hash_combine(h, get_raw_data_hash(threatWeights));
-            hash_combine(h, get_raw_data_hash(threatPsqtWeights));
+            hash_combine(h, get_raw_data_hash(threatAndPpWeights));
+            hash_combine(h, get_raw_data_hash(threatAndPpPsqtWeights));
         }
 
         hash_combine(h, get_hash_value());
@@ -363,13 +387,16 @@ class FeatureTransformer {
 
     alignas(CacheLineSize) std::array<BiasType, HalfDimensions> biases;
     alignas(CacheLineSize) std::array<WeightType, HalfDimensions * InputDimensions> weights;
+    static_assert(PairFeatureSet::IndexBase == ThreatFeatureSet::Dimensions);
     alignas(CacheLineSize)
       std::array<ThreatWeightType,
-                 UseThreats ? HalfDimensions * ThreatInputDimensions : 0> threatWeights;
+                 UseThreats ? HalfDimensions*(ThreatInputDimensions + PairInputDimensions)
+                            : 0> threatAndPpWeights;
     alignas(CacheLineSize) std::array<PSQTWeightType, InputDimensions * PSQTBuckets> psqtWeights;
     alignas(CacheLineSize)
       std::array<PSQTWeightType,
-                 UseThreats ? ThreatInputDimensions * PSQTBuckets : 0> threatPsqtWeights;
+                 UseThreats ? (ThreatInputDimensions + PairInputDimensions) * PSQTBuckets
+                            : 0> threatAndPpPsqtWeights;
 };
 
 }  // namespace Stockfish::Eval::NNUE

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -326,10 +326,11 @@ void Position::set_check_info() const {
 
     Square ksq = square<KING>(~sideToMove);
 
+    const auto [bishopAttacks, rookAttacks] = Attacks::both_attacks_bb(ksq, pieces());
     st->checkSquares[PAWN]   = attacks_bb<PAWN>(ksq, ~sideToMove);
     st->checkSquares[KNIGHT] = attacks_bb<KNIGHT>(ksq);
-    st->checkSquares[BISHOP] = attacks_bb<BISHOP>(ksq, pieces());
-    st->checkSquares[ROOK]   = attacks_bb<ROOK>(ksq, pieces());
+    st->checkSquares[BISHOP] = bishopAttacks;
+    st->checkSquares[ROOK]   = rookAttacks;
     st->checkSquares[QUEEN]  = st->checkSquares[BISHOP] | st->checkSquares[ROOK];
     st->checkSquares[KING]   = 0;
 }
@@ -496,8 +497,9 @@ void Position::update_slider_blockers(Color c) const {
 // Slider attacks use the occupied bitboard to indicate occupancy.
 Bitboard Position::attackers_to(Square s, Bitboard occupied) const {
 
-    return (attacks_bb<ROOK>(s, occupied) & pieces(ROOK, QUEEN))
-         | (attacks_bb<BISHOP>(s, occupied) & pieces(BISHOP, QUEEN))
+    const auto [bishopAttacks, rookAttacks] = Attacks::both_attacks_bb(s, occupied);
+
+    return (rookAttacks & pieces(ROOK, QUEEN)) | (bishopAttacks & pieces(BISHOP, QUEEN))
          | (attacks_bb<PAWN>(s, BLACK) & pieces(WHITE, PAWN))
          | (attacks_bb<PAWN>(s, WHITE) & pieces(BLACK, PAWN))
          | (attacks_bb<KNIGHT>(s) & pieces(KNIGHT)) | (attacks_bb<KING>(s) & pieces(KING));
@@ -508,8 +510,7 @@ bool Position::attackers_to_exist(Square s, Bitboard occupied, Color c) const {
     return (attacks_bb<ROOK>(s, occupied) & pieces(c, ROOK, QUEEN))
         || (attacks_bb<BISHOP>(s, occupied) & pieces(c, BISHOP, QUEEN))
         || (attacks_bb<PAWN>(s, ~c) & pieces(c, PAWN))
-        || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT))
-        || (attacks_bb<KING>(s) & pieces(c, KING));
+        || (attacks_bb<KNIGHT>(s) & pieces(c, KNIGHT)) || (attacks_bb<KING>(s) & pieces(c, KING));
 }
 
 // Tests whether a pseudo-legal move is legal
@@ -665,10 +666,11 @@ bool Position::gives_check(Move m) const {
     case EN_PASSANT : {
         Square   capsq = make_square(file_of(to), rank_of(from));
         Bitboard b     = (pieces() ^ from ^ capsq) | to;
+        const auto [bishopAttacks, rookAttacks] =
+          Attacks::both_attacks_bb(square<KING>(~sideToMove), b);
 
-        return (attacks_bb<ROOK>(square<KING>(~sideToMove), b) & pieces(sideToMove, QUEEN, ROOK))
-             | (attacks_bb<BISHOP>(square<KING>(~sideToMove), b)
-                & pieces(sideToMove, QUEEN, BISHOP));
+        return (rookAttacks & pieces(sideToMove, QUEEN, ROOK))
+             | (bishopAttacks & pieces(sideToMove, QUEEN, BISHOP));
     }
     default :  //CASTLING
     {
@@ -689,8 +691,7 @@ bool Position::gives_check(Move m) const {
 void Position::do_move(Move                      m,
                        StateInfo&                newSt,
                        bool                      givesCheck,
-                       DirtyPiece&               dp,
-                       DirtyThreats&             dts,
+                       Dirties&                  dirties,
                        const TranspositionTable* tt      = nullptr,
                        const SharedHistories*    history = nullptr) {
 
@@ -711,6 +712,13 @@ void Position::do_move(Move                      m,
     ++gamePly;
     ++st->rule50;
     ++st->pliesFromNull;
+
+    auto& dpps = dirties.dirtyPawnPairs;
+    auto& dts  = dirties.dirtyThreats;
+    auto& dp   = dirties.dirtyPiece;
+
+    dpps.before[WHITE] = pieces(WHITE, PAWN);
+    dpps.before[BLACK] = pieces(BLACK, PAWN);
 
     Color  us       = sideToMove;
     Color  them     = ~us;
@@ -977,6 +985,9 @@ void Position::do_move(Move                      m,
 
     assert(pos_is_ok());
 
+    dpps.after[WHITE] = pieces(WHITE, PAWN);
+    dpps.after[BLACK] = pieces(BLACK, PAWN);
+
     assert(dp.pc != NO_PIECE);
     assert(!(bool(captured) || m.type_of() == CASTLING) ^ (dp.remove_sq != SQ_NONE));
     assert(dp.from != SQ_NONE);
@@ -1066,7 +1077,7 @@ void write_multiple_dirties(const Position& p,
     static_assert(sizeof(DirtyThreat) == 4);
 
     const __m512i board      = _mm512_loadu_si512(p.piece_array().data());
-    const __m512i AllSquares = _mm512_set_epi8(
+    const __m512i squareIndices = _mm512_set_epi8(
       63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41,
       40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18,
       17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
@@ -1079,7 +1090,7 @@ void write_multiple_dirties(const Position& p,
 
     // Extract the list of squares and upconvert to 32 bits. There are never more than 16
     // incoming threats so this is sufficient.
-    __m512i threat_squares = _mm512_maskz_compress_epi8(mask, AllSquares);
+    __m512i threat_squares = _mm512_maskz_compress_epi8(mask, squareIndices);
     threat_squares         = _mm512_cvtepi8_epi32(_mm512_castsi512_si128(threat_squares));
 
     __m512i threat_pieces =
@@ -1108,8 +1119,9 @@ void Position::update_piece_threats(Piece                     pc,
     const Bitboard occupied     = pieces();
     const Bitboard rookQueens   = pieces(ROOK, QUEEN);
     const Bitboard bishopQueens = pieces(BISHOP, QUEEN);
-    const Bitboard rAttacks     = attacks_bb<ROOK>(s, occupied);
-    const Bitboard bAttacks     = attacks_bb<BISHOP>(s, occupied);
+    const auto     attacks      = Attacks::both_attacks_bb(s, occupied);
+    const Bitboard bAttacks     = attacks.first;
+    const Bitboard rAttacks     = attacks.second;
     const Bitboard occupiedNoK  = occupied ^ pieces(KING);
 
     Bitboard sliders       = (rookQueens & rAttacks) | (bishopQueens & bAttacks);
@@ -1152,32 +1164,14 @@ void Position::update_piece_threats(Piece                     pc,
     Bitboard threatened       = attacks_bb(pc, s, occupied) & occupiedNoK;
     Bitboard incoming_threats = PseudoAttacks[KNIGHT][s] & knights;
 
-    // Compute both incoming and outgoing pawn threats. Incoming pawn pushers are only
-    // added if 'pc' is a pawn.
-    Bitboard pawnThreats = 0;
-    if (type_of(pc) == PAWN)
-    {
-        Bitboard whiteAttacks = PawnPushOrAttacks[WHITE][s];
-        Bitboard blackAttacks = PawnPushOrAttacks[BLACK][s];
-
-        threatened |= (color_of(pc) == WHITE ? whiteAttacks : blackAttacks) & pieces(PAWN);
-
-        pawnThreats = whiteAttacks & blackPawns;
-        pawnThreats |= blackAttacks & whitePawns;
-    }
-    else
-    {
-        pawnThreats =
+    if (type_of(pc) == KNIGHT || type_of(pc) == ROOK)
+        incoming_threats |=
           (attacks_bb<PAWN>(s, WHITE) & blackPawns) | (attacks_bb<PAWN>(s, BLACK) & whitePawns);
-    }
-
-    if (type_of(pc) == PAWN || type_of(pc) == KNIGHT || type_of(pc) == ROOK)
-        incoming_threats |= pawnThreats;
 
     switch (type_of(pc))
     {
     case PAWN :
-        threatened &= pieces(PAWN, KNIGHT, ROOK);
+        threatened &= pieces(KNIGHT, ROOK);
         break;
     case BISHOP :
     case ROOK :
@@ -1421,8 +1415,9 @@ bool Position::see_ge(Move m, int threshold) const {
             assert(swap >= res);
             occupied ^= least_significant_square_bb(bb);
 
-            attackers |= (attacks_bb<BISHOP>(to, occupied) & pieces(BISHOP, QUEEN))
-                       | (attacks_bb<ROOK>(to, occupied) & pieces(ROOK, QUEEN));
+            const auto [bishopAttacks, rookAttacks] = Attacks::both_attacks_bb(to, occupied);
+            attackers |=
+              (bishopAttacks & pieces(BISHOP, QUEEN)) | (rookAttacks & pieces(ROOK, QUEEN));
         }
 
         else  // KING

--- a/src/position.h
+++ b/src/position.h
@@ -150,8 +150,7 @@ class Position {
     void do_move(Move                      m,
                  StateInfo&                newSt,
                  bool                      givesCheck,
-                 DirtyPiece&               dp,
-                 DirtyThreats&             dts,
+                 Dirties&                  dirties,
                  const TranspositionTable* tt,
                  const SharedHistories*    worker);
     void undo_move(Move m);
@@ -232,8 +231,7 @@ class Position {
     int          gamePly;
     Color        sideToMove;
     bool         chess960;
-    DirtyPiece   scratch_dp;
-    DirtyThreats scratch_dts;
+    Dirties scratchDirties;
 };
 
 std::ostream& operator<<(std::ostream& os, const Position& pos);
@@ -425,8 +423,9 @@ inline void Position::swap_piece(Square s, Piece pc, DirtyThreats* const dts) {
 }
 
 inline void Position::do_move(Move m, StateInfo& newSt, const TranspositionTable* tt = nullptr) {
-    new (&scratch_dts) DirtyThreats;
-    do_move(m, newSt, gives_check(m), scratch_dp, scratch_dts, tt, nullptr);
+    new (&scratchDirties.dirtyThreats) DirtyThreats;
+    new (&scratchDirties.dirtyPawnPairs) DirtyPawnPairs;
+    do_move(m, newSt, gives_check(m), scratchDirties, tt, nullptr);
 }
 
 inline StateInfo* Position::state() const { return st; }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -251,12 +251,9 @@ void Search::Worker::start_searching() {
     if (bestThread != this)
         main_manager()->output_pv(*bestThread, threads, tt, bestThread->completedDepth);
 
-    Experience::on_search_complete(bestThread->rootPos,
-                                   bestThread->rootMoves,
-                                   bestThread->rootMoves[0].score,
-                                   bestThread->rootMoves[0].averageScore,
-                                   bestThread->completedDepth,
-                                   limits);
+    Experience::on_search_complete(
+      bestThread->rootPos, bestThread->rootMoves, bestThread->rootMoves[0].score,
+      bestThread->rootMoves[0].averageScore, bestThread->completedDepth, limits);
 
     std::string ponder;
 
@@ -533,7 +530,6 @@ void Search::Worker::iterative_deepening() {
                 rootMoves[0].score = rootMoves[0].uciScore = lastBestMoveScore;
                 rootMoves[0].pv                            = lastBestMovePV;
                 rootMoves[0].unset_bound_flags();
-
             }
             else if (abortedLossSearch)
                 rootMoves[0].scoreLowerbound = true;
@@ -561,8 +557,7 @@ void Search::Worker::iterative_deepening() {
         // Do we have time for the next iteration? Can we stop searching now?
         if (limits.use_time_management() && !threads.stop && !mainThread->stopOnPonderhit)
         {
-            u64 nodesEffort =
-              rootMoves[0].effort * 100000 / std::max(usize(1), usize(nodes));
+            u64 nodesEffort = rootMoves[0].effort * 100000 / std::max(usize(1), usize(nodes));
 
             double fallingEval = (11.48 + 2.30 * (mainThread->bestPreviousAverageScore - bestValue)
                                   + 1.1 * (mainThread->iterValue[iterIdx] - bestValue))
@@ -638,12 +633,13 @@ void Search::Worker::do_move(
     bool capture = pos.capture_stage(move);
     ++nodes;
 
-    auto [dirtyPiece, dirtyThreats] = accumulatorStack.push();
-    pos.do_move(move, st, givesCheck, dirtyPiece, dirtyThreats, &tt, &sharedHistory);
+    Dirties& dirties = accumulatorStack.push();
+    pos.do_move(move, st, givesCheck, dirties, &tt, &sharedHistory);
 
     if (ss != nullptr)
     {
-        ss->currentMove = move;
+        auto& dirtyPiece = dirties.dirtyPiece;
+        ss->currentMove  = move;
         ss->continuationHistory =
           &continuationHistory[ss->inCheck][capture][dirtyPiece.pc][move.to_sq()];
         ss->continuationCorrectionHistory =
@@ -883,8 +879,7 @@ Value Search::Worker::search(
     }
     else if (!PvNode && !excludedMove && ttData.depth > depth - (ttData.value <= beta)
              && is_valid(ttData.value) && ttData.bound != BOUND_EXACT
-             && ttData.bound & (ttData.value >= beta ? BOUND_UPPER : BOUND_LOWER)
-             && depth > 5)
+             && ttData.bound & (ttData.value >= beta ? BOUND_UPPER : BOUND_LOWER) && depth > 5)
     {
         // If a window-bound mismatch is the only reason cutoff failed,
         // penalize the now-useless tte
@@ -1867,10 +1862,7 @@ const Eval::NNUE::ActiveNetwork& Search::Worker::big_network() const {
     return networks[numaAccessToken];
 }
 
-Eval::NNUE::ActiveAccumulatorCache&
-Search::Worker::big_cache() {
-    return refreshTable.big;
-}
+Eval::NNUE::ActiveAccumulatorCache& Search::Worker::big_cache() { return refreshTable.big; }
 
 Value Search::Worker::evaluate(const Position& pos) {
     return evaluate_with_big_network_bridge(big_network(), pos, accumulatorStack, big_cache(),
@@ -2211,8 +2203,7 @@ void syzygy_extend_pv(const OptionsMap&         options,
           [](const Search::RootMove& a, const Search::RootMove& b) { return a.tbRank > b.tbRank; });
 
         // The winning side tries to minimize DTZ, the losing side maximizes it
-        Tablebases::Config config =
-          Tablebases::rank_root_moves(options, pos, legalMoves, true);
+        Tablebases::Config config = Tablebases::rank_root_moves(options, pos, legalMoves, true);
 
         // If DTZ is not available we might not find a mate, so we bail out
         if (!config.rootInTB || config.cardinality > 0)
@@ -2282,8 +2273,7 @@ void SearchManager::output_pv(Search::Worker&           worker,
         bool isExact = i != pvIdx || tb || usePreviousScore;
 
         // Potentially correct and extend the PV, and in exceptional cases v
-        if (is_decisive(v) && std::abs(v) < VALUE_MATE_IN_MAX_PLY
-            && !usePreviousScore
+        if (is_decisive(v) && std::abs(v) < VALUE_MATE_IN_MAX_PLY && !usePreviousScore
             && ((!rootMoves[i].scoreLowerbound && !rootMoves[i].scoreUpperbound) || isExact))
             syzygy_extend_pv(worker.options, worker.limits, pos, rootMoves[i], v);
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -33,7 +33,7 @@
 #include "numa.h"
 #include "position.h"
 #include "search.h"
-#include "thread_win32_osx.h"
+#include "thread_native.h"
 
 namespace Stockfish {
 

--- a/src/thread_native.h
+++ b/src/thread_native.h
@@ -16,23 +16,35 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef THREAD_WIN32_OSX_H_INCLUDED
-#define THREAD_WIN32_OSX_H_INCLUDED
+#ifndef THREAD_NATIVE_H_INCLUDED
+#define THREAD_NATIVE_H_INCLUDED
 
-#include <thread>
+#ifdef _MSC_VER
+    #include <thread>
+#else
+    #include <pthread.h>
+    #include <functional>
+    #include <utility>
+
+    #include "misc.h"
+#endif
+
+namespace Stockfish {
+
+#ifdef _MSC_VER
+
+// MSVC-compatible toolchains use std::thread because they do not provide
+// pthreads by default. On all other platforms, pthreads is required and used.
+
+using NativeThread = std::thread;
+
+#else
 
 // On OSX threads other than the main thread are created with a reduced stack
 // size of 512KB by default, this is too low for deep searches, which require
 // somewhat more than 1MB stack, so adjust it to TH_STACK_SIZE.
 // The implementation calls pthread_create() with the stack size parameter
 // equal to the Linux 8MB default, on platforms that support it.
-
-#if defined(__APPLE__) || defined(__MINGW32__) || defined(__MINGW64__) || defined(USE_PTHREADS)
-
-    #include <pthread.h>
-    #include <functional>
-
-namespace Stockfish {
 
 class NativeThread {
     pthread_t thread;
@@ -63,16 +75,8 @@ class NativeThread {
     void join() { pthread_join(thread, nullptr); }
 };
 
-}  // namespace Stockfish
-
-#else  // Default case: use STL classes
-
-namespace Stockfish {
-
-using NativeThread = std::thread;
+#endif  // _MSC_VER
 
 }  // namespace Stockfish
 
-#endif
-
-#endif  // #ifndef THREAD_WIN32_OSX_H_INCLUDED
+#endif  // #ifndef THREAD_NATIVE_H_INCLUDED

--- a/src/types.h
+++ b/src/types.h
@@ -105,8 +105,7 @@ namespace Stockfish {
 // Used by NNUE layer code paths.
 template<typename T>
 static inline T load_as(const void* p) {
-    static_assert(std::is_trivially_copyable_v<T>,
-                  "load_as requires trivially copyable type");
+    static_assert(std::is_trivially_copyable_v<T>, "load_as requires trivially copyable type");
     T v;
     std::memcpy(&v, p, sizeof(T));
     return v;
@@ -395,6 +394,17 @@ using DirtyThreatList = ValueList<DirtyThreat, 96>;
 
 struct DirtyThreats {
     DirtyThreatList list;
+};
+
+struct DirtyPawnPairs {
+    Bitboard before[COLOR_NB];
+    Bitboard after[COLOR_NB];
+};
+
+struct Dirties {
+    DirtyPiece     dirtyPiece;
+    DirtyThreats   dirtyThreats;
+    DirtyPawnPairs dirtyPawnPairs;
 };
 
     #define ENABLE_INCR_OPERATORS_ON(T) \


### PR DESCRIPTION
### Motivation
- Apply the official Stockfish dev Jul20 topology block to Revolution to bring in the NUMA parser fix, combined bishop/rook attacks optimization, pthread consolidation, and SFNNv16 NNUE migration with pawn-pair features and the new default network.
- Preserve Revolution identity, existing Experience/Book integrations and P0G–P0J guarantees while adapting local topology and APIs where needed.
- Ensure the repository builds and runs targeted architectures and validate NNUE serialization and network hash before committing the single-block change.

### Description
- Permit trailing whitespace in `str_to_size_t()` while keeping `std::strtoull` validation and the `std::optional<usize>` API (`src/misc.cpp`).
- Replace and expose attack helpers: add `both_attacks_bb()` and inline `line_bb`/`between_bb`/`ray_pass_bb` accessors and adapt callers to use them (`src/attacks.h`, `src/attacks.cpp`, callers in `src/position.cpp`).
- Unify native threading: rename `thread_win32_osx.h` → `thread_native.h`, implement pthread-based `NativeThread` on non-MSVC toolchains, keep `std::thread` on MSVC, and update `thread.h` and `Makefile` linking rules accordingly (`src/thread_native.h`, `src/thread.h`, `src/Makefile`).
- Migrate NNUE to SFNNv16 as a unit: add `PP_3Wide` feature files, update `FullThreats`, unify threat+pawn-pair weight arrays (`threatAndPpWeights` and `threatAndPpPsqtWeights`), extend `FeatureTransformer` to include pair dimensions and matching accessors, and add LEB128 pointer/count overloads (`src/nnue/features/pp_3wide.*`, `src/nnue/features/full_threats.*`, `src/nnue/nnue_feature_transformer.h`, `src/nnue/nnue_common.h`, `src/nnue/nnue_accumulator.*`).
- Introduce `DirtyPawnPairs`, `Dirties` aggregation and adapt accumulator/stack and `Position::do_move()` to use `Dirties&` while preserving local extensions (`src/types.h`, `src/nnue/nnue_accumulator.*`, `src/position.*`, `src/search.cpp`).
- Makefile changes: set `NNUE_NET = nn-89cb98a217f7.nnue`, add `nnue/features/pp_3wide.cpp`/`.h` to `SRCS`/`HEADERS`, switch `thread_win32_osx.h` references to `thread_native.h`, and remove `-DUSE_COMPTIME_ATTACKS` from the PEXT/BMI2 path while preserving `-mbmi2` and platform linking logic (`src/Makefile`).
- Misc small compatibility and formatting adjustments (asserts, include ordering, minor refactors) to integrate the upstream hunks into the local topology without rebranding or replacing Revolution-specific systems.

### Testing
- Fetched upstream and validated the four official Jul20 commits and their order (`b4ea9205`, `d70dec7d`, `4d75fd4f`, `f4bcd404`) and confirmed P0J baseline ancestry prior to edits.
- Network acquisition: ran `make -C src net` and validated `src/nn-89cb98a217f7.nnue` with `sha256sum` matching `89cb98a217f7...`.
- Builds executed:
  - `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=gcc` — built cleanly (no errors, no warnings).
  - `make -C src -j2 build ARCH=x86-64-bmi2 COMP=gcc` — built cleanly (no errors, no warnings) and `USE_COMPTIME_ATTACKS` was not present while `-mbmi2` remained.
  - `make -C src -j2 build ARCH=x86-64-avx2 COMP=gcc` — built cleanly (no errors, no warnings).
  - `make -C src -j2 build ARCH=x86-64-avx512icl COMP=gcc` — build completed and linked but GCC emitted pre-existing narrowing warnings in `movegen.cpp` (these warnings were present in that target; per the contract all executed builds must have zero warnings). 
- Runtime validations with the produced `src/Revolution-6.0-040526-sse41popcnt` binary:
  - `printf "uci\nisready\nquit\n" | <BIN>` — UCI responded with `id name Revolution-6.0-040526`, `uciok`/`readyok`, and `EvalFile` default set to `nn-89cb98a217f7.nnue`.
  - `bench` completed (exit 0); measured NPS and reported nodes.
  - `perft` startpos depth 4 returned `197281` nodes.
  - Threads test with pawn changes completed and produced a `bestmove` (no crashes, no NNUE errors).
  - Mate-in-two regression produced a `bestmove` within timeout.
- Hygiene and repo checks:
  - `git diff --check` was clean after edits.
  - No `.nnue`, `.o`, `.exe`, logs or build artifacts left tracked.
  - A single implementation commit was created: `P0K-SF20260720: apply Jul20 attacks pthread and SFNNv16 updates` on branch `codex/revolution-p0k-sf20260720`.

Note on mergeability: per the contract, every executed build must have zero warnings; the `x86-64-avx512icl` build emitted narrowing warnings (pre-existing in `movegen.cpp`) during the AVX512 target build, therefore this rollout must be considered `NOT SAFE` for automatic SAFE MERGE until the AVX512ICL warnings are addressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cbe9b81148327a024736bf823395d)