### PR TITLE
Final rebrand to 6.10-310726: update Makefile and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
-# Revolution-6.0-040526
+# Revolution-6.10-310726
 
 <p align="center">
   <img src="assets/revolution-logo.svg" alt="Revolution UCI Chess Engine logo featuring a minimalist French tricolor cockade" width="360" />
 </p>
 
-Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-6.0-040526** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
+Revolution UCI Chess Engines is a derivative of Stockfish that develops structural changes and explores new ideas to improve the project while complying with the GNU GPL v3 license. This release identifies itself as **Revolution-6.10-310726** developed by Jorge Ruiz and the Stockfish developers (see AUTHORS file).
 
-## Revolution-6.0-040526 technical release
+## Revolution-6.10-310726 technical release
 
-This release applies the accepted Stockfish development topology dated 2026-06-06 through 2026-06-10:
+This release incorporates the accepted Stockfish development topology through July 26, 2026.
 
-- **June 6:** attack-topology updates, search-formula simplification, transposition-table underflow guards, and AMD slow-BMI2 handling.
-- **June 8:** consistent integer aliases and types.
-- **June 9:** WebAssembly targets, `RelaxedAtomic`, `previousPV` and MultiPV mate-PV correction, plus the timeout harness where applicable.
-- **June 10:** NNUE active-bridge preparation; the HalfKA/Threats accumulator merge; `do_move` reordering with the `materialKey` correction; the stop-search condition when no better move is possible; and Revolution-compatible FEN pawn-rank validation for ranks 1 and 8.
-
-The active NNUE authority remains `nn-0ee0657fb25e.nnue`, and the strict single-net state is preserved. `EvalFileSmall`, `NetworkSmall`, and `nn-83a0d6daf7e5.nnue` are absent. Book, Experience, Zobrist, and Syzygy behavior is preserved. MCTS and MonteCarlo remain absent.
+The baseline uses SFNNv16 with the `PP_3Wide` feature set, a hybrid accumulator path for applicable king moves, and the `nn-ab28990d4ea3.nnue` network. Book, Experience, Zobrist, and Syzygy behavior is preserved.
 
 ## Overview
 
@@ -174,7 +169,7 @@ This distribution of Revolution consists of the following files:
 
 Revolution supports 32-bit and 64-bit CPUs and the same hardware instruction sets as Stockfish. On Unix-like systems you can compile the engine from the `src` directory with:
 
-The UCI `id name` header is the architecture-independent base identity `Revolution-6.0-040526`. Startup, analysis, and informational output uses `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` from `src/Makefile` to expose the compiled architecture. Executable names use the same normalized architecture suffix.
+The UCI `id name` header is the architecture-independent base identity `Revolution-6.10-310726`. Startup, analysis, and informational output uses `ENGINE_BASENAME`, `RELEASE_TAG`, and `ARCH_TAG` from `src/Makefile` to expose the compiled architecture. Executable names use the same normalized architecture suffix.
 
 ```
 cd src
@@ -195,12 +190,12 @@ Targets normalizados para los binarios oficiales:
 
 | Target (`ARCH`) | Identidad visible de análisis | Ejecutable esperado |
 | --- | --- | --- |
-| `x86-64-sse41-popcnt` | `Revolution-6.0-040526-sse41popcnt` | `Revolution-6.0-040526-sse41popcnt[.exe]` |
-| `x86-64-avx2` | `Revolution-6.0-040526-avx2` | `Revolution-6.0-040526-avx2[.exe]` |
-| `x86-64-bmi2` | `Revolution-6.0-040526-bmi2` | `Revolution-6.0-040526-bmi2[.exe]` |
-| `x86-64-fma3` | `Revolution-6.0-040526-fma3` | `Revolution-6.0-040526-fma3[.exe]` |
-| `x86-64-avx512` | `Revolution-6.0-040526-avx512` | `Revolution-6.0-040526-avx512[.exe]` |
-| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-6.0-040526-avx512cl` | `Revolution-6.0-040526-avx512cl[.exe]` |
+| `x86-64-sse41-popcnt` | `Revolution-6.10-310726-sse41popcnt` | `Revolution-6.10-310726-sse41popcnt[.exe]` |
+| `x86-64-avx2` | `Revolution-6.10-310726-avx2` | `Revolution-6.10-310726-avx2[.exe]` |
+| `x86-64-bmi2` | `Revolution-6.10-310726-bmi2` | `Revolution-6.10-310726-bmi2[.exe]` |
+| `x86-64-fma3` | `Revolution-6.10-310726-fma3` | `Revolution-6.10-310726-fma3[.exe]` |
+| `x86-64-avx512` | `Revolution-6.10-310726-avx512` | `Revolution-6.10-310726-avx512[.exe]` |
+| `x86-64-avx512cl` (`x86-64-avx512icl` alias) | `Revolution-6.10-310726-avx512cl` | `Revolution-6.10-310726-avx512cl[.exe]` |
 
 ### Prefetch explícito y LTO en x86-64-bmi2
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,7 +60,7 @@ else
 	EXESUF =
 endif
 ENGINE_BASENAME = Revolution
-RELEASE_TAG ?= 6.0-040526
+RELEASE_TAG ?= 6.10-310726
 
 NNUE_NET = nn-ab28990d4ea3.nnue
 


### PR DESCRIPTION
### Motivation
- Finalize the release identity to `6.10-310726` after integrating the P0L baseline while preserving the existing identity topology and avoiding any functional changes.
- Ensure the release tag and README reflect the accepted Stockfish topology through July 26, 2026, without hardcoding any architecture information.

### Description
- Update `src/Makefile` to set `RELEASE_TAG ?= 6.10-310726` while keeping `ENGINE_BASENAME = Revolution` and the `ARCH_TAG` derivation unchanged. 
- Update `README.md` title, technical heading and identity strings to `Revolution-6.10-310726`, and document the baseline details: `SFNNv16`, `PP_3Wide`, the hybrid accumulator path for applicable king moves, and `nn-ab28990d4ea3.nnue`. 
- Preserve the executable naming formula `$(ENGINE_BASENAME)-$(RELEASE_TAG)-$(ARCH_TAG)` and do not modify any functional source files or NNUE binaries.

### Testing
- Built only `ARCH=x86-64-sse41-popcnt COMP=gcc` with `make -C src -j2 build` which produced `src/Revolution-6.10-310726-sse41popcnt` and reported zero compiler or linker warnings/errors. 
- Ran a UCI session with `printf "uci
isready
quit
" | src/Revolution-6.10-310726-sse41popcnt` and observed `id name Revolution-6.10-310726`, the banner `Revolution-6.10-310726-sse41popcnt`, `uciok` and `readyok`. 
- Executed the integrated benchmark `src/Revolution-6.10-310726-sse41popcnt bench 16 1 8 default depth` which completed successfully, loaded `nn-ab28990d4ea3.nnue`, and produced no asserts, NNUE errors, illegal moves, or crashes. 
- Verified repository hygiene with `git diff`, `rg` and related checks showing only `README.md` and `src/Makefile` changed and zero remaining references to `Revolution-6.0-040526`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ccab3b56c8327b97793b5018d0c12)