### PR TITLE
Revolution P0M: remove dead lmrDivisor declaration

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -53,9 +53,6 @@
 
 namespace Stockfish {
 
-static constexpr std::array<int, 16> lmrDivisor = {3637, 2787, 2761, 2939, 3171, 3347, 3147, 2762,
-                                                   2772, 3106, 3107, 3060, 3112, 2991, 3090, 3542};
-
 namespace TB = Tablebases;
 
 void syzygy_extend_pv(const OptionsMap&            options,


### PR DESCRIPTION
### Motivation
- Eliminate a single Clang warning `-Wunused-const-variable` by removing the dead global `lmrDivisor` declaration in `src/search.cpp` without silencing warnings or changing any behavior.

### Description
- Remove the two-line `static constexpr std::array<int, 16> lmrDivisor = { ... };` (and the immediately following blank line) from `src/search.cpp`, with no other file modifications and no changes to LMR formulas, compiler flags, Makefiles, identity, or NNUE configuration.

### Testing
- Verified repository baseline and branch creation, confirmed one initial `lmrDivisor` occurrence, ran `make -C src -j2 profile-build ARCH=x86-64-sse41-popcnt COMP=clang EXTRALDFLAGS="-fuse-ld=lld"` which completed with exit code 0 and no warnings or errors, validated `clang++ --version` and `ld.lld --version`, downloaded and validated `src/nn-ab28990d4ea3.nnue`, executed UCI readiness (`uci`/`isready`) and a depth-1 runtime producing `bestmove`, and ran the engine bench which finished with status 0; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ccf12f0048327b3d79307dee8b9c4)