### PR TITLE
Revolution P0L: apply Stockfish Jul26 final topology block

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# normalize line endings for all text files
+* text=auto eol=lf

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Aron Petkovski (fury)
 Arseniy Surkov (codedeliveryservice)
 Artem Solopiy (EntityFX)
 Auguste Pop
+Ayush (ayushthepiro11-design)
 Balazs Szilagyi
 Balint Pfliegel
 Baptiste Rech (breatn)
@@ -151,6 +152,7 @@ Leonardo Ljubičić (ICCF World Champion)
 Leonid Pechenik (lp--)
 Li Ying (yl25946)
 Liam Keegan (lkeegan)
+Liang Chenxuan (aba2222)
 Linmiao Xu (linrock)
 Linus Arver (listx)
 loco-loco
@@ -198,6 +200,7 @@ Norman Schmidt (FireFather)
 notruck
 Nour Berakdar (Nonlinear)
 Ofek Shochat (OfekShochat, ghostway)
+Olaf Bernstein (camel-cdr)
 Ondrej Mosnáček (WOnder93)
 Ondřej Mišina (AndrovT)
 Oskar Werkelin Ahlin

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ endif
 ENGINE_BASENAME = Revolution
 RELEASE_TAG ?= 6.0-040526
 
-NNUE_NET = nn-89cb98a217f7.nnue
+NNUE_NET = nn-ab28990d4ea3.nnue
 
 ### Installation dir definitions
 PREFIX = /usr/local
@@ -94,7 +94,7 @@ HEADERS = attacks.h benchmark.h bitboard.h evaluate.h misc.h movegen.h movepick.
 		nnue/nnue_misc.h nnue/features/half_ka_v2_hm.h nnue/features/full_threats.h nnue/features/pp_3wide.h \
 		nnue/layers/affine_transform.h nnue/layers/affine_transform_sparse_input.h \
 		nnue/layers/clipped_relu.h nnue/layers/sqr_clipped_relu.h nnue/nnue_accumulator.h \
-		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/simd.h \
+		nnue/nnue_architecture.h nnue/nnue_common.h nnue/nnue_feature_transformer.h nnue/nnz_helper.h nnue/simd.h \
 		position.h search.h syzygy/tbprobe.h thread.h thread_native.h timeman.h \
 		tt.h tune.h types.h uci.h ucioption.h perft.h nnue/network.h engine.h score.h numa.h memory.h \
 		experience.h experience_compat.h experience_zobrist.h
@@ -952,7 +952,7 @@ BUILD_DATE_FILE      := .build_date.txt
 BUILD_DIFFINDEX_FILE := .build_diffindex.txt
 GIT_SHA              := $(shell git rev-parse HEAD 2>/dev/null | cut -c 1-8 || true)
 GIT_DATE             := $(shell git show -s --date=format:%Y%m%d --format=%cd HEAD 2>/dev/null || true)
-GIT_DIFFINDEX        := $(shell git diff-index --quiet HEAD -- 2>/dev/null; [ $$? -eq 1 ] && echo 1 || true)
+GIT_DIFFINDEX        := $(shell git update-index --refresh >/dev/null 2>&1; git -c core.filemode=false -c core.autocrlf=false diff-index --quiet HEAD -- 2>/dev/null; [ $$? -eq 1 ] && echo 1 || true)
 COMPILER_DATE        := $(shell date +%Y%m%d 2>/dev/null)
 BUILD_DATE           := $(if $(GIT_DATE),$(GIT_DATE),$(COMPILER_DATE))
 

--- a/src/attacks.cpp
+++ b/src/attacks.cpp
@@ -24,10 +24,6 @@
 
 namespace Stockfish::Attacks {
 
-#ifdef USE_DUAL_HYPERBOLA_QUINT
-alignas(64) DualMagic DualMagics[SQUARE_NB];
-#endif
-
 Bitboard LineBB[SQUARE_NB][SQUARE_NB];
 Bitboard BetweenBB[SQUARE_NB][SQUARE_NB];
 Bitboard RayPassBB[SQUARE_NB][SQUARE_NB];
@@ -40,12 +36,12 @@ alignas(64) Magic Magics[SQUARE_NB][2];
 
 }
 
-[[maybe_unused]] static Bitboard line_mask(Square sq, Direction d1, Direction d2) {
-    Bitboard mask = 0, dest;
+[[maybe_unused]] static constexpr Bitboard line_mask(Square sq, Direction d1, Direction d2) {
+    Bitboard mask = 0;
     for (Direction d : {d1, d2})
     {
         Square s = sq;
-        while ((dest = safe_destination(s, d)))
+        while (Bitboard dest = safe_destination(s, d))
         {
             mask |= dest;
             s += d;
@@ -71,16 +67,18 @@ static void init_magics(Magic magics[][2]) {
 #elif defined(USE_DUAL_HYPERBOLA_QUINT)
 
 // Sliding attacks within a rank, indexed by the slider's file and the
-// 8-bit rank occupancy, yielding the 8-bit attack set on that rank
-constexpr auto RankAttacks = []() {
-    std::array<std::array<u8, 256>, FILE_NB> table{};
+// 6 inner bits of the rank occupancy (edge squares never affect the
+// attack set), yielding the 8-bit attack set on that rank
+alignas(64) constexpr auto RankAttacks = []() {
+    std::array<std::array<u8, 64>, FILE_NB> table{};
     for (int file = 0; file < 8; ++file)
-        for (int occ = 0; occ < 256; ++occ)
-            table[file][occ] = u8(sliding_attack(ROOK, Square(file), occ));
+        for (int occ6 = 0; occ6 < 64; ++occ6)
+            table[file][occ6] = u8(sliding_attack(ROOK, Square(file), occ6 << 1));
     return table;
 }();
 
-static void init_dual_magics(DualMagic magics[]) {
+static constexpr auto make_dual_magics() {
+    std::array<DualMagic, SQUARE_NB> magics{};
     for (Square s = SQ_A1; s <= SQ_H8; ++s)
     {
         DualMagic& m        = magics[s];
@@ -93,7 +91,10 @@ static void init_dual_magics(DualMagic magics[]) {
         m.rankAttacksLookup = RankAttacks[int(file_of(s))].data();
         m.shift             = 8 * int(rank_of(s));
     }
+    return magics;
 }
+
+alignas(64) extern constexpr std::array<DualMagic, SQUARE_NB> DualMagics = make_dual_magics();
 
 #else
 
@@ -164,9 +165,7 @@ void init() {
 
 #ifdef USE_HYPERBOLA_QUINT
     init_magics(Magics);
-#elif defined(USE_DUAL_HYPERBOLA_QUINT)
-    init_dual_magics(DualMagics);
-#else
+#elif !defined(USE_DUAL_HYPERBOLA_QUINT)
     init_magics(ROOK, RookTable.data(), Magics);
     init_magics(BISHOP, BishopTable.data(), Magics);
 #endif

--- a/src/attacks.h
+++ b/src/attacks.h
@@ -92,7 +92,8 @@ struct alignas(32) DualMagic {
     // When using hyperbola quintessence, file, diagonal and antidiagonal attacks
     // can use a byte reversal rather than a full bit reversal (because all squares
     // reside in different bytes). Rank attacks cannot. Thus, for rank attacks
-    // only, we use a compact lookup table indexed by the 8 bits of the rank's occupancy.
+    // only, we use a compact lookup table indexed by the 6 inner bits of the rank's
+    // occupancy (the edge squares never affect the attack set).
     std::pair<Bitboard, Bitboard> both_attacks_bb(Bitboard occupied) const {
         // Byteswap within 128-bit elements
         const auto bswap = [](__m256i v) {
@@ -116,7 +117,7 @@ struct alignas(32) DualMagic {
         __m128i rookBishop =
           _mm_or_si128(_mm256_extracti128_si256(result, 1), _mm256_castsi256_si128(result));
 
-        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> shift) & 0xff];
+        Bitboard rowOccupancy = rankAttacksLookup[(occupied >> (shift + 1)) & 0x3f];
         Bitboard rankAttacks  = rowOccupancy << shift;
 
         // [bishop, rook]
@@ -124,9 +125,8 @@ struct alignas(32) DualMagic {
     }
 };
 
-extern DualMagic DualMagics[SQUARE_NB];
-
-inline const DualMagic& dual_magic(Square s) { return DualMagics[s]; }
+extern const std::array<DualMagic, SQUARE_NB> DualMagics;
+inline const DualMagic&                       dual_magic(Square s) { return DualMagics[s]; }
 
 #else
 // Magic holds all magic bitboards relevant data for a single square
@@ -283,7 +283,7 @@ inline Bitboard attacks_bb(Square s, Bitboard occupied) {
     assert(Pt != PAWN && is_ok(s));
 
 #ifdef USE_DUAL_HYPERBOLA_QUINT
-    const auto [bishop, rook] = dual_magic(s).both_attacks_bb(occupied);
+    [[maybe_unused]] const auto [bishop, rook] = dual_magic(s).both_attacks_bb(occupied);
 
     switch (Pt)
     {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -247,6 +247,8 @@ void Engine::set_on_bestmove(std::function<void(std::string_view, std::string_vi
     updateContext.onBestmove = std::move(f);
 }
 
+void Engine::set_on_start(std::function<void()>&& f) { updateContext.onStart = std::move(f); }
+
 void Engine::set_on_verify_networks(std::function<void(std::string_view)>&& f) {
     onVerifyNetwork = std::move(f);
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -81,6 +81,7 @@ class Engine {
     void set_on_update_full(std::function<void(const InfoFull&)>&&);
     void set_on_iter(std::function<void(const InfoIter&)>&&);
     void set_on_bestmove(std::function<void(std::string_view, std::string_view)>&&);
+    void set_on_start(std::function<void()>&&);
     void set_on_verify_networks(std::function<void(std::string_view)>&&);
     void set_on_verify_network(std::function<void(std::string_view)>&&);
 

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -35,7 +35,7 @@ namespace Eval {
 // for the build process (profile-build and fishtest) to work. Do not change the
 // name of the macro or the location where this macro is defined, as it is used
 // in the Makefile/Fishtest.
-#define EvalFileDefaultName "nn-89cb98a217f7.nnue"
+#define EvalFileDefaultName "nn-ab28990d4ea3.nnue"
 
 namespace NNUE {
 struct AccumulatorCaches;

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -46,7 +46,7 @@ namespace Stockfish::Eval::NNUE::Layers {
 
 // Fallback implementation for older/other architectures.
 // Requires the input to be padded to at least 16 values.
-#ifndef ENABLE_SEQ_OPT
+#if !defined(ENABLE_SEQ_OPT) && !defined(USE_RVV)
 
 template<IndexType InputDimensions, IndexType PaddedInputDimensions, IndexType OutputDimensions>
 static void
@@ -104,26 +104,6 @@ affine_transform_non_ssse3(i32* output, const i8* weights, const i32* biases, co
         output[i] = SIMD::neon_m128_reduce_add_epi32(sum);
 
         #endif
-    }
-    #elif defined(USE_RVV)
-    for (IndexType i = 0; i < OutputDimensions; ++i)
-    {
-        const i8*  row  = &weights[i * PaddedInputDimensions];
-        vint32m1_t vsum = __riscv_vmv_v_x_i32m1(0, __riscv_vsetvlmax_e32m1());
-
-        for (usize j = 0; j < InputDimensions;)
-        {
-            usize vl = __riscv_vsetvl_e8m4(InputDimensions - j);
-
-            vint8m4_t  w    = __riscv_vle8_v_i8m4(&row[j], vl);
-            vuint8m4_t x    = __riscv_vle8_v_u8m4(&input[j], vl);
-            vint16m8_t prod = __riscv_vwmulsu_vv_i16m8(w, x, vl);
-
-            vsum = __riscv_vwredsum_vs_i16m8_i32m1(prod, vsum, vl);
-            j += vl;
-        }
-
-        output[i] = biases[i] + __riscv_vmv_x_s_i32m1_i32(vsum);
     }
     #else
     std::memcpy(output, biases, sizeof(i32) * OutputDimensions);
@@ -377,6 +357,48 @@ class AffineTransform {
     #undef vec_add_dpbusd_32
     #undef vec_hadd
         }
+#elif defined(USE_RVV)
+        const i8* wIt = weights;
+
+    #define RVV_PROPAGATE_SINGLE(m2, m1) \
+        do \
+        { \
+            vint32m1_t     zero = __riscv_vmv_s_x_i32m1(0, 1); \
+            usize          vl   = __riscv_vsetvl_e8##m1(InputDimensions); \
+            vuint8##m1##_t in   = __riscv_vle8_v_u8##m1(input, vl); \
+            for (IndexType i = 0; i < OutputDimensions; ++i, wIt += PaddedInputDimensions) \
+            { \
+                vint8##m1##_t  w    = __riscv_vle8_v_i8##m1(wIt, vl); \
+                vint16##m2##_t prod = __riscv_vwmulsu(w, in, vl); \
+                output[i]           = biases[i] + __riscv_vmv_x(__riscv_vwredsum(prod, zero, vl)); \
+            } \
+        } while (0)
+
+        static usize VL1 = __riscv_vsetvlmax_e16m1();
+        if (InputDimensions <= VL1)
+            RVV_PROPAGATE_SINGLE(m1, mf2);
+        else if (InputDimensions <= VL1 * 2)
+            RVV_PROPAGATE_SINGLE(m2, m1);
+        else if (InputDimensions <= VL1 * 4)
+            RVV_PROPAGATE_SINGLE(m4, m2);
+        else
+        {
+            for (IndexType i = 0; i < OutputDimensions; ++i, wIt += PaddedInputDimensions)
+            {
+                vint32m1_t sum = __riscv_vmv_s_x_i32m1(0, 1);
+                for (IndexType vl, j = 0; j < InputDimensions; j += vl)
+                {
+                    vl              = __riscv_vsetvl_e8m2(InputDimensions - j);
+                    vuint8m2_t in   = __riscv_vle8_v_u8m2(input + j, vl);
+                    vint8m2_t  w    = __riscv_vle8_v_i8m2(wIt + j, vl);
+                    vint16m4_t prod = __riscv_vwmulsu(w, in, vl);
+                    sum             = __riscv_vwredsum(prod, sum, vl);
+                }
+                output[i] = biases[i] + __riscv_vmv_x(sum);
+            }
+        }
+
+    #undef RVV_PROPAGATE_SINGLE
 #else
         // Use old implementation for the other architectures.
         affine_transform_non_ssse3<InputDimensions, PaddedInputDimensions, OutputDimensions>(

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -30,6 +30,7 @@
 #include "../../memory.h"
 #include "../simd.h"
 #include "../nnue_common.h"
+#include "../nnz_helper.h"
 
 /*
   This file contains the definition for a fully connected layer (aka affine transform) with block sparse input.
@@ -251,9 +252,11 @@ class AffineTransformSparseInput {
     }
 
     // Forward propagation
-    void propagate(const InputType* input, OutputType* output) const {
+    void propagate(const InputType*                        input,
+                   OutputType*                             output,
+                   [[maybe_unused]] const NNZInfo<InDims>& nnzInfo) const {
 
-#if (USE_SSSE3 | (USE_NEON >= 8))
+#if (defined(USE_SSSE3) || defined(USE_LSX) || defined(USE_LASX) || (USE_NEON >= 8))
     #if defined(USE_AVX512)
         using invec_t  = __m512i;
         using outvec_t = __m512i;
@@ -281,74 +284,64 @@ class AffineTransformSparseInput {
         using outvec_t = int32x4_t;
         #define vec_set_32(a) vreinterpretq_s8_u32(vdupq_n_u32(a))
         #define vec_add_dpbusd_32 SIMD::neon_m128_add_dpbusd_epi32
+    #elif defined(USE_LASX)
+        using invec_t  = __m256i;
+        using outvec_t = __m256i;
+        #define vec_add_32 __lasx_xvadd_w
+        #define vec_set_32 __lasx_xvreplgr2vr_w
+        #define vec_add_dpbusd_32 SIMD::lasx_m256_add_dpbusd_epi32
+    #elif defined(USE_LSX)
+        using invec_t  = __m128i;
+        using outvec_t = __m128i;
+        #define vec_add_32 __lsx_vadd_w
+        #define vec_set_32 __lsx_vreplgr2vr_w
+        #define vec_add_dpbusd_32 SIMD::lsx_m128_add_dpbusd_epi32
     #endif
         constexpr IndexType OutputSimdWidth = sizeof(outvec_t) / sizeof(OutputType);
-        constexpr IndexType NumChunks = ceil_to_multiple<IndexType>(InputDimensions, 8) / ChunkSize;
-        constexpr IndexType NumAccums = OutputDimensions / OutputSimdWidth;
+        constexpr IndexType NumAccums       = OutputDimensions / OutputSimdWidth;
         // If we're using high-latency dot product instructions, split the accumulators
         // into separate dependency chains and merge at the end
         constexpr IndexType NumRegs =
-    #if defined(USE_AVXVNNI)
-          2 * NumAccums;
-    #elif defined(USE_VNNI)
+    #if (defined(USE_VNNI) && defined(USE_AVX512)) || defined(USE_NEON_DOTPROD)
           3 * NumAccums;
+    #elif defined(USE_AVXVNNI)
+          2 * NumAccums;
     #else
           NumAccums;
     #endif
-        u16 nnz[NumChunks];
-        IndexType     count;
-
-        // Find indices of nonzero 32-bit blocks
-        find_nnz<NumChunks>(input, nnz, count);
 
         const outvec_t* biasvec = reinterpret_cast<const outvec_t*>(biases);
         outvec_t        acc[NumRegs];
         for (IndexType k = 0; k < NumAccums; ++k)
             acc[k] = biasvec[k];
 
-        const auto* start = nnz;
-        const auto* end   = nnz + count;
-
-        // convince GCC to not do weird pointer arithmetic in the following loop
-        const i8* weights_cp = weights;
     #if defined(USE_AVXVNNI)
         for (IndexType k = NumAccums; k < NumRegs; ++k)
-            acc[k] = vec_zero();
+            acc[k] = vec_set_32(0);
+    #elif defined(USE_NEON_DOTPROD)
+        for (IndexType k = NumAccums; k < NumRegs; ++k)
+            acc[k] = vdupq_n_s32(0);
+    #endif
 
-        while (start < end - 1)
-        {
-            const isize i0 = *start++;
-            const isize i1 = *start++;
-            const invec_t in0 = vec_set_32(load_as<i32>(input + i0 * sizeof(i32)));
-            const invec_t in1 = vec_set_32(load_as<i32>(input + i1 * sizeof(i32)));
-            const auto col0 =
-              reinterpret_cast<const invec_t*>(&weights_cp[i0 * OutputDimensions * ChunkSize]);
-            const auto col1 =
-              reinterpret_cast<const invec_t*>(&weights_cp[i1 * OutputDimensions * ChunkSize]);
-            for (IndexType k = 0; k < NumAccums; ++k)
-            {
-                vec_add_dpbusd_32(acc[k], in0, col0[k]);
-                vec_add_dpbusd_32(acc[k + NumAccums], in1, col1[k]);
-            }
-        }
-        for (IndexType k = 0; k < NumAccums; ++k)
-            acc[k] = vec_add_32(acc[k], acc[k + NumAccums]);
-    #elif defined(USE_VNNI)
+        // convince GCC to not do weird pointer arithmetic in the following loops
+        const i8* weights_cp = weights;
+
+    #if defined(USE_AVX512)
+        const auto* start = nnzInfo.nnz;
+        const auto* end   = nnzInfo.nnz + nnzInfo.count;
+
         for (IndexType k = NumAccums; k < NumRegs; ++k)
             acc[k] = vec_zero();
-
+        #if defined(USE_VNNI)
         while (start < end - 2)
         {
-            const isize i0 = *start++;
-            const isize i1 = *start++;
-            const isize i2 = *start++;
-            const invec_t        in0 =
-              vec_set_32(load_as<i32>(input + i0 * sizeof(i32)));
-            const invec_t in1 =
-              vec_set_32(load_as<i32>(input + i1 * sizeof(i32)));
-            const invec_t in2 =
-              vec_set_32(load_as<i32>(input + i2 * sizeof(i32)));
-            const auto col0 =
+            const isize   i0  = *start++;
+            const isize   i1  = *start++;
+            const isize   i2  = *start++;
+            const invec_t in0 = vec_set_32(load_as<i32>(input + i0 * sizeof(i32)));
+            const invec_t in1 = vec_set_32(load_as<i32>(input + i1 * sizeof(i32)));
+            const invec_t in2 = vec_set_32(load_as<i32>(input + i2 * sizeof(i32)));
+            const auto    col0 =
               reinterpret_cast<const invec_t*>(&weights_cp[i0 * OutputDimensions * ChunkSize]);
             const auto col1 =
               reinterpret_cast<const invec_t*>(&weights_cp[i1 * OutputDimensions * ChunkSize]);
@@ -361,19 +354,147 @@ class AffineTransformSparseInput {
                 vec_add_dpbusd_32(acc[k + 2 * NumAccums], in2, col2[k]);
             }
         }
+
         for (IndexType k = 0; k < NumAccums; ++k)
             acc[k] = vec_add_32(vec_add_32(acc[k], acc[k + NumAccums]), acc[k + 2 * NumAccums]);
-    #endif
+        #endif
+
         while (start < end)
         {
-            const isize i = *start++;
+            const isize   i  = *start++;
             const invec_t in = vec_set_32(load_as<i32>(input + i * sizeof(i32)));
             const auto    col =
               reinterpret_cast<const invec_t*>(&weights_cp[i * OutputDimensions * ChunkSize]);
             for (IndexType k = 0; k < NumAccums; ++k)
                 vec_add_dpbusd_32(acc[k], in, col[k]);
         }
+    #else
+        static_assert(InputDimensions % 256 == 0);
 
+        for (IndexType k = 0; k < InputDimensions / 256; ++k)
+        {
+            u64   bits = load_as<u64>(nnzInfo.bitset + k * 8);
+            isize base = k * 64;
+
+            auto* base_addr    = input + base * sizeof(i32);
+            auto* weights_base = &weights_cp[base * OutputDimensions * ChunkSize];
+
+        #if defined(USE_NEON_DOTPROD) && defined(__GNUC__) && !defined(__clang__)
+            // GCC 15 pessimizes the following code on ARM64 by eliding the intermediate
+            // computation of key pointers (base_addr, weights_base, col, input_addr), leading
+            // to a lot of redundant indexing arithmetic in the while (bits) loop. The
+            // optimization barriers force these pointers to be calculated and used.
+            #if __GNUC__ >= 15
+                #define FIX_GCC15_MISOPTIMIZATION
+            #endif
+        #endif
+
+        #ifdef FIX_GCC15_MISOPTIMIZATION
+            asm("" : "+r"(base_addr), "+r"(weights_base));  // opt barrier
+        #endif
+
+        #if defined(USE_AVXVNNI)
+            while (bits)
+            {
+                const isize   i0   = pop_lsb(bits);
+                const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                const auto    col0 = reinterpret_cast<const invec_t*>(
+                  &weights_base[i0 * OutputDimensions * ChunkSize]);
+
+                if (!bits)
+                {
+                    for (IndexType l = 0; l < NumAccums; ++l)
+                        vec_add_dpbusd_32(acc[l], in0, col0[l]);
+                    break;
+                }
+
+                const isize   i1   = pop_lsb(bits);
+                const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
+                const auto    col1 = reinterpret_cast<const invec_t*>(
+                  &weights_base[i1 * OutputDimensions * ChunkSize]);
+
+                for (IndexType l = 0; l < NumAccums; ++l)
+                {
+                    vec_add_dpbusd_32(acc[l], in0, col0[l]);
+                    vec_add_dpbusd_32(acc[l + NumAccums], in1, col1[l]);
+                }
+            }
+        #elif defined(USE_NEON_DOTPROD)
+            while (bits)
+            {
+                const isize i0 = pop_lsb(bits);
+                if (!bits)
+                {
+                    const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                    const auto    col0 = reinterpret_cast<const invec_t*>(
+                      &weights_base[i0 * OutputDimensions * ChunkSize]);
+                    for (IndexType l = 0; l < NumAccums; ++l)
+                        vec_add_dpbusd_32(acc[l], in0, col0[l]);
+                    break;
+                }
+
+                const isize i1 = pop_lsb(bits);
+                if (!bits)
+                {
+                    const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                    const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
+                    const auto    col0 = reinterpret_cast<const invec_t*>(
+                      &weights_base[i0 * OutputDimensions * ChunkSize]);
+                    const auto col1 = reinterpret_cast<const invec_t*>(
+                      &weights_base[i1 * OutputDimensions * ChunkSize]);
+                    for (IndexType l = 0; l < NumAccums; ++l)
+                    {
+                        vec_add_dpbusd_32(acc[l], in0, col0[l]);
+                        vec_add_dpbusd_32(acc[l + NumAccums], in1, col1[l]);
+                    }
+                    break;
+                }
+
+                const isize   i2   = pop_lsb(bits);
+                const invec_t in0  = vec_set_32(load_as<i32>(base_addr + i0 * sizeof(i32)));
+                const invec_t in1  = vec_set_32(load_as<i32>(base_addr + i1 * sizeof(i32)));
+                const invec_t in2  = vec_set_32(load_as<i32>(base_addr + i2 * sizeof(i32)));
+                const auto    col0 = reinterpret_cast<const invec_t*>(
+                  &weights_base[i0 * OutputDimensions * ChunkSize]);
+                const auto col1 = reinterpret_cast<const invec_t*>(
+                  &weights_base[i1 * OutputDimensions * ChunkSize]);
+                const auto col2 = reinterpret_cast<const invec_t*>(
+                  &weights_base[i2 * OutputDimensions * ChunkSize]);
+                for (IndexType l = 0; l < NumAccums; ++l)
+                {
+                    vec_add_dpbusd_32(acc[l], in0, col0[l]);
+                    vec_add_dpbusd_32(acc[l + NumAccums], in1, col1[l]);
+                    vec_add_dpbusd_32(acc[l + 2 * NumAccums], in2, col2[l]);
+                }
+            }
+        #else
+            while (bits)
+            {
+                isize       i          = pop_lsb(bits);
+                const auto* input_addr = base_addr + i * sizeof(i32);
+                auto        col =
+                  reinterpret_cast<const invec_t*>(&weights_base[i * OutputDimensions * ChunkSize]);
+
+            #ifdef FIX_GCC15_MISOPTIMIZATION
+                asm("" : "+r"(col), "+r"(input_addr));
+                #undef FIX_GCC15_MISOPTIMIZATION
+            #endif
+
+                const invec_t in = vec_set_32(load_as<i32>(input_addr));
+                for (IndexType l = 0; l < NumAccums; ++l)
+                    vec_add_dpbusd_32(acc[l], in, col[l]);
+            }
+        #endif
+        }
+
+        #if defined(USE_AVXVNNI)
+        for (IndexType l = 0; l < NumAccums; ++l)
+            acc[l] = vec_add_32(acc[l], acc[l + NumAccums]);
+        #elif defined(USE_NEON_DOTPROD)
+        for (IndexType l = 0; l < NumAccums; ++l)
+            acc[l] = vaddq_s32(vaddq_s32(acc[l], acc[l + NumAccums]), acc[l + 2 * NumAccums]);
+        #endif
+    #endif
         outvec_t* outptr = reinterpret_cast<outvec_t*>(output);
         for (IndexType k = 0; k < NumAccums; ++k)
             outptr[k] = acc[k];
@@ -383,6 +504,53 @@ class AffineTransformSparseInput {
     #ifdef vec_add_32
         #undef vec_add_32
     #endif
+#elif defined(USE_RVV)
+        // we don't support larger for now
+        static_assert(OutputDimensions <= 128 * 8 / 32);
+
+    #define RVV_SPARSE_PROPAGATE(m1, m2, m4) \
+        do \
+        { \
+            usize          vl  = OutputDimensions; \
+            vint32##m4##_t acc = __riscv_vle32_v_i32##m4(biases, vl); \
+            IndexType      i   = 0; \
+            for (; i + 2 <= nnzInfo.count; i += 2) \
+            { \
+                usize         idx0 = nnzInfo.nnz[i + 0]; \
+                usize         idx1 = nnzInfo.nnz[i + 1]; \
+                uint8_t       in0  = input[idx0]; \
+                uint8_t       in1  = input[idx1]; \
+                vint8##m1##_t w0   = __riscv_vle8_v_i8##m1(&weights[idx0 * OutputDimensions], vl); \
+                vint8##m1##_t w1   = __riscv_vle8_v_i8##m1(&weights[idx1 * OutputDimensions], vl); \
+                /* input is in [0:127], weights is in [-128:127], \
+                 * so it's safe to accumulate into 16-bit twice */ \
+                vint16##m2##_t prod = __riscv_vwmulsu(w0, in0, vl); \
+                prod                = __riscv_vwmaccus(prod, in1, w1, vl); \
+                acc                 = __riscv_vwadd_wv(acc, prod, vl); \
+            } \
+            if (i < nnzInfo.count) \
+            { \
+                usize          idx  = nnzInfo.nnz[i]; \
+                uint8_t        in   = input[idx]; \
+                vint8##m1##_t  w    = __riscv_vle8_v_i8##m1(&weights[idx * OutputDimensions], vl); \
+                vint16##m2##_t prod = __riscv_vwmulsu(w, in, vl); \
+                acc                 = __riscv_vwadd_wv(acc, prod, vl); \
+            } \
+            __riscv_vse32(output, acc, vl); \
+        } while (0)
+
+        // Select LMUL
+        const usize VL1 = __riscv_vsetvlmax_e32m1();
+        if (VL1 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(mf4, mf2, m1);
+        else if (VL1 * 2 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(mf2, m1, m2);
+        else if (VL1 * 4 >= OutputDimensions)
+            RVV_SPARSE_PROPAGATE(m1, m2, m4);
+        else
+            RVV_SPARSE_PROPAGATE(m2, m4, m8);
+
+    #undef RVV_SPARSE_PROPAGATE
 #else
         // Use dense implementation for the other architectures.
         affine_transform_non_ssse3<InputDimensions, PaddedInputDimensions, OutputDimensions>(

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -66,9 +66,9 @@ class SqrClippedReLU {
         return h;
     }
 
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_PAIR_ACTIVATIONS)
     // Produce the squared and linear clipped activations together, sharing the input loads and
-    // the initial signed 32-to-16-bit saturating packs.
+    // the initial signed 32-to-16-bit saturating narrowing.
     void propagate_pair(const InputType* input, OutputType* squared, OutputType* clipped) const {
         static_assert(WeightScaleBitsLocal >= 5 && WeightScaleBitsLocal <= 8,
                       "SqrClippedReLU only support WeightScaleBitsLocal between 5 and 8");
@@ -77,6 +77,29 @@ class SqrClippedReLU {
         constexpr IndexType NumChunks       = InputDimensions / 32;
         constexpr int       SimdShiftAmount = WeightScaleBitsLocal * 2 + 7 - 16;
 
+    #if defined(USE_AVX512)
+        const auto in      = reinterpret_cast<const __m512i*>(input);
+        auto       sqrOut  = reinterpret_cast<__m256i*>(squared);
+        auto       clipOut = reinterpret_cast<__m256i*>(clipped);
+
+        const __m512i zero = _mm512_setzero_si512();
+
+        for (IndexType i = 0; i < NumChunks; ++i)
+        {
+            const __m256i words0 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 0]));
+            const __m256i words1 = _mm512_cvtsepi32_epi16(_mm512_load_si512(&in[i * 2 + 1]));
+            const __m512i words  = _mm512_inserti64x4(_mm512_castsi256_si512(words0), words1, 1);
+
+            const __m512i sqrWords =
+              _mm512_srli_epi16(_mm512_mulhi_epi16(words, words), SimdShiftAmount);
+            _mm256_store_si256(&sqrOut[i], _mm512_cvtsepi16_epi8(sqrWords));
+
+            const __m512i clipWords =
+              _mm512_srli_epi16(_mm512_max_epi16(words, zero), WeightScaleBitsLocal);
+            _mm256_store_si256(&clipOut[i], _mm512_cvtsepi16_epi8(clipWords));
+        }
+
+    #elif defined(USE_AVX2_PAIR_ACTIVATIONS)
         const auto in      = reinterpret_cast<const __m256i*>(input);
         auto       sqrOut  = reinterpret_cast<__m256i*>(squared);
         auto       clipOut = reinterpret_cast<__m256i*>(clipped);
@@ -104,6 +127,7 @@ class SqrClippedReLU {
             const __m256i clipPacked = _mm256_packs_epi16(clip0, clip1);
             _mm256_store_si256(&clipOut[i], clipPacked);
         }
+    #endif
     }
 #endif
 

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -35,6 +35,7 @@
 #include "nnue_architecture.h"
 #include "nnue_common.h"
 #include "nnue_misc.h"
+#include "nnz_helper.h"
 
 // Macro to embed the default efficiently updatable neural network (NNUE) file
 // data in the engine binary (using incbin.h, by Dale Weiler).
@@ -175,10 +176,12 @@ Network<Arch, Transformer>::evaluate(const Position&                         pos
 
     ASSERT_ALIGNED(transformedFeatures, alignment);
 
+    NNZInfo<FTDimensions> nnzInfo;
+
     const int  bucket = (pos.count<ALL_PIECES>() - 1) / 4;
-    const auto psqt =
-      featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-    const auto positional = network[bucket].propagate(transformedFeatures);
+    const auto psqt = featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures,
+                                                   bucket, nnzInfo);
+    const auto positional = network[bucket].propagate(transformedFeatures, nnzInfo);
     return {static_cast<Value>(psqt / OutputScale), static_cast<Value>(positional / OutputScale)};
 }
 
@@ -241,9 +244,10 @@ Network<Arch, Transformer>::trace_evaluate(const Position&                      
     t.correctBucket = (pos.count<ALL_PIECES>() - 1) / 4;
     for (IndexType bucket = 0; bucket < LayerStacks; ++bucket)
     {
-        const auto materialist =
-          featureTransformer.transform(pos, accumulatorStack, cache, transformedFeatures, bucket);
-        const auto positional = network[bucket].propagate(transformedFeatures);
+        NNZInfo<FTDimensions> nnzInfo;
+        const auto materialist = featureTransformer.transform(
+          pos, accumulatorStack, cache, transformedFeatures, bucket, nnzInfo);
+        const auto positional = network[bucket].propagate(transformedFeatures, nnzInfo);
 
         t.psqt[bucket]       = static_cast<Value>(materialist / OutputScale);
         t.positional[bucket] = static_cast<Value>(positional / OutputScale);

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -48,6 +48,13 @@ void update_accumulator_refresh_cache(Color                     perspective,
                                       const Position&           pos,
                                       AccumulatorState&         accumulatorState,
                                       ActiveAccumulatorCache&        cache);
+
+void update_accumulator_hybrid(Color                           perspective,
+                               const Position&                 pos,
+                               const ActiveFeatureTransformer& featureTransformer,
+                               AccumulatorState&               target,
+                               const AccumulatorState&         computed,
+                               ActiveAccumulatorCache&         cache);
 }
 
 const AccumulatorState& AccumulatorStack::latest() const noexcept { return accumulators[size - 1]; }
@@ -90,6 +97,8 @@ void AccumulatorStack::evaluate_side(Color                     perspective,
                                      const ActiveFeatureTransformer& featureTransformer,
                                      ActiveAccumulatorCache&        cache) noexcept {
 
+    constexpr int MIN_PC_COUNT_HYBRID = 15;
+
     const auto last_usable_accum = find_last_usable_accumulator(perspective);
 
     if (accumulators[last_usable_accum].computed[perspective])
@@ -97,6 +106,20 @@ void AccumulatorStack::evaluate_side(Color                     perspective,
 
     else
     {
+        const auto& dirtyPiece = latest().dirtyPiece;
+
+        if (dirtyPiece.pc == make_piece(perspective, KING)
+            && accumulators[size - 2].computed[perspective]
+            && pos.count<ALL_PIECES>() >= MIN_PC_COUNT_HYBRID
+            && ((int(dirtyPiece.from) & 0b100) == (int(dirtyPiece.to) & 0b100))
+            && dirtyPiece.add_sq == SQ_NONE  // excludes castling
+        )
+        {
+            update_accumulator_hybrid(perspective, pos, featureTransformer, mut_latest(),
+                                      accumulators[size - 2], cache);
+            return;
+        }
+
         update_accumulator_refresh_cache(perspective, featureTransformer, pos, mut_latest(), cache);
         backward_update_incremental(perspective, pos, featureTransformer, last_usable_accum);
     }
@@ -464,6 +487,358 @@ Bitboard get_changed_pieces(const std::array<Piece, SQUARE_NB>& oldPieces,
 
     return changed;
 #endif
+}
+
+// Updates accumulator for a king move, and also updates the accumulator cache
+// for the new king position.
+void update_accumulator_hybrid(Color                     perspective,
+                               const Position&           pos,
+                               const ActiveFeatureTransformer& featureTransformer,
+                               AccumulatorState&         target,
+                               const AccumulatorState&   computed,
+                               ActiveAccumulatorCache&   cache) {
+    const auto& dirtyPiece = target.dirtyPiece;
+
+    assert(dirtyPiece.pc == make_piece(perspective, KING));
+    assert(dirtyPiece.to != SQ_NONE);
+    assert((int(dirtyPiece.from) & 0b100) == (int(dirtyPiece.to) & 0b100));
+    assert(computed.computed[perspective]);
+    assert(!target.computed[perspective]);
+
+    const Square oldKsq = dirtyPiece.from;
+    const Square newKsq = dirtyPiece.to;
+    assert(oldKsq != newKsq);
+
+    const auto& currentPieces  = pos.piece_array();
+    auto        previousPieces = currentPieces;  // copies 64 bytes!
+
+    Bitboard previousPieceBB = pos.pieces();
+
+    assert(previousPieces[newKsq] == dirtyPiece.pc);
+
+    if (dirtyPiece.remove_sq != SQ_NONE)
+    {
+        assert(dirtyPiece.remove_sq == newKsq);
+        previousPieces[newKsq] = dirtyPiece.remove_pc;
+    }
+    else
+    {
+        previousPieces[newKsq] = NO_PIECE;
+        previousPieceBB &= ~square_bb(newKsq);
+    }
+
+    assert(previousPieces[oldKsq] == NO_PIECE);
+    previousPieces[oldKsq] = make_piece(perspective, KING);
+    previousPieceBB |= square_bb(oldKsq);
+
+    const auto& oldEntry = cache[oldKsq][perspective];
+    auto&       newEntry = cache[newKsq][perspective];
+
+    // "Remove" means we need to remove them from the cache entry,
+    // "Add" means add them to the entry to get the accumulator we want
+    PSQFeatureSet::IndexList oldRemove, oldAdd, newRemove, newAdd;
+
+    Bitboard oldChangedBB = get_changed_pieces(oldEntry.pieces, previousPieces);
+    Bitboard oldRemovedBB = oldChangedBB & oldEntry.pieceBB;
+    Bitboard oldAddedBB   = oldChangedBB & previousPieceBB;
+
+    Bitboard newChangedBB = get_changed_pieces(newEntry.pieces, currentPieces);
+    Bitboard newRemovedBB = newChangedBB & newEntry.pieceBB;
+    Bitboard newAddedBB   = newChangedBB & pos.pieces();
+
+#if defined(USE_AVX512ICL)
+    PSQFeatureSet::write_indices(oldEntry.pieces, previousPieces, oldRemovedBB, oldAddedBB,
+                                 perspective, oldKsq, oldRemove, oldAdd);
+    PSQFeatureSet::write_indices(newEntry.pieces, currentPieces, newRemovedBB, newAddedBB,
+                                 perspective, newKsq, newRemove, newAdd);
+#else
+    while (oldRemovedBB)
+    {
+        Square sq = pop_lsb(oldRemovedBB);
+        oldRemove.push_back(
+          PSQFeatureSet::make_index(perspective, sq, oldEntry.pieces[sq], oldKsq));
+    }
+    while (oldAddedBB)
+    {
+        Square sq = pop_lsb(oldAddedBB);
+        oldAdd.push_back(PSQFeatureSet::make_index(perspective, sq, previousPieces[sq], oldKsq));
+    }
+    while (newRemovedBB)
+    {
+        Square sq = pop_lsb(newRemovedBB);
+        newRemove.push_back(
+          PSQFeatureSet::make_index(perspective, sq, newEntry.pieces[sq], newKsq));
+    }
+    while (newAddedBB)
+    {
+        Square sq = pop_lsb(newAddedBB);
+        newAdd.push_back(PSQFeatureSet::make_index(perspective, sq, currentPieces[sq], newKsq));
+    }
+#endif
+
+    ThreatFeatureSet::IndexList thrRemoved, thrAdded;  // also contain pp indices
+    const auto*                 threatPpBase = &featureTransformer.threatAndPpWeights[0];
+    IndexType                   pfStride     = ActiveFeatureTransformer::OutputDimensions;
+    ThreatFeatureSet::append_changed_indices(perspective, newKsq, target.dirtyThreats, thrRemoved,
+                                             thrAdded, threatPpBase, pfStride);
+    PairFeatureSet::append_changed_indices(perspective, newKsq, target.dirtyPawnPairs, thrRemoved,
+                                           thrAdded, threatPpBase, pfStride);
+
+    constexpr IndexType Dimensions = ActiveFeatureTransformer::OutputDimensions;
+
+    const auto& fromAcc = computed.accumulation[perspective];
+    auto&       toAcc   = target.accumulation[perspective];
+
+    const auto& fromPsqtAcc = computed.psqtAccumulation[perspective];
+    auto&       toPsqtAcc   = target.psqtAccumulation[perspective];
+
+#ifdef VECTOR
+    using Tiling = SIMDTiling<Dimensions, Dimensions, PSQTBuckets>;
+
+    vec_t      acc[Tiling::NumRegs];
+    psqt_vec_t psqt[Tiling::NumPsqtRegs];
+
+    const auto* weights            = &featureTransformer.weights[0];
+    const auto* threatAndPpWeights = &featureTransformer.threatAndPpWeights[0];
+
+    for (IndexType j = 0; j < Dimensions / Tiling::TileHeight; ++j)
+    {
+        const usize tileOff      = j * Tiling::TileHeight;
+        auto*       fromTile     = reinterpret_cast<const vec_t*>(&fromAcc[tileOff]);
+        auto*       oldEntryTile = reinterpret_cast<const vec_t*>(&oldEntry.accumulation[tileOff]);
+        auto*       newEntryTile = reinterpret_cast<vec_t*>(&newEntry.accumulation[tileOff]);
+        auto*       toTile       = reinterpret_cast<vec_t*>(&toAcc[tileOff]);
+
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+            acc[k] = newEntryTile[k];
+
+        for (int i = 0; i < newRemove.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[newRemove[i] * Dimensions + tileOff]);
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_sub_16(acc[k], column[k]);
+        }
+        for (int i = 0; i < newAdd.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[newAdd[i] * Dimensions + tileOff]);
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], column[k]);
+        }
+
+        for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+        {
+            vec_store(&newEntryTile[k], acc[k]);
+            // adding the old accumulator adds (most of) the threats and pp weights that we need
+            acc[k] = vec_add_16(acc[k], fromTile[k]);
+            // But we have added a whole bunch of psq weights for the wrong king bucket which
+            // we need to remove
+            // first we remove the cached psq accumulation for the old king position...
+            acc[k] = vec_sub_16(acc[k], oldEntryTile[k]);
+        }
+
+        // ... then we adjust
+        for (int i = 0; i < oldRemove.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[oldRemove[i] * Dimensions + tileOff]);
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], column[k]);
+        }
+        for (int i = 0; i < oldAdd.ssize(); ++i)
+        {
+            auto* column =
+              reinterpret_cast<const vec_t*>(&weights[oldAdd[i] * Dimensions + tileOff]);
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_sub_16(acc[k], column[k]);
+        }
+
+        for (int i = 0; i < thrRemoved.ssize(); ++i)
+        {
+            auto* column = reinterpret_cast<const vec_i8_t*>(
+              &threatAndPpWeights[thrRemoved[i] * Dimensions + tileOff]);
+
+    #ifdef USE_NEON
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                acc[k]     = vsubw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vsubw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #else
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_sub_16(acc[k], vec_convert_8_16(column[k]));
+    #endif
+        }
+
+        for (int i = 0; i < thrAdded.ssize(); ++i)
+        {
+            auto* column = reinterpret_cast<const vec_i8_t*>(
+              &threatAndPpWeights[thrAdded[i] * Dimensions + tileOff]);
+
+    #ifdef USE_NEON
+            for (IndexType k = 0; k < Tiling::NumRegs; k += 2)
+            {
+                acc[k]     = vaddw_s8(acc[k], vget_low_s8(column[k / 2]));
+                acc[k + 1] = vaddw_high_s8(acc[k + 1], column[k / 2]);
+            }
+    #else
+            for (IndexType k = 0; k < Tiling::NumRegs; ++k)
+                acc[k] = vec_add_16(acc[k], vec_convert_8_16(column[k]));
+    #endif
+        }
+
+        for (IndexType k = 0; k < Tiling::NumRegs; k++)
+            vec_store(&toTile[k], acc[k]);
+    }
+
+    for (IndexType j = 0; j < PSQTBuckets / Tiling::PsqtTileHeight; ++j)
+    {
+        const usize psqtTileOff  = j * Tiling::PsqtTileHeight;
+        auto*       fromTilePsqt = reinterpret_cast<const psqt_vec_t*>(&fromPsqtAcc[psqtTileOff]);
+        auto*       oldEntryTilePsqt =
+          reinterpret_cast<const psqt_vec_t*>(&oldEntry.psqtAccumulation[psqtTileOff]);
+        auto* newEntryTilePsqt =
+          reinterpret_cast<psqt_vec_t*>(&newEntry.psqtAccumulation[psqtTileOff]);
+        auto* toTilePsqt = reinterpret_cast<psqt_vec_t*>(&toPsqtAcc[psqtTileOff]);
+
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+            psqt[k] = newEntryTilePsqt[k];
+
+        for (int i = 0; i < newRemove.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[newRemove[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+        }
+        for (int i = 0; i < newAdd.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[newAdd[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+        {
+            vec_store_psqt(&newEntryTilePsqt[k], psqt[k]);
+            psqt[k] = vec_add_psqt_32(psqt[k], fromTilePsqt[k]);
+            psqt[k] = vec_sub_psqt_32(psqt[k], oldEntryTilePsqt[k]);
+        }
+
+        for (int i = 0; i < oldRemove.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[oldRemove[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+        for (int i = 0; i < oldAdd.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.psqtWeights[oldAdd[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (int i = 0; i < thrRemoved.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer
+                 .threatAndPpPsqtWeights[thrRemoved[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_sub_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (int i = 0; i < thrAdded.ssize(); ++i)
+        {
+            auto* columnPsqt = reinterpret_cast<const psqt_vec_t*>(
+              &featureTransformer.threatAndPpPsqtWeights[thrAdded[i] * PSQTBuckets + psqtTileOff]);
+            for (usize k = 0; k < Tiling::NumPsqtRegs; ++k)
+                psqt[k] = vec_add_psqt_32(psqt[k], columnPsqt[k]);
+        }
+
+        for (IndexType k = 0; k < Tiling::NumPsqtRegs; ++k)
+            vec_store_psqt(&toTilePsqt[k], psqt[k]);
+    }
+
+#else
+    for (const auto index : newRemove)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            newEntry.accumulation[j] -= featureTransformer.weights[offset + j];
+
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            newEntry.psqtAccumulation[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
+    for (const auto index : newAdd)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            newEntry.accumulation[j] += featureTransformer.weights[offset + j];
+
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            newEntry.psqtAccumulation[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
+
+    toAcc     = newEntry.accumulation;
+    toPsqtAcc = newEntry.psqtAccumulation;
+
+    for (IndexType j = 0; j < Dimensions; ++j)
+    {
+        toAcc[j] += fromAcc[j];
+        toAcc[j] -= oldEntry.accumulation[j];
+    }
+    for (usize k = 0; k < PSQTBuckets; ++k)
+    {
+        toPsqtAcc[k] += fromPsqtAcc[k];
+        toPsqtAcc[k] -= oldEntry.psqtAccumulation[k];
+    }
+
+    for (const auto index : oldRemove)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] += featureTransformer.weights[offset + j];
+
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] += featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
+    for (const auto index : oldAdd)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] -= featureTransformer.weights[offset + j];
+
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] -= featureTransformer.psqtWeights[index * PSQTBuckets + k];
+    }
+
+    for (const auto index : thrRemoved)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] -= featureTransformer.threatAndPpWeights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] -= featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
+    }
+    for (const auto index : thrAdded)
+    {
+        const IndexType offset = Dimensions * index;
+        for (IndexType j = 0; j < Dimensions; ++j)
+            toAcc[j] += featureTransformer.threatAndPpWeights[offset + j];
+        for (usize k = 0; k < PSQTBuckets; ++k)
+            toPsqtAcc[k] += featureTransformer.threatAndPpPsqtWeights[index * PSQTBuckets + k];
+    }
+
+#endif
+
+    newEntry.pieces  = currentPieces;
+    newEntry.pieceBB = pos.pieces();
+
+    target.computed[perspective] = true;
 }
 
 // HalfKA data comes from the Finny table entry, while the threats are built

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -32,6 +32,7 @@
 #include "layers/clipped_relu.h"
 #include "layers/sqr_clipped_relu.h"
 #include "nnue_common.h"
+#include "nnz_helper.h"
 
 namespace Stockfish::Eval::NNUE {
 
@@ -107,7 +108,8 @@ struct NetworkArchitecture {
             && fc_2.write_parameters(stream);
     }
 
-    i32 propagate(const TransformedFeatureType* transformedFeatures) const {
+    i32 propagate(const TransformedFeatureType* transformedFeatures,
+                  const NNZInfo<TransformedFeatureDimensions>& nnzInfo) const {
         struct alignas(CacheLineSize) Buffer {
             alignas(CacheLineSize) typename decltype(fc_0)::OutputBuffer fc_0_out;
             alignas(CacheLineSize) typename decltype(ac_sqr_0)::OutputType
@@ -125,8 +127,8 @@ struct NetworkArchitecture {
         alignas(CacheLineSize) static thread_local Buffer buffer;
 #endif
 
-        fc_0.propagate(transformedFeatures, buffer.fc_0_out);
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+        fc_0.propagate(transformedFeatures, buffer.fc_0_out, nnzInfo);
+#if defined(USE_PAIR_ACTIVATIONS)
         ac_sqr_0.propagate_pair(buffer.fc_0_out, buffer.concat_buffer,
                                 buffer.concat_buffer + FC_0_OUTPUTS);
 #else
@@ -135,7 +137,7 @@ struct NetworkArchitecture {
 #endif
 
         fc_1.propagate(buffer.concat_buffer, buffer.fc_1_out);
-#if defined(USE_AVX2_PAIR_ACTIVATIONS)
+#if defined(USE_PAIR_ACTIVATIONS)
         ac_sqr_1.propagate_pair(buffer.fc_1_out, buffer.concat_buffer + FC_0_OUTPUTS * 2,
                                 buffer.concat_buffer + FC_0_OUTPUTS * 2 + FC_1_OUTPUTS);
 #else

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -32,6 +32,7 @@
 #include "nnue_accumulator.h"
 #include "nnue_architecture.h"
 #include "nnue_common.h"
+#include "nnz_helper.h"
 #include "simd.h"
 
 namespace Stockfish::Eval::NNUE {
@@ -248,11 +249,12 @@ class FeatureTransformer {
     }
 
     // Convert input features
-    i32 transform(const Position&                           pos,
-                           AccumulatorStack&                         accumulatorStack,
-                           AccumulatorCaches::Cache<HalfDimensions>& cache,
-                           OutputType*                               output,
-                           int                                       bucket) const {
+    i32 transform(const Position&                             pos,
+                  AccumulatorStack&                           accumulatorStack,
+                  AccumulatorCaches::Cache<HalfDimensions>&  cache,
+                  OutputType*                                 output,
+                  int                                         bucket,
+                  [[maybe_unused]] NNZInfo<OutputDimensions>& nnzInfo) const {
 
         using namespace SIMD;
         accumulatorStack.evaluate(pos, *this, cache);
@@ -272,15 +274,15 @@ class FeatureTransformer {
 
 #if defined(VECTOR)
 
+            [[maybe_unused]] auto cursor = nnzInfo.make_cursor(p);
+
             constexpr IndexType OutputChunkSize = MaxChunkSize;
             static_assert((HalfDimensions / 2) % OutputChunkSize == 0);
             constexpr IndexType NumOutputChunks = HalfDimensions / 2 / OutputChunkSize;
 
-#if !defined(USE_NEON)
-            const vec_t   Zero  = vec_zero();
-            const vec_t   FtMax = vec_set_16(FtMaxVal);
-            constexpr int shift = 7;
-#endif
+            [[maybe_unused]] const vec_t   Zero  = vec_zero();
+            [[maybe_unused]] const vec_t   FtMax = vec_set_16(FtMaxVal);
+            [[maybe_unused]] constexpr int shift = 7;
 
             const vec_t* in0 = reinterpret_cast<const vec_t*>(&(accumulation[perspectives[p]][0]));
             const vec_t* in1 =
@@ -334,35 +336,106 @@ class FeatureTransformer {
             // 8 bits. Shifting it by 7 bits left will no longer occupy the
             // signed bit, so we are safe.
 
-                for (IndexType j = 0; j < NumOutputChunks; ++j)
+            for (IndexType j = 0; j < NumOutputChunks; j += 2)
+            {
+                vec_t packed[2];
+                for (IndexType k = 0; k < 2; ++k)
                 {
-#if defined(USE_NEON)
-                    // The NEON path relies on unsigned saturation for crelu.
+                    const IndexType i = (j + k) * 2;
+
+                    vec_t acc0a = in0[i + 0];
+                    vec_t acc0b = in0[i + 1];
+                    vec_t acc1a = in1[i + 0];
+                    vec_t acc1b = in1[i + 1];
+
                     static_assert(FtMaxVal == 255);
 
-                    const uint16x8_t mul0 =
-                      vmull_u8(vqmovun_s16(in0[j * 2 + 0]), vqmovun_s16(in1[j * 2 + 0]));
-                    const uint16x8_t mul1 =
-                      vmull_u8(vqmovun_s16(in0[j * 2 + 1]), vqmovun_s16(in1[j * 2 + 1]));
+    #if defined(USE_NEON)
+                    uint16x8_t mul0 = vmull_u8(vqmovun_s16(acc0a), vqmovun_s16(acc1a));
+                    uint16x8_t mul1 = vmull_u8(vqmovun_s16(acc0b), vqmovun_s16(acc1b));
 
-                    const uint8x16x2_t uzp =
+                    uint8x16x2_t uzp =
                       vuzpq_u8(vreinterpretq_u8_u16(mul0), vreinterpretq_u8_u16(mul1));
-                    const uint8x16_t pab = vshrq_n_u8(uzp.val[1], 1);
-                    out[j] = reinterpret_cast<vec_t>(pab);
-#else
-                    const vec_t sum0a =
-                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 0], FtMax), Zero), shift);
-                    const vec_t sum0b =
-                      vec_slli_16(vec_max_16(vec_min_16(in0[j * 2 + 1], FtMax), Zero), shift);
-                    const vec_t sum1a = vec_min_16(in1[j * 2 + 0], FtMax);
-                    const vec_t sum1b = vec_min_16(in1[j * 2 + 1], FtMax);
+                    uint8x16_t pab    = vshrq_n_u8(uzp.val[1], 1);
+                    vec_t      result = reinterpret_cast<vec_t>(pab);
+    #elif defined(USE_LSX) || defined(USE_LASX)
+                    vec_t pa = vec_packus_16(acc0a, acc0b);
+                    vec_t pb = vec_packus_16(acc1a, acc1b);
 
-                    const vec_t pa = vec_mulhi_16(sum0a, sum1a);
-                    const vec_t pb = vec_mulhi_16(sum0b, sum1b);
+                    vec_t hi     = vec_mulhi_8(pa, pb);
+                    vec_t result = vec_srli_8(hi, 1);
+    #elif defined(__wasm__)
+                    // _mm_mulhi_epi16 is lowered to 32-bit multiplies, so we take
+                    // a similar approach as the NEON path.
+                    vec_t mul0 = vec_packus_16(acc0a, acc0b);
+                    vec_t mul1 = vec_packus_16(acc1a, acc1b);
 
-                    out[j] = vec_packus_16(pa, pb);
-#endif
+                    vec_t low = wasm_u16x8_extmul_low_u8x16(mul0, mul1);
+                    vec_t hi  = wasm_u16x8_extmul_high_u8x16(mul0, mul1);
+
+                    // equivalent to vuzp2_u8
+                    vec_t merged = wasm_i8x16_shuffle(low, hi, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19,
+                                                      21, 23, 25, 27, 29, 31);
+                    vec_t result = wasm_u8x16_shr(merged, 1);
+    #else
+                    vec_t sum0a = vec_slli_16(vec_max_16(vec_min_16(acc0a, FtMax), Zero), shift);
+                    vec_t sum0b = vec_slli_16(vec_max_16(vec_min_16(acc0b, FtMax), Zero), shift);
+                    vec_t sum1a = vec_min_16(acc1a, FtMax);
+                    vec_t sum1b = vec_min_16(acc1b, FtMax);
+
+                    vec_t pa = vec_mulhi_16(sum0a, sum1a);
+                    vec_t pb = vec_mulhi_16(sum0b, sum1b);
+
+                    vec_t result = vec_packus_16(pa, pb);
+    #endif
+
+                    packed[k] = out[j + k] = result;
                 }
+
+                cursor.record2(packed[0], packed[1]);
+            }
+
+#elif defined(USE_RVV)
+
+            usize       j  = 0;
+            usize       VL = __riscv_vsetvlmax_e8m1();
+            vuint8m1_t  vid8;
+            vuint16m2_t vid16;
+            if (VL <= 256)
+                vid8 = __riscv_vid_v_u8m1(VL);
+            else
+                vid16 = __riscv_vid_v_u16m2(VL);
+            const auto& accp = accumulation[perspectives[p]];
+
+            for (usize vl; j < HalfDimensions / 2; j += vl)
+            {
+                vl = __riscv_vsetvl_e16m2(HalfDimensions / 2 - j);
+
+                vint16m2_t acc0 = __riscv_vle16_v_i16m2(&accp[j], vl);
+                vint16m2_t acc1 = __riscv_vle16_v_i16m2(&accp[j + HalfDimensions / 2], vl);
+
+                acc0 = __riscv_vmax(acc0, 0, vl);
+                acc1 = __riscv_vmax(acc1, 0, vl);
+
+                vuint8m1_t pa = __riscv_vnclipu(__riscv_vreinterpret_u16m2(acc0), 0, 0, vl);
+                vuint8m1_t pb = __riscv_vnclipu(__riscv_vreinterpret_u16m2(acc1), 0, 0, vl);
+
+                vuint8m1_t hi     = __riscv_vmulhu(pa, pb, vl);
+                vuint8m1_t result = __riscv_vsrl(hi, 1, vl);
+
+                __riscv_vse8(&output[offset + j], result, vl);
+
+                vbool8_t    m   = __riscv_vmsne(result, 0, vl);
+                usize       cnt = __riscv_vcpop(m, vl);
+                vuint16m2_t vidx;
+                if (VL <= 256)
+                    vidx = __riscv_vzext_vf2(__riscv_vcompress(vid8, m, vl), cnt);
+                else
+                    vidx = __riscv_vcompress(vid16, m, vl);
+                __riscv_vse16(&nnzInfo.nnz[nnzInfo.count], __riscv_vadd(vidx, offset + j, cnt),
+                              cnt);
+                nnzInfo.count += cnt;
+            }
 
 #else
 
@@ -371,7 +444,6 @@ class FeatureTransformer {
                 BiasType sum0 = accumulation[static_cast<int>(perspectives[p])][j + 0];
                 BiasType sum1 =
                   accumulation[static_cast<int>(perspectives[p])][j + HalfDimensions / 2];
-
 
                 sum0 = std::clamp<BiasType>(sum0, 0, FtMaxVal);
                 sum1 = std::clamp<BiasType>(sum1, 0, FtMaxVal);

--- a/src/nnue/nnz_helper.h
+++ b/src/nnue/nnz_helper.h
@@ -1,0 +1,171 @@
+/*
+  Stockfish, a UCI chess playing engine derived from Glaurung 2.1
+  Copyright (C) 2004-2026 The Stockfish developers (see AUTHORS file)
+
+  Stockfish is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Stockfish is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NNZ_HELPER_H_INCLUDED
+#define NNZ_HELPER_H_INCLUDED
+
+#include <utility>
+
+#include "nnue_common.h"
+#include "simd.h"
+
+namespace Stockfish::Eval::NNUE {
+
+template<usize Dimensions>
+struct NNZInfo {
+
+#if defined(USE_AVX512)
+    unsigned count = 0;
+    // indices of non-zero chunks
+    u16 nnz[Dimensions / 4];
+
+    #ifdef USE_AVX512ICL
+    alignas(64) static constexpr auto Indices = []() {
+        std::array<std::array<u16, 32>, 2> indices{};
+        for (int i = 0; i < 2; ++i)
+        {
+            indices[i] = {0, 1, 2,  3,  16, 17, 18, 19, 4,  5,  6,  7,  20, 21, 22, 23,
+                          8, 9, 10, 11, 24, 25, 26, 27, 12, 13, 14, 15, 28, 29, 30, 31};
+            for (u16& m : indices[i])
+                m += u16(i * Dimensions / 8);
+        }
+        return indices;
+    }();
+    #else
+    alignas(64) static constexpr auto Indices = []() {
+        std::array<std::array<u32, 16>, 2> indices{};
+        for (int i = 0; i < 2; ++i)
+        {
+            indices[i] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+            for (u32& m : indices[i])
+                m += i * Dimensions / 8;
+        }
+        return indices;
+    }();
+    #endif
+
+    struct NNZCursor {
+        NNZInfo& info;
+        __m512i  indices;
+        unsigned count;
+
+        NNZCursor(NNZInfo& info_, bool perspective, unsigned count_) :
+            info(info_),
+            count(count_) {
+            indices = _mm512_load_si512(&Indices[perspective]);
+        }
+
+        void record2(SIMD::vec_t neurons1, SIMD::vec_t neurons2) {
+    #if defined(USE_AVX512ICL)
+            const __m512i increment = _mm512_set1_epi16(32);
+
+            // Get a bitmask and gather non zero indices
+            const __m512i   inputV01 = _mm512_packs_epi32(neurons1, neurons2);
+            const __mmask32 nnzMask  = _mm512_test_epi16_mask(inputV01, inputV01);
+
+            // Avoid _mm512_mask_compressstoreu_epi16() as it's 256 uOps on Zen4
+            __m512i nnzIndices = _mm512_maskz_compress_epi16(nnzMask, indices);
+            _mm512_storeu_si512(info.nnz + count, nnzIndices);
+
+            count += popcount(nnzMask);
+            indices = _mm512_add_epi16(indices, increment);
+    #else
+            const __m512i increment = _mm512_set1_epi32(16);
+
+            for (auto neurons : {neurons1, neurons2})
+            {
+                // Get a bitmask and gather non zero indices
+                const __mmask16 nnzMask = _mm512_test_epi32_mask(neurons, neurons);
+                const __m512i   nnzV    = _mm512_maskz_compress_epi32(nnzMask, indices);
+                _mm512_mask_cvtepi32_storeu_epi16(info.nnz + count, 0xFFFF, nnzV);
+
+                count += popcount(nnzMask);
+                indices = _mm512_add_epi32(indices, increment);
+            }
+    #endif
+        }
+
+        ~NNZCursor() { info.count = count; }
+    };
+
+    NNZCursor make_cursor(bool perspective) { return {*this, perspective, count}; }
+#elif defined(USE_RVV)
+    usize count = 0;
+    u16   nnz[Dimensions];  // indices of non-zero chunks
+#else
+    // Each 8-bit chunk
+    alignas(8) u8 bitset[(Dimensions + 31) / 32];
+
+    struct NNZCursor {
+        u8* out;
+
+        NNZCursor(NNZInfo& info, bool perspective) {
+            out = info.bitset + perspective * Dimensions / 64;
+        }
+
+    #if (defined(USE_SSSE3) || defined(USE_LSX) || defined(USE_LASX) || (USE_NEON >= 8))
+        void record2(SIMD::vec_t neurons1, SIMD::vec_t neurons2) {
+            using namespace SIMD;
+
+        #ifdef USE_NEON
+            alignas(16) static constexpr u16 Mask8[8] = {1, 16, 2, 32, 4, 64, 8, 128};
+
+            uint32x4_t n1 = vreinterpretq_u32_s16(neurons1);
+            uint32x4_t n2 = vreinterpretq_u32_s16(neurons2);
+
+            const uint32x4_t t1 = vtstq_u32(n1, n1);
+            const uint32x4_t t2 = vtstq_u32(n2, n2);
+
+            const uint16x8_t packed =
+              vtrn1q_u16(vreinterpretq_u16_u32(t1), vreinterpretq_u16_u32(t2));
+            const uint16x8_t bits = vandq_u16(packed, vld1q_u16(Mask8));
+
+            *out++ = vaddvq_u16(bits);
+        #elif defined(__wasm__)
+            __m128i packed = _mm_packus_epi32(neurons1, neurons2);
+            packed         = _mm_packs_epi16(packed, packed);
+            *out++         = ~_mm_movemask_epi8(_mm_cmpeq_epi8(packed, _mm_setzero_si128()));
+        #else
+            auto m1 = vec_nnz(neurons1);
+            auto m2 = vec_nnz(neurons2);
+
+            if (sizeof(neurons1) == 16)
+            {
+                *out++ = m1 + (m2 << 4);
+            }
+            else
+            {
+                usize bytes = sizeof(neurons1) / 32;
+                memcpy(out, &m1, bytes);
+                out += bytes;
+                memcpy(out, &m2, bytes);
+                out += bytes;
+            }
+        #endif
+        }
+    #elif defined(VECTOR)
+        void record2(SIMD::vec_t, SIMD::vec_t) {}
+    #endif
+    };
+
+    NNZCursor make_cursor(bool perspective) { return {*this, perspective}; }
+#endif
+};
+}  // namespace Stockfish::Eval::NNUE
+
+#endif

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -46,6 +46,10 @@ using Stockfish::load_as;
     #define USE_AVX2_PAIR_ACTIVATIONS
 #endif
 
+#if defined(USE_AVX512) || defined(USE_AVX2_PAIR_ACTIVATIONS)
+    #define USE_PAIR_ACTIVATIONS
+#endif
+
 // If vector instructions are enabled, we update and refresh the
 // accumulator tile by tile such that each tile fits in the CPU's
 // vector registers.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -201,6 +201,7 @@ void Search::Worker::start_searching() {
     main_manager()->tm.init(limits, rootPos.side_to_move(), rootPos.game_ply(), options,
                             main_manager()->originalTimeAdjust);
     tt.new_search();
+    main_manager()->updates.onStart();
     Experience::on_new_position(rootPos, rootMoves);
 
     if (rootMoves.empty())
@@ -977,12 +978,12 @@ Value Search::Worker::search(
 
     // Step 9. Null move search with verification search
     if (cutNode && ss->staticEval >= beta - 13 * depth - 47 * improving + 365 && !excludedMove
-        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && !is_loss(beta))
+        && pos.non_pawn_material(us) && ss->ply >= nmpMinPly && beta >= -2000)
     {
         assert((ss - 1)->currentMove != Move::null());
 
         // Null move dynamic reduction based on depth
-        Depth R = 7 + depth / 3;
+        Depth R = 7 + depth / 3 + std::max((ss->staticEval - beta) / 256, 0);
         do_null_move(pos, st, ss);
 
         Value nullValue = -search<NonPV>(pos, ss + 1, -beta, -beta + 1, depth - R, false);

--- a/src/search.h
+++ b/src/search.h
@@ -236,12 +236,14 @@ class SearchManager: public ISearchManager {
     using UpdateFull     = std::function<void(const InfoFull&)>;
     using UpdateIter     = std::function<void(const InfoIteration&)>;
     using UpdateBestmove = std::function<void(std::string_view, std::string_view)>;
+    using UpdateStart    = std::function<void()>;
 
     struct UpdateContext {
         UpdateShort    onUpdateNoMoves;
         UpdateFull     onUpdateFull;
         UpdateIter     onIter;
         UpdateBestmove onBestmove;
+        UpdateStart    onStart;
     };
 
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -298,18 +298,17 @@ void ThreadPool::start_thinking(const OptionsMap&  options,
     increaseDepth = true;
 
     Search::RootMoves rootMoves;
-    const auto        legalmoves = MoveList<LEGAL>(pos);
 
     for (const auto& uciMove : limits.searchmoves)
     {
         auto move = UCIEngine::to_move(pos, uciMove);
 
-        if (std::find(legalmoves.begin(), legalmoves.end(), move) != legalmoves.end())
+        if (move != Move::none())
             rootMoves.emplace_back(move);
     }
 
     if (rootMoves.empty())
-        for (const auto& m : legalmoves)
+        for (const auto& m : MoveList<LEGAL>(pos))
             rootMoves.emplace_back(m);
 
     Tablebases::Config tbConfig = Tablebases::rank_root_moves(options, pos, rootMoves);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
@@ -42,6 +43,9 @@
 #include "ucioption.h"
 
 namespace Stockfish {
+
+using Time = std::chrono::steady_clock;
+using ms   = std::chrono::milliseconds;
 
 constexpr auto BenchmarkCommand = "speedtest";
 
@@ -90,6 +94,7 @@ void UCIEngine::init_search_update_listeners() {
     engine.set_on_update_no_moves([](const auto& i) { on_update_no_moves(i); });
     engine.set_on_update_full(
       [this](const auto& i) { on_update_full(i, engine.get_options()["UCI_ShowWDL"]); });
+    engine.set_on_start([]() {});
     engine.set_on_bestmove([](const auto& bm, const auto& p) { on_bestmove(bm, p); });
     engine.set_on_verify_networks([](const auto& s) { print_info_string(s); });
 }
@@ -338,10 +343,9 @@ void UCIEngine::benchmark(std::istream& args) {
     static constexpr int NUM_WARMUP_POSITIONS = 3;
 
     std::string token;
-    u64    nodes = 0, cnt = 1;
-    u64    nodesSearched = 0;
+    u64         cnt = 1;
 
-    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+    engine.set_on_update_full([](const auto&) {});
 
     engine.set_on_iter([](const auto&) {});
     engine.set_on_update_no_moves([](const auto&) {});
@@ -353,7 +357,6 @@ void UCIEngine::benchmark(std::istream& args) {
     const auto numGoCommands = count_if(setup.commands.begin(), setup.commands.end(),
                                         [](const std::string& s) { return s.find("go ") == 0; });
 
-    TimePoint totalTime = 0;
 
     // Set options once at the start.
     auto ss = std::istringstream("name Threads value " + std::to_string(setup.threads));
@@ -394,8 +397,7 @@ void UCIEngine::benchmark(std::istream& args) {
 
     std::cerr << "\n";
 
-    cnt   = 1;
-    nodes = 0;
+    cnt = 1;
 
     int           numHashfullReadings = 0;
     constexpr int hashfullAges[]      = {0, 999};  // Only normal hashfull and touched hash.
@@ -416,6 +418,24 @@ void UCIEngine::benchmark(std::istream& args) {
 
     engine.search_clear();  // search_clear may take a while
 
+    Time::time_point elapsed;
+    Time::duration   totalTime(0);
+
+    u64 nodes = 0, nodesSearched = 0;
+
+    engine.set_on_update_full([&](const Engine::InfoFull& i) { nodesSearched = i.nodes; });
+
+    engine.set_on_start([&elapsed, &nodesSearched]() {
+        elapsed       = Time::now();
+        nodesSearched = 0;
+    });
+
+    engine.set_on_bestmove(
+      [&totalTime, &elapsed, &nodes, &nodesSearched](const auto&, const auto&) {
+          totalTime += Time::now() - elapsed;
+          nodes += nodesSearched;
+      });
+
     for (const auto& cmd : setup.commands)
     {
         currentCmd = cmd;
@@ -429,18 +449,11 @@ void UCIEngine::benchmark(std::istream& args) {
 
             Search::LimitsType limits = parse_limits(is);
 
-            nodesSearched     = 0;
-            TimePoint elapsed = now();
-
             // Run with silenced network verification
             engine.go(limits);
             engine.wait_for_search_finished();
 
-            totalTime += now() - elapsed;
-
             updateHashfullReadings();
-
-            nodes += nodesSearched;
         }
         else if (token == "position")
             position(is);
@@ -450,7 +463,8 @@ void UCIEngine::benchmark(std::istream& args) {
         }
     }
 
-    totalTime = std::max<TimePoint>(totalTime, 1);  // Ensure positivity to avoid a 'divide by zero'
+    // Ensure positivity to avoid a 'divide by zero'
+    const auto totalTimeMs = std::max<i64>(std::chrono::duration_cast<ms>(totalTime).count(), 1LL);
 
     dbg_print();
 
@@ -485,8 +499,8 @@ void UCIEngine::benchmark(std::istream& args) {
               << "\n    single game            : " << maxHashfull[1] << ", "
               << totalHashfull[1] / numHashfullReadings
               << "\nTotal nodes searched       : " << nodes
-              << "\nTotal search time [s]      : " << totalTime / 1000.0
-              << "\nNodes/second               : " << 1000 * nodes / totalTime << std::endl;
+              << "\nTotal search time [s]      : " << totalTimeMs / 1000.0
+              << "\nNodes/second               : " << 1000 * nodes / totalTimeMs << std::endl;
 
     // clang-format on
 

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -86,9 +86,6 @@ void OptionsMap::add(const std::string& name, const Option& option) {
 
 usize OptionsMap::count(const std::string& name) const { return options_map.count(name); }
 
-Option::Option(const OptionsMap* map) :
-    parent(map) {}
-
 Option::Option(const char* v, OnChange f) :
     type("string"),
     min(0),

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -40,7 +40,6 @@ class Option {
    public:
     using OnChange = std::function<std::optional<std::string>(const Option&)>;
 
-    Option(const OptionsMap*);
     Option(OnChange = nullptr);
     Option(bool v, OnChange = nullptr);
     Option(const char* v, OnChange = nullptr);


### PR DESCRIPTION
### Motivation
- Bring Revolution up to date with the ten official Stockfish dev commits from 2026-07-26 while preserving the local Revolution identity, P0K baseline semantics and runtime constraints (only `ARCH=x86-64-sse41-popcnt COMP=gcc`, no AVX512/AVX2/RVV builds). 

### Description
- Implement the search `onStart` callback and update speedtest to use `steady_clock` with proper nodes/time accumulation and minimum 1ms protection, and register an empty `onStart` in normal UCI initialization (`Engine`, `SearchManager`, `UCIEngine`, `uci.cpp`, `search.cpp`).
- Add a standard `.gitattributes` and harden `GIT_DIFFINDEX` semantics in `src/Makefile` to `git update-index --refresh` and ignore filemode/`core.autocrlf` differences.
- Integrate the RVV affine-transform upstream changes with a local NNZ helper and caller topology: add `src/nnue/nnz_helper.h`, update `FeatureTransformer`, `network.cpp`, `nnue_architecture.h`, and `affine_transform*` layers to carry `NNZInfo` without enabling RVV builds.
- Port the hybrid accumulator path (`update_accumulator_hybrid`) and local adaptations so it triggers only for king moves with >=15 pieces in same half and excludes castling; preserve PSQT/Threat/PP semantics and cache updates (`src/nnue/nnue_accumulator.cpp`).
- Update default NNUE network name to `nn-ab28990d4ea3.nnue` and add download/validation logic (SHA-256 checked), preserve that the net is not tracked (`src/evaluate.h`, `src/Makefile`, `src/nnue/*`).
- Add `USE_PAIR_ACTIVATIONS` gating for paired activations (preserve existing AVX2 route) and implement paired activation branches (`sqr_clipped_relu.h`, `nnue/simd.h`).
- Reintroduce NMP static-eval based reduction exactly as upstream: change `!is_loss(beta)` to `beta >= -2000` and set `Depth R = 7 + depth / 3 + std::max((ss->staticEval - beta) / 256, 0)` (`src/search.cpp`).
- Optimize `RankAttacks` to `8 × 64` constexpr tables and index using the six inner bits with `(occupied >> (shift + 1)) & 0x3f`, and move to compile-time `DualMagics` (`src/attacks.*`).
- Remove the unused constructor `Option(const OptionsMap*)` and its definition and keep all other `Option` forms (`src/ucioption.*`).
- Small local topology and glue updates (credits added in `AUTHORS`, various `nnue` and `uci` adjustments) while preserving Book, Experience, SFNNv16, PP_3Wide, DirtyPawnPairs, `thread_native.h`, Zobrist and Revolution identity.
- Files added/modified include `.gitattributes`, `AUTHORS`, many `src/nnue/*` files (including `nnz_helper.h`), `src/search.*`, `src/uci.*`, `src/engine.*`, `src/attacks.*`, `src/ucioption.*`, and Makefile adjustments; `src/movegen.cpp` was not changed.

### Testing
- Verified repository/upstream topology and ensured P0K presence and official commit order using local git/audit checks; all ten upstream commits were accounted for in correct order.
- Built only the required target with `make -C src -j2 build ARCH=x86-64-sse41-popcnt COMP=gcc` and obtained a successful `Revolution-6.0-040526-sse41popcnt` binary with zero compiler/linker errors and zero warnings in the recorded build log.
- Ran automated runtime validations against the produced binary which all succeeded: `uci` handshake (identity/options), `bench`, `speedtest`, `perft 4` (returned `197281`), hybrid-king `searchmoves` test (returned `bestmove e1f1`), mixed `searchmoves` test (accepted `e2e4`, ignored illegal `e2e5`), multithreaded pawn-pairs scenario (completed with bestmove), and the mandatory mate-in-two regression (finished before timeout with a bestmove); speedtest/bench exited with code 0.
- Verified NNUE network acquisition and SHA-256 prefix (`ab28990d4ea3...`), confirmed `src/nn-ab28990d4ea3.nnue` exists, and that the network file is not tracked by git.
- Run hygiene checks: `git diff --check` clean, no conflict markers, `git diff -- src/movegen.cpp` empty, and no unwanted tracked artifacts (`*.nnue`, `*.o`, binaries, logs) remained.

All automated checks and runtime tests listed above passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cc5c09c648327859088e6759e365c)